### PR TITLE
Add smart list continuation and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ fallbacks remain available when a terminal cannot report a modifier.
 | `Primary+Z` | Undo an edit |
 | `Shift+Primary+Z` | Redo an edit |
 | `Primary+V` | Read the native clipboard |
+| `Enter` | Continue `-`, `*`, `+`, ordered, and task list items; exit an empty top-level item |
 | `↑` / `↓` twice at a boundary | Return to the board and focus the adjacent thought |
 
 Mouse users can focus and edit thoughts, place the cursor, drag selections,
@@ -209,6 +210,10 @@ reorder thoughts, click controls, use help, and choose verified Herdr targets.
 Holding the final click while dragging extends by complete words or logical
 lines. Moving onto folded context selects its complete canonical range.
 `Enter` expands the fold, while typing or deletion replaces it atomically.
+Press `Esc`, open `:`, and choose `Insert plain newline` to bypass list
+continuation without relying on a terminal modifier; mouse users can open the
+palette directly while editing. Set `smart_lists = false` to keep every ordinary
+editor `Enter` plain.
 
 ## Resume and organize sessions
 
@@ -461,6 +466,7 @@ shortcuts remain available:
 
 ```toml
 check_for_updates = true
+smart_lists = true
 theme = "auto"
 density = "comfortable" # or "compact"
 

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -653,6 +653,17 @@ every action retains a terminal-safe fallback and a configurable binding.
 deletes one newline-delimited logical line as a single undoable edit. Logical
 line commands operate on the text model and are independent of visual wrapping.
 
+The default `smart_lists = true` setting maps an unselected editor `Enter` to a
+terminal-independent smart-newline command. The editor recognizes only the
+bounded CommonMark-style markers supported by the product contract, preserves
+the document's local LF or CRLF convention, and reports continuation or marker
+removal as one explicit text-change transaction. The UI flushes that transaction
+as one persistent revision. Selection replacement uses the ordinary newline
+command, bracketed paste remains a distinct exact payload, and the command
+palette exposes the ordinary newline command directly. This boundary can later
+gain explicit indentation commands without making Tab or Shift+Tab part of the
+current behavior.
+
 Bracketed paste is one payload and one undoable edit. When no thought is
 selected, paste creates and focuses a new thought. The application never tries
 to split a paste heuristically.

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -568,6 +568,18 @@ Edit mode behaves like a focused multiline text editor. It supports:
   scroll mode by default.
 - Optional external editor handoff later.
 
+With `smart_lists = true`, the default, `Enter` continues `-`, `*`, and `+`
+items, one-to-nine-digit ordered markers ending in `.` or `)`, and unchecked or
+checked task items. Ordered continuation increments only the new marker, and
+task continuation always starts unchecked. Exact indentation, marker spacing,
+delimiter, Unicode content, annotations, and LF or CRLF convention remain
+unchanged. An empty generated top-level item exits by removing its marker as
+one persistent editor revision. Selection replacement and paste stay exact and
+never invoke list continuation. Escaped markers, thematic breaks, fenced code,
+and conservatively detected indented code remain plain text. The command
+palette provides an explicit plain-newline action without requiring a terminal
+modifier. Nested Tab and Shift+Tab indentation remain a later feature.
+
 Leaving edit mode returns to the same board position and keeps the edited
 thought selected.
 
@@ -1045,6 +1057,12 @@ The current direction is grounded in these public primary sources:
 - [Ratatui](https://github.com/ratatui/ratatui) and
   [tui-textarea](https://github.com/rhysd/tui-textarea) for openly licensed TUI
   and editor primitives.
+- [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) under CC BY-SA 4.0
+  for list-marker, thematic-break, fenced-code, and indented-code behavior.
+- [CodeMirror Markdown](https://github.com/codemirror/lang-markdown) under MIT
+  as an interaction reference for specialized list continuation with a plain
+  newline fallback. Proqi's implementation is independent and deliberately
+  does not cascade-renumber later items.
 - [SQLite WAL documentation](https://www.sqlite.org/wal.html) for local
   persistence and concurrent instance behavior.
 - [Homebrew's Formula Cookbook](https://docs.brew.sh/Formula-Cookbook) and

--- a/src/adapters/editor/mod.rs
+++ b/src/adapters/editor/mod.rs
@@ -2,6 +2,7 @@
 
 mod mutation;
 mod pointer;
+mod smart_lists;
 mod text;
 
 use std::cmp::Ordering;
@@ -199,6 +200,7 @@ impl Editor for RopeEditor {
             EditCommand::InsertNewline => {
                 self.mutate(|editor| editor.replace_selection_or_insert("\n"))
             }
+            EditCommand::InsertSmartNewline => self.mutate(Self::insert_smart_newline),
             EditCommand::DeleteBack => self.mutate(Self::delete_back),
             EditCommand::DeleteForward => self.mutate(Self::delete_forward),
             EditCommand::DeleteLogicalLine => self.mutate(Self::delete_logical_line),

--- a/src/adapters/editor/mutation.rs
+++ b/src/adapters/editor/mutation.rs
@@ -118,7 +118,12 @@ impl RopeEditor {
         changes
     }
 
-    fn replace_byte_range(&mut self, start: usize, end: usize, replacement: &str) -> AppliedRange {
+    pub(super) fn replace_byte_range(
+        &mut self,
+        start: usize,
+        end: usize,
+        replacement: &str,
+    ) -> AppliedRange {
         let start_char = self.state.text.byte_to_char(start);
         let end_char = self.state.text.byte_to_char(end);
         self.state.text.remove(start_char..end_char);

--- a/src/adapters/editor/smart_lists.rs
+++ b/src/adapters/editor/smart_lists.rs
@@ -1,0 +1,220 @@
+//! Conservative, exact Markdown list continuation.
+
+use crate::ports::text_layout::logical_lines;
+
+use super::{RopeEditor, mutation::AppliedRange};
+
+struct ListMarker<'a> {
+    indentation: &'a str,
+    marker: Marker<'a>,
+    spacing: &'a str,
+    task_spacing: Option<&'a str>,
+    content: &'a str,
+}
+
+enum Marker<'a> {
+    Bullet(char),
+    Ordered { number: &'a str, delimiter: char },
+}
+
+impl RopeEditor {
+    pub(super) fn insert_smart_newline(&mut self) -> Option<AppliedRange> {
+        let content = self.content();
+        let newline = preferred_newline(&content, self.state.cursor_byte);
+        if self.selection_bytes().is_some() {
+            return self.replace_selection_or_insert(newline);
+        }
+        let cursor = self.state.cursor_byte;
+        let Some(line) = logical_lines(&content)
+            .into_iter()
+            .find(|line| cursor >= line.start && cursor <= line.content_end)
+        else {
+            return self.replace_selection_or_insert(newline);
+        };
+        if cursor != line.content_end || inside_fenced_code(&content, line.start) {
+            return self.replace_selection_or_insert(newline);
+        }
+        let line_text = &content[line.start..line.content_end];
+        let Some(marker) = parse_marker(line_text) else {
+            return self.replace_selection_or_insert(newline);
+        };
+        if is_thematic_break(line_text) {
+            return self.replace_selection_or_insert(newline);
+        }
+        if marker.indentation.is_empty() && marker.content.trim_matches([' ', '\t']).is_empty() {
+            return Some(self.replace_byte_range(line.start, cursor, ""));
+        }
+        let continuation = marker.continuation();
+        Some(self.replace_byte_range(cursor, cursor, &format!("{newline}{continuation}")))
+    }
+}
+
+impl ListMarker<'_> {
+    fn continuation(&self) -> String {
+        let marker = match self.marker {
+            Marker::Bullet(bullet) => bullet.to_string(),
+            Marker::Ordered { number, delimiter } => {
+                number
+                    .parse::<u64>()
+                    .map_or_else(|_| number.to_owned(), |number| (number + 1).to_string())
+                    + &delimiter.to_string()
+            }
+        };
+        let task = self
+            .task_spacing
+            .map_or_else(String::new, |spacing| format!("[ ]{spacing}"));
+        format!("{}{marker}{}{task}", self.indentation, self.spacing)
+    }
+}
+
+fn parse_marker(line: &str) -> Option<ListMarker<'_>> {
+    let indentation_end = line
+        .char_indices()
+        .find_map(|(index, character)| (!matches!(character, ' ' | '\t')).then_some(index))
+        .unwrap_or(line.len());
+    let indentation = &line[..indentation_end];
+    if indentation_columns(indentation) > 3 {
+        return None;
+    }
+    let rest = &line[indentation_end..];
+    let (marker, marker_end) = parse_base_marker(rest)?;
+    let spacing_end = marker_end + whitespace_prefix(&rest[marker_end..]);
+    if spacing_end == marker_end {
+        return None;
+    }
+    let spacing = &rest[marker_end..spacing_end];
+    let after_marker = &rest[spacing_end..];
+    let (task_spacing, content) =
+        parse_task(after_marker).map_or((None, after_marker), |parsed| (Some(parsed.0), parsed.1));
+    Some(ListMarker {
+        indentation,
+        marker,
+        spacing,
+        task_spacing,
+        content,
+    })
+}
+
+fn parse_base_marker(rest: &str) -> Option<(Marker<'_>, usize)> {
+    let first = rest.chars().next()?;
+    if matches!(first, '-' | '*' | '+') {
+        return Some((Marker::Bullet(first), first.len_utf8()));
+    }
+    let digit_end = rest.bytes().take(9).take_while(u8::is_ascii_digit).count();
+    if digit_end == 0
+        || rest
+            .as_bytes()
+            .get(digit_end)
+            .is_some_and(u8::is_ascii_digit)
+    {
+        return None;
+    }
+    let delimiter = rest[digit_end..].chars().next()?;
+    matches!(delimiter, '.' | ')').then_some((
+        Marker::Ordered {
+            number: &rest[..digit_end],
+            delimiter,
+        },
+        digit_end + delimiter.len_utf8(),
+    ))
+}
+
+fn parse_task(after_marker: &str) -> Option<(&str, &str)> {
+    let task = after_marker.get(..3)?;
+    if !matches!(task, "[ ]" | "[x]" | "[X]") {
+        return None;
+    }
+    let spacing_end = 3 + whitespace_prefix(&after_marker[3..]);
+    (spacing_end > 3).then_some((&after_marker[3..spacing_end], &after_marker[spacing_end..]))
+}
+
+fn whitespace_prefix(value: &str) -> usize {
+    value
+        .char_indices()
+        .find_map(|(index, character)| (!matches!(character, ' ' | '\t')).then_some(index))
+        .unwrap_or(value.len())
+}
+
+fn indentation_columns(indentation: &str) -> usize {
+    indentation.chars().fold(0, |column, character| {
+        if character == '\t' {
+            column + (4 - column % 4)
+        } else {
+            column + 1
+        }
+    })
+}
+
+fn preferred_newline(content: &str, cursor: usize) -> &'static str {
+    let cursor = cursor.min(content.len());
+    if content[cursor..].starts_with("\r\n") {
+        "\r\n"
+    } else if content[cursor..].starts_with('\n') {
+        "\n"
+    } else if let Some(newline) = content[..cursor].rfind('\n') {
+        if newline > 0 && content.as_bytes()[newline - 1] == b'\r' {
+            "\r\n"
+        } else {
+            "\n"
+        }
+    } else if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+fn is_thematic_break(line: &str) -> bool {
+    let compact = line
+        .trim_matches([' ', '\t'])
+        .chars()
+        .filter(|character| !matches!(character, ' ' | '\t'))
+        .collect::<String>();
+    compact.len() >= 3
+        && compact.chars().next().is_some_and(|marker| {
+            matches!(marker, '-' | '*') && compact.chars().all(|c| c == marker)
+        })
+}
+
+fn inside_fenced_code(content: &str, current_start: usize) -> bool {
+    let mut open: Option<(char, usize)> = None;
+    for line in logical_lines(content)
+        .into_iter()
+        .take_while(|line| line.start < current_start)
+    {
+        let text = &content[line.start..line.content_end];
+        let Some((marker, count, trailing)) = fence(text) else {
+            continue;
+        };
+        match open {
+            None => open = Some((marker, count)),
+            Some((open_marker, minimum))
+                if marker == open_marker
+                    && count >= minimum
+                    && trailing.trim_matches([' ', '\t']).is_empty() =>
+            {
+                open = None;
+            }
+            Some(_) => {}
+        }
+    }
+    open.is_some()
+}
+
+fn fence(line: &str) -> Option<(char, usize, &str)> {
+    let indentation = whitespace_prefix(line);
+    let prefix = &line[..indentation];
+    if indentation_columns(prefix) > 3 {
+        return None;
+    }
+    let rest = &line[indentation..];
+    let marker = rest.chars().next()?;
+    if !matches!(marker, '`' | '~') {
+        return None;
+    }
+    let count = rest
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
+    (count >= 3).then_some((marker, count, &rest[count..]))
+}

--- a/src/adapters/terminal/input/tests.rs
+++ b/src/adapters/terminal/input/tests.rs
@@ -200,6 +200,22 @@ fn bracketed_paste_remains_one_exact_input() {
 }
 
 #[test]
+fn enter_is_normalized_independently_from_exact_bracketed_paste() {
+    assert_eq!(
+        translate(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))),
+        Some(UiInput::Key(UiKey::Enter))
+    );
+    let list = "- pasted".to_owned();
+    assert_eq!(
+        translate(Event::Paste(list.clone())),
+        Some(UiInput::Paste(list))
+    );
+}
+
+#[test]
 fn host_focus_is_a_semantic_refresh_signal() {
     assert_eq!(
         translate(Event::FocusGained),

--- a/src/adapters/terminal/settings.rs
+++ b/src/adapters/terminal/settings.rs
@@ -45,6 +45,7 @@ enum ThemeSource {
 #[serde(default, deny_unknown_fields)]
 struct SettingsDocument {
     check_for_updates: bool,
+    smart_lists: bool,
     theme: String,
     theme_overrides: ThemeOverrides,
     keyboard_enhancement: KeyboardEnhancement,
@@ -56,6 +57,7 @@ impl Default for SettingsDocument {
     fn default() -> Self {
         Self {
             check_for_updates: true,
+            smart_lists: true,
             theme: "auto".to_owned(),
             theme_overrides: ThemeOverrides::default(),
             keyboard_enhancement: KeyboardEnhancement::default(),
@@ -103,6 +105,7 @@ fn parse_settings(config_dir: &Path, content: &str) -> Result<LoadedSettings, Te
         .map_err(|error| TerminalError::Config(error.to_owned()))?;
     let ui = UiSettings {
         check_for_updates: document.check_for_updates,
+        smart_lists: document.smart_lists,
         keyboard_enhancement: document.keyboard_enhancement,
         keybindings: document.keybindings,
         density: document.density,

--- a/src/adapters/terminal/settings/tests.rs
+++ b/src/adapters/terminal/settings/tests.rs
@@ -11,6 +11,7 @@ fn missing_config_uses_the_adaptive_default() {
     let directory = tempfile::tempdir().expect("config directory");
     let settings = load_settings(directory.path()).expect("defaults");
     assert_eq!(settings.ui.keybindings.new, 'n');
+    assert!(settings.ui.smart_lists);
     assert_eq!(settings.theme.base, ThemePreference::Auto);
     assert_eq!(settings.theme_source, ThemeSource::BuiltIn);
 }
@@ -26,8 +27,21 @@ fn existing_settings_remain_compatible() {
     let settings = load_settings(directory.path()).expect("settings");
     assert_eq!(settings.ui.keybindings.new, 't');
     assert!(!settings.ui.check_for_updates);
+    assert!(settings.ui.smart_lists);
     assert_eq!(settings.ui.density, BoardDensity::Compact);
     assert_eq!(settings.theme.base, ThemePreference::Dark);
+}
+
+#[test]
+fn smart_lists_can_be_disabled_without_changing_existing_config_defaults() {
+    let directory = tempfile::tempdir().expect("config directory");
+    fs::write(
+        directory.path().join("config.toml"),
+        "smart_lists = false\n",
+    )
+    .expect("write config");
+    let settings = load_settings(directory.path()).expect("settings");
+    assert!(!settings.ui.smart_lists);
 }
 
 #[test]

--- a/src/ports/editor.rs
+++ b/src/ports/editor.rs
@@ -86,6 +86,8 @@ pub enum EditCommand {
     Paste(String),
     /// Insert a line feed.
     InsertNewline,
+    /// Insert a newline with conservative Markdown list continuation.
+    InsertSmartNewline,
     /// Delete the grapheme before the cursor or the selection.
     DeleteBack,
     /// Delete the grapheme after the cursor or the selection.

--- a/src/ui/app/commands.rs
+++ b/src/ui/app/commands.rs
@@ -211,6 +211,14 @@ impl BoardApp {
         {
             return self.flush_pending_edit(ids, clock);
         }
+        if matches!(key, UiKey::Enter)
+            && self.settings.smart_lists
+            && self
+                .editor_snapshot()
+                .is_some_and(|snapshot| snapshot.selection.is_none())
+        {
+            return self.insert_newline(true, ids, clock);
+        }
         let adjacent_fold = match key {
             UiKey::Backspace => self.delete_adjacent_fold(true),
             UiKey::Delete => self.delete_adjacent_fold(false),

--- a/src/ui/app/editing.rs
+++ b/src/ui/app/editing.rs
@@ -21,6 +21,22 @@ pub(super) struct PendingEdit {
 }
 
 impl BoardApp {
+    pub(super) fn insert_newline(
+        &mut self,
+        smart: bool,
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        let mut effects = self.flush_pending_edit(ids, clock);
+        self.apply_edit(if smart {
+            EditCommand::InsertSmartNewline
+        } else {
+            EditCommand::InsertNewline
+        });
+        effects.extend(self.flush_pending_edit(ids, clock));
+        effects
+    }
+
     pub(super) fn finish_boundary_navigation(
         &mut self,
         movement: CursorMovement,

--- a/src/ui/app/palette.rs
+++ b/src/ui/app/palette.rs
@@ -14,6 +14,7 @@ enum Command {
     SendSession,
     SendSessionRemove,
     Edit,
+    PlainNewline,
     Delete,
     Copy,
     Cut,
@@ -36,10 +37,11 @@ enum Command {
 }
 
 impl Command {
-    const ALL: [(Self, &'static str); 24] = [
+    const ALL: [(Self, &'static str); 25] = [
         (Self::New, "New thought"),
         (Self::RenameSession, "Rename session"),
         (Self::Edit, "Edit thought"),
+        (Self::PlainNewline, "Insert plain newline"),
         (Self::Delete, "Delete thought"),
         (Self::Copy, "Copy thought"),
         (Self::Cut, "Cut thought"),
@@ -75,15 +77,17 @@ pub(super) struct PaletteState {
     selected: usize,
     scroll: usize,
     submit_supported: bool,
+    plain_newline_supported: bool,
 }
 
 impl PaletteState {
-    fn new(submit_supported: bool) -> Self {
+    fn new(submit_supported: bool, plain_newline_supported: bool) -> Self {
         Self {
             query: QueryEditor::default(),
             selected: 0,
             scroll: 0,
             submit_supported,
+            plain_newline_supported,
         }
     }
 
@@ -119,6 +123,7 @@ impl PaletteState {
     fn available(&self, command: Command) -> bool {
         match command {
             Command::SubmitRemove | Command::SubmitKeep => self.submit_supported,
+            Command::PlainNewline => self.plain_newline_supported,
             _ => true,
         }
     }
@@ -133,7 +138,10 @@ impl BoardApp {
     pub(super) fn open_palette(&mut self) {
         self.help = false;
         self.search = None;
-        self.palette = Some(PaletteState::new(self.supports_submission()));
+        self.palette = Some(PaletteState::new(
+            self.supports_submission(),
+            !self.insertion_focused() && self.state.focused_thought.is_some(),
+        ));
     }
 
     pub(super) fn close_overlay(&mut self) {
@@ -279,6 +287,15 @@ impl BoardApp {
             Command::Edit => {
                 self.enter_edit();
                 Vec::new()
+            }
+            Command::PlainNewline => {
+                if !matches!(
+                    self.state.mode,
+                    crate::application::InteractionMode::Edit { .. }
+                ) {
+                    self.enter_edit();
+                }
+                self.insert_newline(false, ids, clock)
             }
             Command::Delete => self.delete(ids, clock),
             Command::Copy => self.copy_active(ids),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -21,6 +21,8 @@ pub enum KeyboardEnhancement {
 pub struct UiSettings {
     /// Permit automatic stable-release checks on interactive release startup.
     pub check_for_updates: bool,
+    /// Continue recognized Markdown list items when Enter inserts a newline.
+    pub smart_lists: bool,
     /// Keyboard protocol negotiation.
     pub keyboard_enhancement: KeyboardEnhancement,
     /// Remappable direct board keys.
@@ -33,6 +35,7 @@ impl Default for UiSettings {
     fn default() -> Self {
         Self {
             check_for_updates: true,
+            smart_lists: true,
             keyboard_enhancement: KeyboardEnhancement::default(),
             keybindings: KeyBindings::default(),
             density: BoardDensity::default(),

--- a/tests/domain_reducer/history.rs
+++ b/tests/domain_reducer/history.rs
@@ -76,6 +76,65 @@ fn editor_history_is_separate_from_board_history() {
 }
 
 #[test]
+fn smart_continuation_and_exit_remain_two_persistent_editor_revisions() {
+    let mut fixture = Fixture::new();
+    let thought_id = fixture.create("- first");
+    for (before, after, before_cursor, after_cursor) in [
+        (
+            "- first",
+            "- first\n- ",
+            TextPosition::new(0, 7),
+            TextPosition::new(1, 2),
+        ),
+        (
+            "- first\n- ",
+            "- first\n",
+            TextPosition::new(1, 2),
+            TextPosition::new(1, 0),
+        ),
+    ] {
+        let revision_id = fixture.ids.revision_id();
+        let at = fixture.time();
+        reduce(
+            &mut fixture.state,
+            Action::EditThought {
+                thought_id,
+                revision_id,
+                before_content: before.to_owned(),
+                after_content: after.to_owned(),
+                before_annotations: Vec::new(),
+                after_annotations: Vec::new(),
+                before_cursor,
+                after_cursor,
+                at,
+            },
+        )
+        .expect("smart list revision");
+    }
+    assert_eq!(fixture.state.editor_history_cursor(thought_id), 2);
+    move_history(&mut fixture, UndoScope::Editor { thought_id }, true);
+    assert_eq!(
+        fixture
+            .state
+            .board
+            .thought(thought_id)
+            .expect("thought")
+            .content,
+        "- first\n- "
+    );
+    move_history(&mut fixture, UndoScope::Editor { thought_id }, true);
+    assert_eq!(
+        fixture
+            .state
+            .board
+            .thought(thought_id)
+            .expect("thought")
+            .content,
+        "- first"
+    );
+}
+
+#[test]
 fn undoing_a_nonfocused_create_keeps_the_next_insertion_valid() {
     let mut fixture = Fixture::new();
     let first = fixture.create("first");

--- a/tests/editor_contract.rs
+++ b/tests/editor_contract.rs
@@ -2,6 +2,8 @@
 
 #[path = "editor_contract/changes.rs"]
 mod changes;
+#[path = "editor_contract/smart_lists.rs"]
+mod smart_lists;
 
 use proqi::adapters::editor::RopeEditor;
 use proqi::{

--- a/tests/editor_contract/smart_lists.rs
+++ b/tests/editor_contract/smart_lists.rs
@@ -1,0 +1,146 @@
+use proqi::{
+    domain::TextPosition,
+    ports::editor::{CursorMovement, EditCommand, Editor},
+};
+
+use super::{assert_change, editor};
+
+fn at_end(text: &str) -> impl Editor {
+    let mut editor = editor(text);
+    editor.apply(EditCommand::Move {
+        movement: CursorMovement::DocumentEnd,
+        extend_selection: false,
+    });
+    editor
+}
+
+#[test]
+fn bullet_ordered_and_task_items_continue_with_exact_markup() {
+    for (before, after) in [
+        ("- first item", "- first item\n- "),
+        (" *  indented", " *  indented\n *  "),
+        ("\t+ tabbed", "\t+ tabbed\n"),
+        ("9) item", "9) item\n10) "),
+        ("000000009. item", "000000009. item\n10. "),
+        ("- [x] done", "- [x] done\n- [ ] "),
+        ("+ [X]\tchecked", "+ [X]\tchecked\n+ [ ]\t"),
+        ("2. [ ]  open", "2. [ ]  open\n3. [ ]  "),
+    ] {
+        let mut editor = at_end(before);
+        let outcome = editor.apply(EditCommand::InsertSmartNewline);
+        assert_eq!(outcome.snapshot.content, after, "{before:?}");
+        assert_eq!(outcome.snapshot.selection, None);
+    }
+}
+
+#[test]
+fn smart_continuation_preserves_crlf_and_changes_only_the_inserted_marker() {
+    let mut editor = at_end("1) first\r\n9) item\r\n10) existing");
+    editor.apply(EditCommand::SetCursor {
+        position: TextPosition::new(1, 7),
+        extend_selection: false,
+    });
+    let outcome = editor.apply(EditCommand::InsertSmartNewline);
+    let inserted = "\r\n10) ";
+    let cursor = "1) first\r\n9) item".len();
+    assert_change(&outcome, cursor..cursor, cursor..cursor + inserted.len());
+    assert_eq!(
+        outcome.snapshot.content,
+        "1) first\r\n9) item\r\n10) \r\n10) existing"
+    );
+    assert_eq!(outcome.snapshot.cursor, TextPosition::new(2, 4));
+}
+
+#[test]
+fn empty_top_level_items_exit_as_one_undoable_transaction() {
+    for before in [
+        "- first\n- ",
+        "9) item\n10) ",
+        "- [x] done\n- [ ] ",
+        "- first\r\n- ",
+    ] {
+        let mut editor = at_end(before);
+        let line_start = before.rfind('\n').map_or(0, |index| index + 1);
+        let outcome = editor.apply(EditCommand::InsertSmartNewline);
+        assert_change(&outcome, line_start..before.len(), line_start..line_start);
+        assert_eq!(outcome.snapshot.content, &before[..line_start]);
+        assert_eq!(outcome.snapshot.cursor, TextPosition::new(1, 0));
+        assert_eq!(
+            editor.apply(EditCommand::Undo).snapshot.content,
+            before,
+            "{before:?}"
+        );
+        assert_eq!(
+            editor.apply(EditCommand::Redo).snapshot.content,
+            &before[..line_start]
+        );
+    }
+
+    let mut sole_item = at_end("- ");
+    let outcome = sole_item.apply(EditCommand::InsertSmartNewline);
+    assert_eq!(outcome.snapshot.content, "");
+    assert_eq!(outcome.snapshot.cursor, TextPosition::default());
+}
+
+#[test]
+fn selection_replacement_is_an_exact_plain_newline() {
+    let mut editor = at_end("- first item");
+    editor.apply(EditCommand::Move {
+        movement: CursorMovement::WordBack,
+        extend_selection: true,
+    });
+    let before = editor.snapshot();
+    let _selection = before.selection.expect("selection");
+    let outcome = editor.apply(EditCommand::InsertSmartNewline);
+    assert_eq!(outcome.snapshot.content, "- first \n");
+    assert_eq!(outcome.snapshot.cursor, TextPosition::new(1, 0));
+}
+
+#[test]
+fn paste_never_invokes_list_continuation() {
+    let mut editor = at_end("- first item");
+    let outcome = editor.apply(EditCommand::Paste("\n- pasted".to_owned()));
+    assert_eq!(outcome.snapshot.content, "- first item\n- pasted");
+}
+
+#[test]
+fn ambiguous_markdown_and_code_contexts_fall_back_to_plain_newline() {
+    for before in [
+        ".",
+        "\\- escaped",
+        "---",
+        "- - -",
+        "* * *",
+        "    - indented code",
+        "\t- tab-indented code",
+        "1234567890. too many digits",
+        "1.no spacing",
+        "```\n- fenced",
+        "~~~rust\n9) fenced",
+    ] {
+        let mut editor = at_end(before);
+        let outcome = editor.apply(EditCommand::InsertSmartNewline);
+        assert_eq!(
+            outcome.snapshot.content,
+            format!("{before}\n"),
+            "{before:?}"
+        );
+    }
+}
+
+#[test]
+fn closed_fences_and_unicode_list_content_continue_normally() {
+    let before = "```\n- code\n```\n  + Grüße 👩🏽‍💻 第二行";
+    let mut editor = at_end(before);
+    let outcome = editor.apply(EditCommand::InsertSmartNewline);
+    assert_eq!(outcome.snapshot.content, format!("{before}\n  + "));
+    assert_eq!(outcome.snapshot.cursor, TextPosition::new(4, 4));
+}
+
+#[test]
+fn indented_empty_items_do_not_implement_nested_list_exit() {
+    let before = "- parent\n  - ";
+    let mut editor = at_end(before);
+    let outcome = editor.apply(EditCommand::InsertSmartNewline);
+    assert_eq!(outcome.snapshot.content, format!("{before}\n  - "));
+}

--- a/tests/ui_board.rs
+++ b/tests/ui_board.rs
@@ -486,6 +486,8 @@ mod scroll_regressions;
 mod selection;
 #[path = "ui_board/session_navigation.rs"]
 mod session_navigation;
+#[path = "ui_board/smart_lists.rs"]
+mod smart_lists;
 #[path = "ui_board/snapshots.rs"]
 mod snapshots;
 #[path = "ui_board/submission_locks.rs"]

--- a/tests/ui_board/smart_lists.rs
+++ b/tests/ui_board/smart_lists.rs
@@ -1,0 +1,163 @@
+use super::*;
+
+fn revision(effects: &[Effect]) -> &proqi::domain::ThoughtRevision {
+    let [Effect::CommitRevision(revision)] = effects else {
+        panic!("expected one durable editor revision, got {effects:?}");
+    };
+    revision
+}
+
+#[test]
+fn enter_continues_each_required_list_form_as_one_persistent_revision() {
+    for (before, after) in [
+        ("- first item", "- first item\n- "),
+        ("9) item", "9) item\n10) "),
+        ("- [x] done", "- [x] done\n- [ ] "),
+        ("  *\tGrüße 👩🏽‍💻", "  *\tGrüße 👩🏽‍💻\n  *\t"),
+    ] {
+        let mut fixture = Fixture::new();
+        fixture.paste(before);
+        let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+        let revision = revision(&effects);
+        assert_eq!(revision.before_content, before, "{before:?}");
+        assert_eq!(revision.after_content, after, "{before:?}");
+        assert_eq!(
+            fixture.app.editor_snapshot().expect("editor").content,
+            after,
+            "{before:?}"
+        );
+        assert!(!fixture.app.has_pending_edit());
+    }
+}
+
+#[test]
+fn empty_item_exit_and_continuation_are_separate_restart_safe_undo_steps() {
+    let mut fixture = Fixture::new();
+    fixture.paste("- first");
+    let continuation = fixture.effects(UiInput::Key(UiKey::Enter));
+    assert_eq!(revision(&continuation).after_content, "- first\n- ");
+
+    let exit = fixture.effects(UiInput::Key(UiKey::Enter));
+    assert_eq!(revision(&exit).before_content, "- first\n- ");
+    assert_eq!(revision(&exit).after_content, "- first\n");
+    assert_eq!(
+        revision(&exit).after_cursor,
+        proqi::domain::TextPosition::new(1, 0)
+    );
+
+    assert_eq!(fixture.effects(UiInput::Key(UiKey::Undo)).len(), 1);
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("editor").content,
+        "- first\n- "
+    );
+    assert_eq!(fixture.effects(UiInput::Key(UiKey::Undo)).len(), 1);
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("editor").content,
+        "- first"
+    );
+}
+
+#[test]
+fn disabled_setting_and_selection_replacement_keep_plain_newline_behavior() {
+    let settings = UiSettings {
+        smart_lists: false,
+        ..UiSettings::default()
+    };
+    let mut disabled = Fixture::with_settings(settings);
+    disabled.paste("- first");
+    assert!(disabled.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    assert_eq!(
+        disabled.app.editor_snapshot().expect("editor").content,
+        "- first\n"
+    );
+
+    let mut selected = Fixture::new();
+    selected.paste("- first");
+    selected.input(UiInput::Key(UiKey::SelectAll));
+    assert!(selected.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    assert_eq!(
+        selected.app.editor_snapshot().expect("editor").content,
+        "\n"
+    );
+}
+
+#[test]
+fn paste_is_exact_and_smart_newlines_preserve_annotations_through_resize() {
+    let mut fixture = Fixture::new();
+    fixture.paste("- first");
+    fixture.input(UiInput::Paste("\n9) pasted".to_owned()));
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("editor").content,
+        "- first\n9) pasted"
+    );
+
+    let path = "/tmp/context.txt";
+    let content = format!("{path}\n- item");
+    let annotation = ContentAnnotation {
+        start: 0,
+        end: path.len(),
+        kind: ContentAnnotationKind::Attachment {
+            image: false,
+            display_name: "context.txt".to_owned(),
+        },
+    };
+    let mut annotated = Fixture::new();
+    annotated.input(UiInput::PasteAnnotated(PastePayload::annotated(
+        content,
+        vec![annotation.clone()],
+    )));
+    let effects = annotated.effects(UiInput::Key(UiKey::Enter));
+    assert_eq!(revision(&effects).after_annotations, vec![annotation]);
+    let cursor = annotated.app.editor_snapshot().expect("editor").cursor;
+    for (width, height) in [(12, 4), (80, 8), (7, 12), (40, 3)] {
+        let _terminal = draw(&mut annotated, width, height);
+        assert_eq!(
+            annotated.app.editor_snapshot().expect("editor").cursor,
+            cursor
+        );
+    }
+}
+
+#[test]
+fn command_palette_inserts_a_plain_newline_without_a_modifier_by_keyboard_and_mouse() {
+    let mut keyboard = Fixture::new();
+    keyboard.paste("- item");
+    keyboard.input(UiInput::Key(UiKey::Escape));
+    keyboard.input(UiInput::Key(UiKey::Character(':')));
+    for character in "plain newline".chars() {
+        keyboard.input(UiInput::Key(UiKey::Character(character)));
+    }
+    let effects = keyboard.effects(UiInput::Key(UiKey::Enter));
+    assert_eq!(revision(&effects).after_content, "- item\n");
+
+    let mut mouse = Fixture::new();
+    mouse.paste("9) item");
+    let commands = mouse
+        .app
+        .prepare_frame(Rect::new(0, 0, 80, 8))
+        .controls
+        .into_iter()
+        .find_map(|(target, area)| (target == HitTarget::Commands).then_some(area))
+        .expect("commands control");
+    mouse.pointer(
+        commands.x,
+        commands.y,
+        PointerKind::Down(PointerButton::Left),
+    );
+    for character in "plain newline".chars() {
+        mouse.input(UiInput::Key(UiKey::Character(character)));
+    }
+    let item = mouse
+        .app
+        .prepare_frame(Rect::new(0, 0, 80, 8))
+        .overlay
+        .expect("palette")
+        .items[0];
+    let effects = mouse.effects(UiInput::Pointer(PointerInput {
+        column: item.x,
+        row: item.y,
+        kind: PointerKind::Down(PointerButton::Left),
+        extend_selection: false,
+    }));
+    assert_eq!(revision(&effects).after_content, "9) item\n");
+}

--- a/tests/ui_board/snapshots.rs
+++ b/tests/ui_board/snapshots.rs
@@ -228,3 +228,16 @@ fn command_palette_has_a_complete_searchable_buffer() {
     }
     insta::assert_snapshot!(snapshot(&mut fixture, 72, 18, ThemePreference::Dark));
 }
+
+#[test]
+fn plain_newline_fallback_is_visible_in_the_command_palette() {
+    let mut fixture = Fixture::new();
+    let sequence = fixture.paste("- list item");
+    fixture.app.acknowledge_persistence(sequence, true);
+    fixture.input(UiInput::Key(UiKey::Escape));
+    fixture.input(UiInput::Key(UiKey::Character(':')));
+    for character in "plain newline".chars() {
+        fixture.input(UiInput::Key(UiKey::Character(character)));
+    }
+    insta::assert_snapshot!(snapshot(&mut fixture, 72, 14, ThemePreference::Dark));
+}

--- a/tests/ui_board/snapshots/ui_board__snapshots__plain_newline_fallback_is_visible_in_the_command_palette.snap
+++ b/tests/ui_board/snapshots/ui_board__snapshots__plain_newline_fallback_is_visible_in_the_command_palette.snap
@@ -1,0 +1,38 @@
+---
+source: tests/ui_board/snapshots.rs
+assertion_line: 242
+expression: "snapshot(&mut fixture, 72, 14, ThemePreference::Dark)"
+---
+SIZE 72x14
+
+TEXT
+00││
+01│⋮ - list item│
+02│       ┌ commands ────────────────────────────────────────────[x]│
+03│       │:plain newline                                          ││
+04│       │Insert plain newline                                    ││
+05│       │                                                        ││
+06│       └────────────────────────────────────────────────────────┘│
+07││
+08││
+09││
+10││
+11│  proqi-ui-contract│
+12│  1 thought · board · saved│
+13│  n New   y Copy  x Cut  d Delete  Space Select u Undo  / Search│
+
+STYLE RUNS
+0: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-71 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+2: 0-61 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 62-64 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 65-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+3: 0-7 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 8-63 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 64-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-7 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 8-63 fg=Rgb(112, 214, 155) bg=Rgb(39, 40, 48) mod=BOLD | 64-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+6: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+7: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+8: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+9: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+10: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+11: 0-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+12: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-69 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 70-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+13: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 11-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-18 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 19-24 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 25-25 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 26-34 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 35-39 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 40-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 48-48 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 49-55 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 56-56 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 57-71 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE


### PR DESCRIPTION
## Summary

- add conservative smart continuation for unordered, ordered, and task list items while preserving indentation, spacing, delimiter, line endings, Unicode, cursor state, annotations, folds, and later list numbering
- exit a generated empty top-level item as one durable editor revision and undo step
- add the default-on `smart_lists` setting plus an accessible `Insert plain newline` command-palette fallback that works without terminal modifiers
- document the behavior and cover editor, reducer, input, settings, palette, persistence, resize, and visible TUI behavior

## Acceptance criteria

- [x] continue `- first item` as `- `, `9) item` as `10) `, and completed tasks as unchecked tasks
- [x] support `-`, `*`, `+`, one-to-nine-digit ordered markers with `.` or `)`, preserved indentation/spacing/delimiter, and LF/CRLF
- [x] support `[ ]`, `[x]`, and `[X]`, always generating `[ ]`
- [x] remove a generated empty top-level marker as one semantic action; keep selection replacement exact
- [x] leave paste, bare `.`, escaped markers, thematic breaks, fenced code, and conservatively detected indented code unchanged
- [x] do not cascade-renumber later items
- [x] default `smart_lists` to true with parsing and backward-compatibility coverage
- [x] expose a keyboard- and mouse-accessible plain-newline palette command without relying on terminal modifiers
- [x] persist continuation/exit as one revision and undo step, including restart-safe undo/redo
- [x] preserve cursor, Unicode, annotations/folds, wrapping, and resize behavior
- [x] keep nested Tab/Shift+Tab indentation out of scope and leave room for future editor commands

## Verification

- `cargo xtask check` — green: formatting, diff, source limits, 20 reviewed snapshots, public assets, architecture, Clippy, rustdoc, 553 nextest tests passed / 4 skipped, and doc tests
- `cargo test --test editor_contract` — 33 passed
- `cargo test --test ui_board` — 133 passed
- `cargo test --test domain_reducer` — 15 passed
- `cargo test --lib adapters::terminal::` — 49 passed
- live Herdr TUI: typed `- first item`, Enter generated `- `, second Enter exited the list; persisted content was exactly `- first item\n`
- separate-process CLI undo restored `- first item\n- ` and redo restored the exit, proving restart-safe history

## Research and provenance

- [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) (CC BY-SA 4.0) informed marker limits and conservative thematic-break/fenced/indented-code guards.
- [CodeMirror lang-markdown commands](https://github.com/codemirror/lang-markdown/blob/main/src/commands.ts) ([MIT license](https://github.com/codemirror/lang-markdown/blob/main/LICENSE)) informed the interaction model of a specialized list-newline command with a plain fallback and unchecked follow-on tasks.
- The implementation is original; no external code was copied. Unlike editor behaviors that renumber following items, this ticket intentionally changes only the newly inserted marker.

## Risks and limitations

- leading indentation of four or more columns and tab-indented lines are conservatively treated as code
- nested Tab/Shift+Tab indentation remains deliberately out of scope
- later ordered items are never cascade-renumbered by this command
