### PR TITLE
Make installed package contract state run-owned

### DIFF
--- a/tests/package_contract.rs
+++ b/tests/package_contract.rs
@@ -5,6 +5,7 @@ use std::{
     io::Write as _,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
+    sync::Arc,
 };
 
 use rusqlite::Connection;
@@ -13,21 +14,31 @@ use serde_json::Value;
 #[cfg(unix)]
 #[path = "package_contract/pty.rs"]
 mod pty;
+#[path = "package_contract/sandbox.rs"]
+mod sandbox;
+
+use sandbox::PackageSandbox;
 
 struct InstalledProduct {
     binary: PathBuf,
     archive: PathBuf,
     state: PathBuf,
     working: PathBuf,
+    sandbox: Arc<PackageSandbox>,
 }
 
 impl InstalledProduct {
     fn from_environment() -> Self {
+        let sandbox = Arc::new(
+            PackageSandbox::create(&required_path("PROQI_PACKAGE_ROOT"))
+                .expect("create package-contract sandbox"),
+        );
         Self {
             binary: required_path("PROQI_PACKAGE_BINARY"),
             archive: required_path("PROQI_PACKAGE_ARCHIVE"),
-            state: required_path("PROQI_PACKAGE_STATE"),
-            working: required_path("PROQI_PACKAGE_WORKING"),
+            state: sandbox.state().to_owned(),
+            working: sandbox.working().to_owned(),
+            sandbox,
         }
     }
 
@@ -69,6 +80,7 @@ impl InstalledProduct {
 #[ignore = "run by cargo xtask package with an installed release binary"]
 fn installed_product_contract() {
     let product = InstalledProduct::from_environment();
+    let owned_root = product.sandbox.root().to_owned();
     assert!(!product.state.join("data/proqi.sqlite3").exists());
     assert_identity_and_completion_contract(&product);
     let (session, thought, content) = assert_json_workflow(&product);
@@ -77,6 +89,8 @@ fn installed_product_contract() {
     assert_archive_and_runtime_independence(&product);
     #[cfg(unix)]
     pty::assert_active_owner_and_terminal_restoration(&product, &session);
+    drop(product);
+    assert!(!owned_root.exists(), "package sandbox survived its owner");
 }
 
 fn assert_identity_and_completion_contract(product: &InstalledProduct) {
@@ -229,6 +243,7 @@ fn run_for_state(product: &InstalledProduct, state: &Path, arguments: &[&str]) -
 fn isolated_command(binary: &Path, working: &Path) -> Command {
     let mut command = Command::new(binary);
     command
+        .env_clear()
         .current_dir(working)
         .env("PROQI_DISABLE_HERDR", "1")
         .env("NO_PROXY", "*")

--- a/tests/package_contract/pty.rs
+++ b/tests/package_contract/pty.rs
@@ -2,15 +2,13 @@
 
 use std::{
     fs,
-    io::{Read, Write},
     os::unix::fs::symlink,
-    process::Command,
-    sync::{Arc, Mutex},
+    process::{Command, Stdio},
+    sync::Arc,
     thread,
     time::{Duration, Instant},
 };
 
-use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
 use proqi::{
     adapters::{
         control::LocalUpdateControlClient,
@@ -30,23 +28,20 @@ use proqi::{
         },
     },
 };
-use serde_json::Value;
 
 use super::{InstalledProduct, package_version};
 
-struct PtyChild {
-    child: Box<dyn Child + Send + Sync>,
-    input: Box<dyn Write + Send>,
-    output: Arc<Mutex<Vec<u8>>>,
-    reader: thread::JoinHandle<()>,
-}
+#[path = "pty/process.rs"]
+mod process;
+
+use process::{PtyChild, assert_terminal_restored};
 
 pub(super) fn assert_active_owner_and_terminal_restoration(
     product: &InstalledProduct,
     session: &str,
 ) {
-    let mut owner = spawn(product, session);
-    wait_for_owner(product, session, &mut owner);
+    let mut owner = PtyChild::spawn(product, session);
+    owner.wait_for_owner(product, session);
     let forwarded = product.json_input(
         &["thoughts", "add", session],
         "forwarded through the installed owner Grüße 界",
@@ -56,28 +51,56 @@ pub(super) fn assert_active_owner_and_terminal_restoration(
             .as_str()
             .is_some_and(|id| id.starts_with("tht_"))
     );
-    owner.input.write_all(b"q").expect("quit owner");
-    owner.input.flush().expect("flush quit");
-    let output = finish(owner, Duration::from_secs(10));
+    owner.input().write_all(b"q").expect("quit owner");
+    owner.input().flush().expect("flush quit");
+    let output = owner.finish(Duration::from_secs(10));
     assert_terminal_restored(&output);
 
     let created = product.json(&[]);
     let terminated_session = created["data"]["session_id"]
         .as_str()
         .expect("termination session");
-    let mut owner = spawn(product, terminated_session);
-    wait_for_owner(product, terminated_session, &mut owner);
-    let process_id = owner.child.process_id().expect("PTY process ID");
+    let mut owner = PtyChild::spawn(product, terminated_session);
+    owner.wait_for_owner(product, terminated_session);
+    let process_id = owner.process_id();
     let termination = Command::new("/bin/kill")
         .args(["-TERM", &process_id.to_string()])
         .status()
         .expect("signal PTY owner");
     assert!(termination.success());
-    let output = finish(owner, Duration::from_secs(10));
+    let output = owner.finish(Duration::from_secs(10));
     assert_terminal_restored(&output);
     let resumed = product.json(&["-r", terminated_session]);
     assert_eq!(resumed["data"]["session_id"], terminated_session);
+    assert_drop_guard_releases_owner(product);
     assert_update_contract(product);
+}
+
+fn assert_drop_guard_releases_owner(product: &InstalledProduct) {
+    let created = product.json(&[]);
+    let session = created["data"]["session_id"]
+        .as_str()
+        .expect("drop-guard session");
+    let mut owner = PtyChild::spawn(product, session);
+    owner.wait_for_owner(product, session);
+    let process_id = owner.process_id();
+    drop(owner);
+    let probe = Command::new("/bin/kill")
+        .args(["-0", &process_id.to_string()])
+        .stderr(Stdio::null())
+        .status()
+        .expect("probe dropped PTY owner");
+    assert!(!probe.success(), "dropped PTY owner remained alive");
+    let resumed = product.json(&["-r", session]);
+    assert_eq!(resumed["data"]["session_id"], session);
+    let instances = product.state.join("runtime/instances");
+    assert_eq!(
+        fs::read_dir(instances)
+            .expect("read cleaned runtime metadata")
+            .count(),
+        0,
+        "dropped owner metadata survived recovery"
+    );
 }
 
 struct FakeSource {
@@ -120,8 +143,8 @@ fn assert_update_contract(product: &InstalledProduct) {
     let session = created["data"]["session_id"]
         .as_str()
         .expect("update session");
-    let mut owner = spawn(&homebrew, session);
-    wait_for_owner(&homebrew, session, &mut owner);
+    let mut owner = PtyChild::spawn(&homebrew, session);
+    owner.wait_for_owner(&homebrew, session);
     let installation = SystemInstallDetector::for_executable(homebrew.binary.clone())
         .detect()
         .expect("fake Homebrew installation");
@@ -159,9 +182,9 @@ fn assert_update_contract(product: &InstalledProduct) {
     );
     let after = wait_for_replacement(&registry, session, before.instance_id);
     assert_eq!(after.pid, before.pid);
-    owner.input.write_all(b"q").expect("quit replaced owner");
-    owner.input.flush().expect("flush replaced quit");
-    assert_terminal_restored(&finish(owner, Duration::from_secs(10)));
+    owner.input().write_all(b"q").expect("quit replaced owner");
+    owner.input().flush().expect("flush replaced quit");
+    assert_terminal_restored(&owner.finish(Duration::from_secs(10)));
     assert_failed_exec_is_recoverable(product);
 }
 
@@ -234,8 +257,8 @@ fn assert_failed_exec_is_recoverable(product: &InstalledProduct) {
     let session = created["data"]["session_id"]
         .as_str()
         .expect("failed-exec session");
-    let mut owner = spawn(&homebrew, session);
-    wait_for_owner(&homebrew, session, &mut owner);
+    let mut owner = PtyChild::spawn(&homebrew, session);
+    owner.wait_for_owner(&homebrew, session);
     let installation = SystemInstallDetector::for_executable(homebrew.binary.clone())
         .detect()
         .expect("failed-exec installation");
@@ -286,7 +309,7 @@ fn assert_failed_exec_is_recoverable(product: &InstalledProduct) {
             .expect("accept failed replacement")
             .accepted
     );
-    let (success, output) = finish_with_status(owner, Duration::from_secs(10));
+    let (success, output) = owner.finish_with_status(Duration::from_secs(10));
     assert!(
         !success,
         "injected Unix exec failure unexpectedly succeeded"
@@ -321,6 +344,7 @@ fn fake_homebrew_product(product: &InstalledProduct, name: &str) -> InstalledPro
         archive: product.archive.clone(),
         state,
         working: product.working.clone(),
+        sandbox: Arc::clone(&product.sandbox),
     }
 }
 
@@ -362,138 +386,5 @@ fn wait_for_replacement(
         }
         assert!(Instant::now() < deadline, "installed owner did not exec");
         thread::sleep(Duration::from_millis(20));
-    }
-}
-
-fn spawn(product: &InstalledProduct, session: &str) -> PtyChild {
-    let pair = native_pty_system()
-        .openpty(PtySize {
-            rows: 24,
-            cols: 100,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
-        .expect("open package PTY");
-    let reader = pair.master.try_clone_reader().expect("clone PTY reader");
-    let input = pair.master.take_writer().expect("take PTY writer");
-    let output = Arc::new(Mutex::new(Vec::new()));
-    let reader_output = Arc::clone(&output);
-    let reader = thread::spawn(move || read_pty(reader, &reader_output));
-    let mut command = CommandBuilder::new(&product.binary);
-    command.arg("--state-dir");
-    command.arg(&product.state);
-    command.args(["-r", session]);
-    command.cwd(&product.working);
-    command.env("PROQI_DISABLE_HERDR", "1");
-    command.env("NO_PROXY", "*");
-    command.env("HTTP_PROXY", "http://127.0.0.1:1");
-    command.env("HTTPS_PROXY", "http://127.0.0.1:1");
-    command.env("TERM", "xterm-256color");
-    let child = pair
-        .slave
-        .spawn_command(command)
-        .expect("spawn installed PTY owner");
-    drop(pair.slave);
-    PtyChild {
-        child,
-        input,
-        output,
-        reader,
-    }
-}
-
-fn read_pty(mut reader: Box<dyn Read + Send>, output: &Mutex<Vec<u8>>) {
-    let mut buffer = [0_u8; 8 * 1024];
-    loop {
-        match reader.read(&mut buffer) {
-            Ok(0) | Err(_) => return,
-            Ok(read) => output
-                .lock()
-                .expect("PTY output lock")
-                .extend_from_slice(&buffer[..read]),
-        }
-    }
-}
-
-fn finish(owner: PtyChild, timeout: Duration) -> Vec<u8> {
-    let (success, output) = finish_with_status(owner, timeout);
-    assert!(
-        success,
-        "PTY owner exited unsuccessfully: {}",
-        String::from_utf8_lossy(&output)
-    );
-    output
-}
-
-fn finish_with_status(mut owner: PtyChild, timeout: Duration) -> (bool, Vec<u8>) {
-    let deadline = Instant::now() + timeout;
-    loop {
-        match owner.child.try_wait().expect("poll PTY child") {
-            Some(status) => {
-                let success = status.success();
-                drop(owner.input);
-                owner.reader.join().expect("join PTY reader");
-                let output = owner.output.lock().expect("PTY output lock").clone();
-                return (success, output);
-            }
-            None if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
-            None => {
-                owner.child.kill().expect("kill timed-out PTY owner");
-                panic!("PTY owner did not exit within {timeout:?}");
-            }
-        }
-    }
-}
-
-fn wait_for_owner(product: &InstalledProduct, session: &str, owner: &mut PtyChild) {
-    let deadline = Instant::now() + Duration::from_secs(8);
-    loop {
-        if owner_is_ready(product, session) {
-            return;
-        }
-        if let Some(status) = owner.child.try_wait().expect("poll starting owner") {
-            panic!(
-                "installed owner exited with {status}: {}",
-                String::from_utf8_lossy(&owner.output.lock().expect("PTY output lock"))
-            );
-        }
-        assert!(
-            Instant::now() < deadline,
-            "installed owner did not start: {}",
-            String::from_utf8_lossy(&owner.output.lock().expect("PTY output lock"))
-        );
-        thread::sleep(Duration::from_millis(20));
-    }
-}
-
-fn owner_is_ready(product: &InstalledProduct, session: &str) -> bool {
-    let directory = product.state.join("runtime/instances");
-    let Ok(entries) = fs::read_dir(directory) else {
-        return false;
-    };
-    entries.filter_map(Result::ok).any(|entry| {
-        fs::read(entry.path())
-            .ok()
-            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
-            .is_some_and(|metadata| {
-                metadata["session_id"] == session
-                    && metadata["control_protocol"].as_u64()
-                        == Some(u64::from(proqi::ports::control::CONTROL_PROTOCOL_VERSION))
-                    && metadata["control_endpoint"]
-                        .as_str()
-                        .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
-            })
-    })
-}
-
-fn assert_terminal_restored(output: &[u8]) {
-    for sequence in [b"\x1b[?1049h".as_slice(), b"\x1b[?1049l".as_slice()] {
-        assert!(
-            output
-                .windows(sequence.len())
-                .any(|window| window == sequence),
-            "terminal output omitted restoration sequence {sequence:?}: {}",
-            String::from_utf8_lossy(output)
-        );
     }
 }

--- a/tests/package_contract/pty.rs
+++ b/tests/package_contract/pty.rs
@@ -94,13 +94,39 @@ fn assert_drop_guard_releases_owner(product: &InstalledProduct) {
     let resumed = product.json(&["-r", session]);
     assert_eq!(resumed["data"]["session_id"], session);
     let instances = product.state.join("runtime/instances");
-    assert_eq!(
-        fs::read_dir(instances)
-            .expect("read cleaned runtime metadata")
-            .count(),
-        0,
-        "dropped owner metadata survived recovery"
+    let survivors = runtime_instance_summaries(&instances);
+    assert!(
+        survivors.is_empty(),
+        "dropped owner {session} pid {process_id} metadata survived recovery: {survivors:?}"
     );
+}
+
+fn runtime_instance_summaries(
+    instances: &std::path::Path,
+) -> Vec<(String, String, String, u64, u64)> {
+    fs::read_dir(instances)
+        .expect("read cleaned runtime metadata")
+        .map(|entry| {
+            let entry = entry.expect("runtime metadata entry");
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let bytes = fs::read(entry.path()).expect("read runtime metadata entry");
+            let metadata = serde_json::from_slice::<serde_json::Value>(&bytes)
+                .unwrap_or(serde_json::Value::Null);
+            (
+                name,
+                metadata["instance_id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                metadata["session_id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_owned(),
+                metadata["pid"].as_u64().unwrap_or_default(),
+                metadata["control_protocol"].as_u64().unwrap_or_default(),
+            )
+        })
+        .collect()
 }
 
 struct FakeSource {

--- a/tests/package_contract/pty/process.rs
+++ b/tests/package_contract/pty/process.rs
@@ -3,38 +3,49 @@
 use std::{
     fs,
     io::{Read, Write},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex, TryLockError,
+        atomic::{AtomicBool, Ordering},
+    },
     thread,
     time::{Duration, Instant},
 };
 
-use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
+use portable_pty::{Child, CommandBuilder, ExitStatus, PtySize, native_pty_system};
+use rustix::process::{
+    Pid, Signal, WaitId, WaitIdOptions, kill_process, kill_process_group, waitid,
+};
 use serde_json::Value;
 
 use crate::InstalledProduct;
 
+#[path = "process/cleanup.rs"]
+mod cleanup;
+
+use cleanup::{
+    CleanupOutcome, CleanupProgress, CleanupState, TeardownDeadline, process_group_is_absent,
+};
+
+const OUTPUT_LIMIT: usize = 64 * 1024;
+const TEARDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+// Match the production terminal shutdown budget before forcing the owned group.
+const TERM_GRACE: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+
 pub(super) struct PtyChild {
     child: Option<Box<dyn Child + Send + Sync>>,
+    process_group: Option<Pid>,
     input: Option<Box<dyn Write + Send>>,
     output: Arc<Mutex<Vec<u8>>>,
     reader: Option<thread::JoinHandle<()>>,
+    exit_status: Option<ExitStatus>,
+    cleanup: Option<CleanupProgress>,
+    #[cfg(test)]
+    drop_success: Option<Arc<AtomicBool>>,
 }
 
 impl PtyChild {
     pub(super) fn spawn(product: &InstalledProduct, session: &str) -> Self {
-        let pair = native_pty_system()
-            .openpty(PtySize {
-                rows: 24,
-                cols: 100,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .expect("open package PTY");
-        let reader = pair.master.try_clone_reader().expect("clone PTY reader");
-        let input = pair.master.take_writer().expect("take PTY writer");
-        let output = Arc::new(Mutex::new(Vec::new()));
-        let reader_output = Arc::clone(&output);
-        let reader = thread::spawn(move || read_pty(reader, &reader_output));
         let mut command = CommandBuilder::new(&product.binary);
         command.env_clear();
         command.arg("--state-dir");
@@ -46,17 +57,72 @@ impl PtyChild {
         command.env("HTTP_PROXY", "http://127.0.0.1:1");
         command.env("HTTPS_PROXY", "http://127.0.0.1:1");
         command.env("TERM", "xterm-256color");
+        Self::spawn_command(command)
+    }
+
+    fn spawn_command(command: CommandBuilder) -> Self {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 100,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("open package PTY");
+        let reader = pair.master.try_clone_reader().expect("clone PTY reader");
+        let input = pair.master.take_writer().expect("take PTY writer");
         let child = pair
             .slave
             .spawn_command(command)
             .expect("spawn installed PTY owner");
-        drop(pair.slave);
-        Self {
+        let process_group = child_pid(child.as_ref());
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let reader_output = Arc::clone(&output);
+        // Arm ownership before inspecting any fallible PID or PTY metadata.
+        let mut owned = Self {
             child: Some(child),
+            process_group,
             input: Some(input),
             output,
-            reader: Some(reader),
+            reader: None,
+            exit_status: None,
+            cleanup: None,
+            #[cfg(test)]
+            drop_success: None,
+        };
+        let process = owned
+            .child
+            .as_ref()
+            .and_then(|child| child_pid(child.as_ref()))
+            .expect("PTY process ID");
+        let process_group = pair
+            .master
+            .process_group_leader()
+            .and_then(Pid::from_raw)
+            .expect("dedicated PTY process group");
+        assert_eq!(
+            process_group, process,
+            "portable-pty did not isolate the package owner as its group leader"
+        );
+        drop(pair.slave);
+        match thread::Builder::new()
+            .name("package-pty-output".to_owned())
+            .spawn(move || read_pty(reader, &reader_output))
+        {
+            Ok(reader) => owned.reader = Some(reader),
+            Err(error) => {
+                let cleanup = owned.terminate();
+                panic!("spawn package PTY reader: {error}; cleanup: {cleanup:?}");
+            }
         }
+        owned
+    }
+
+    #[cfg(test)]
+    fn observe_drop_success(&mut self) -> Arc<AtomicBool> {
+        let success = Arc::new(AtomicBool::new(false));
+        self.drop_success = Some(Arc::clone(&success));
+        success
     }
 
     pub(super) fn input(&mut self) -> &mut dyn Write {
@@ -76,17 +142,11 @@ impl PtyChild {
             if owner_is_ready(product, session) {
                 return;
             }
-            if let Some(status) = self
-                .child
-                .as_mut()
-                .expect("live PTY child")
-                .try_wait()
-                .expect("poll starting owner")
-            {
-                self.child.take();
-                self.close_io();
+            if self.child_has_exited().expect("poll starting owner") {
+                let cleanup = self.terminate();
+                let status = self.exit_status.as_ref().expect("reaped PTY owner");
                 panic!(
-                    "installed owner exited with {status}: {}",
+                    "installed owner exited with {status}; cleanup: {cleanup:?}: {}",
                     String::from_utf8_lossy(&self.output())
                 );
             }
@@ -112,55 +172,185 @@ impl PtyChild {
     pub(super) fn finish_with_status(mut self, timeout: Duration) -> (bool, Vec<u8>) {
         let deadline = Instant::now() + timeout;
         loop {
-            match self
-                .child
-                .as_mut()
-                .expect("live PTY child")
-                .try_wait()
-                .expect("poll PTY child")
-            {
-                Some(status) => {
-                    self.child.take();
-                    self.close_io();
-                    return (status.success(), self.output());
+            match self.child_has_exited().expect("poll PTY child") {
+                true => {
+                    let cleanup = self.terminate();
+                    assert!(
+                        cleanup.successful(),
+                        "PTY teardown exceeded its deadline: {cleanup:?}: {}",
+                        String::from_utf8_lossy(&self.output())
+                    );
+                    let success = self
+                        .exit_status
+                        .as_ref()
+                        .expect("reaped PTY owner")
+                        .success();
+                    return (success, self.output());
                 }
-                None if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
-                None => {
-                    self.terminate();
-                    panic!("PTY owner did not exit within {timeout:?}");
+                false if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+                false => {
+                    let cleanup = self.terminate();
+                    panic!(
+                        "PTY owner did not exit within {timeout:?}; cleanup: {cleanup:?}: {}",
+                        String::from_utf8_lossy(&self.output())
+                    );
                 }
             }
         }
     }
 
+    fn child_has_exited(&self) -> rustix::io::Result<bool> {
+        let process = self
+            .child
+            .as_ref()
+            .and_then(|child| child_pid(child.as_ref()));
+        let Some(process) = process else {
+            return Ok(true);
+        };
+        waitid(
+            WaitId::Pid(process),
+            WaitIdOptions::EXITED | WaitIdOptions::NOHANG | WaitIdOptions::NOWAIT,
+        )
+        .map(|status| status.is_some())
+    }
+
     fn output(&self) -> Vec<u8> {
-        self.output.lock().expect("PTY output lock").clone()
-    }
-
-    fn close_io(&mut self) {
-        self.input.take();
-        if let Some(reader) = self.reader.take() {
-            reader.join().expect("join PTY reader");
+        match self.output.try_lock() {
+            Ok(output) => output.clone(),
+            Err(TryLockError::Poisoned(error)) => error.into_inner().clone(),
+            Err(TryLockError::WouldBlock) => b"<PTY output reader still active>".to_vec(),
         }
     }
 
-    fn terminate(&mut self) {
+    fn terminate(&mut self) -> CleanupOutcome {
         self.input.take();
-        if let Some(mut child) = self.child.take()
-            && !matches!(child.try_wait(), Ok(Some(_)))
+        if self.cleanup.is_none() {
+            let deadline = TeardownDeadline::after(TEARDOWN_TIMEOUT);
+            self.cleanup = Some(CleanupProgress {
+                deadline,
+                force_at: deadline.capped_after(TERM_GRACE),
+                term_sent: false,
+                kill_sent: false,
+                outcome: CleanupOutcome::new(self),
+            });
+        }
+        if !self
+            .cleanup
+            .as_ref()
+            .is_some_and(|cleanup| cleanup.term_sent)
         {
-            let _ = child.kill();
-            let _ = child.wait();
+            self.signal_owned(Signal::TERM);
+            self.cleanup.as_mut().expect("cleanup progress").term_sent = true;
         }
-        if let Some(reader) = self.reader.take() {
-            let _ = reader.join();
+        loop {
+            self.poll_reader();
+            let child_exited = self.child_has_exited().unwrap_or(false);
+            let cleanup = self.cleanup.as_ref().expect("cleanup progress");
+            if !cleanup.kill_sent && (cleanup.force_at.expired() || child_exited) {
+                // Keep the direct leader waitable until the final group signal
+                // has been sent, so its PID cannot be reused as a foreign PGID.
+                self.signal_owned(Signal::KILL);
+                self.cleanup.as_mut().expect("cleanup progress").kill_sent = true;
+            }
+            if self
+                .cleanup
+                .as_ref()
+                .is_some_and(|cleanup| cleanup.kill_sent)
+            {
+                let child = self.poll_child();
+                self.cleanup
+                    .as_mut()
+                    .expect("cleanup progress")
+                    .outcome
+                    .child = child;
+            }
+            self.poll_group();
+            let cleanup = self.cleanup.as_ref().expect("cleanup progress");
+            if cleanup.outcome.settled() || cleanup.deadline.expired() {
+                return cleanup.outcome;
+            }
+            thread::sleep(POLL_INTERVAL.min(cleanup.next_deadline().remaining()));
         }
+    }
+
+    fn signal_owned(&self, signal: Signal) {
+        let group_signalled = self
+            .process_group
+            .is_some_and(|group| kill_process_group(group, signal).is_ok());
+        if !group_signalled
+            && let Some(process) = self
+                .child
+                .as_ref()
+                .and_then(|child| child_pid(child.as_ref()))
+        {
+            let _ = kill_process(process, signal);
+        }
+    }
+
+    fn poll_reader(&mut self) {
+        let reader = self.join_finished_reader();
+        if let Some(reader) = reader {
+            self.cleanup
+                .as_mut()
+                .expect("cleanup progress")
+                .outcome
+                .reader = reader;
+        }
+    }
+
+    fn poll_group(&mut self) {
+        let group = if self.process_group.is_none_or(process_group_is_absent) {
+            self.process_group.take();
+            CleanupState::Complete
+        } else {
+            CleanupState::Pending
+        };
+        self.cleanup
+            .as_mut()
+            .expect("cleanup progress")
+            .outcome
+            .group = group;
+    }
+
+    fn poll_child(&mut self) -> CleanupState {
+        let Some(child) = self.child.as_mut() else {
+            return CleanupState::Complete;
+        };
+        if let Ok(Some(status)) = child.try_wait() {
+            self.exit_status = Some(status);
+            self.child.take();
+            CleanupState::Complete
+        } else {
+            CleanupState::Pending
+        }
+    }
+
+    fn join_finished_reader(&mut self) -> Option<CleanupState> {
+        if !self
+            .reader
+            .as_ref()
+            .is_some_and(thread::JoinHandle::is_finished)
+        {
+            return None;
+        }
+        let reader = self.reader.take().expect("finished PTY reader");
+        // `is_finished` is polled only within `TeardownDeadline`; joining here
+        // cannot wait for a still-running reader that retains the PTY master.
+        Some(if reader.join().is_ok() {
+            CleanupState::Complete
+        } else {
+            CleanupState::Failed
+        })
     }
 }
 
 impl Drop for PtyChild {
     fn drop(&mut self) {
-        self.terminate();
+        let cleanup = self.terminate();
+        #[cfg(test)]
+        if let Some(success) = &self.drop_success {
+            success.store(cleanup.successful(), Ordering::Release);
+        }
     }
 }
 
@@ -181,12 +371,29 @@ fn read_pty(mut reader: Box<dyn Read + Send>, output: &Mutex<Vec<u8>>) {
     loop {
         match reader.read(&mut buffer) {
             Ok(0) | Err(_) => return,
-            Ok(read) => output
-                .lock()
-                .expect("PTY output lock")
-                .extend_from_slice(&buffer[..read]),
+            Ok(read) => append_bounded(output, &buffer[..read]),
         }
     }
+}
+
+fn append_bounded(output: &Mutex<Vec<u8>>, bytes: &[u8]) {
+    let mut output = output.lock().expect("PTY output lock");
+    let overflow = output
+        .len()
+        .saturating_add(bytes.len())
+        .saturating_sub(OUTPUT_LIMIT);
+    if overflow > 0 {
+        let remove = overflow.min(output.len());
+        output.drain(..remove);
+    }
+    output.extend_from_slice(bytes);
+}
+
+fn child_pid(child: &(dyn Child + Send + Sync)) -> Option<Pid> {
+    child
+        .process_id()
+        .and_then(|process| i32::try_from(process).ok())
+        .and_then(Pid::from_raw)
 }
 
 fn owner_is_ready(product: &InstalledProduct, session: &str) -> bool {
@@ -194,17 +401,30 @@ fn owner_is_ready(product: &InstalledProduct, session: &str) -> bool {
     let Ok(entries) = fs::read_dir(directory) else {
         return false;
     };
-    entries.filter_map(Result::ok).any(|entry| {
-        fs::read(entry.path())
-            .ok()
-            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
-            .is_some_and(|metadata| {
-                metadata["session_id"] == session
-                    && metadata["control_protocol"].as_u64()
-                        == Some(u64::from(proqi::ports::control::CONTROL_PROTOCOL_VERSION))
-                    && metadata["control_endpoint"]
-                        .as_str()
-                        .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
-            })
-    })
+    entries
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                == Some("json")
+        })
+        .any(|entry| {
+            fs::read(entry.path())
+                .ok()
+                .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                .is_some_and(|metadata| {
+                    metadata["session_id"] == session
+                        && metadata["control_protocol"].as_u64()
+                            == Some(u64::from(proqi::ports::control::CONTROL_PROTOCOL_VERSION))
+                        && metadata["control_endpoint"]
+                            .as_str()
+                            .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
+                })
+        })
 }
+
+#[cfg(test)]
+#[path = "process/tests.rs"]
+mod tests;

--- a/tests/package_contract/pty/process.rs
+++ b/tests/package_contract/pty/process.rs
@@ -1,0 +1,210 @@
+//! Panic-safe ownership of an installed product running under a Unix PTY.
+
+use std::{
+    fs,
+    io::{Read, Write},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
+use serde_json::Value;
+
+use crate::InstalledProduct;
+
+pub(super) struct PtyChild {
+    child: Option<Box<dyn Child + Send + Sync>>,
+    input: Option<Box<dyn Write + Send>>,
+    output: Arc<Mutex<Vec<u8>>>,
+    reader: Option<thread::JoinHandle<()>>,
+}
+
+impl PtyChild {
+    pub(super) fn spawn(product: &InstalledProduct, session: &str) -> Self {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 100,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("open package PTY");
+        let reader = pair.master.try_clone_reader().expect("clone PTY reader");
+        let input = pair.master.take_writer().expect("take PTY writer");
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let reader_output = Arc::clone(&output);
+        let reader = thread::spawn(move || read_pty(reader, &reader_output));
+        let mut command = CommandBuilder::new(&product.binary);
+        command.env_clear();
+        command.arg("--state-dir");
+        command.arg(&product.state);
+        command.args(["-r", session]);
+        command.cwd(&product.working);
+        command.env("PROQI_DISABLE_HERDR", "1");
+        command.env("NO_PROXY", "*");
+        command.env("HTTP_PROXY", "http://127.0.0.1:1");
+        command.env("HTTPS_PROXY", "http://127.0.0.1:1");
+        command.env("TERM", "xterm-256color");
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .expect("spawn installed PTY owner");
+        drop(pair.slave);
+        Self {
+            child: Some(child),
+            input: Some(input),
+            output,
+            reader: Some(reader),
+        }
+    }
+
+    pub(super) fn input(&mut self) -> &mut dyn Write {
+        self.input.as_deref_mut().expect("live PTY input")
+    }
+
+    pub(super) fn process_id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .and_then(|child| child.process_id())
+            .expect("PTY process ID")
+    }
+
+    pub(super) fn wait_for_owner(&mut self, product: &InstalledProduct, session: &str) {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        loop {
+            if owner_is_ready(product, session) {
+                return;
+            }
+            if let Some(status) = self
+                .child
+                .as_mut()
+                .expect("live PTY child")
+                .try_wait()
+                .expect("poll starting owner")
+            {
+                self.child.take();
+                self.close_io();
+                panic!(
+                    "installed owner exited with {status}: {}",
+                    String::from_utf8_lossy(&self.output())
+                );
+            }
+            assert!(
+                Instant::now() < deadline,
+                "installed owner did not start: {}",
+                String::from_utf8_lossy(&self.output())
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    pub(super) fn finish(self, timeout: Duration) -> Vec<u8> {
+        let (success, output) = self.finish_with_status(timeout);
+        assert!(
+            success,
+            "PTY owner exited unsuccessfully: {}",
+            String::from_utf8_lossy(&output)
+        );
+        output
+    }
+
+    pub(super) fn finish_with_status(mut self, timeout: Duration) -> (bool, Vec<u8>) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self
+                .child
+                .as_mut()
+                .expect("live PTY child")
+                .try_wait()
+                .expect("poll PTY child")
+            {
+                Some(status) => {
+                    self.child.take();
+                    self.close_io();
+                    return (status.success(), self.output());
+                }
+                None if Instant::now() < deadline => thread::sleep(Duration::from_millis(20)),
+                None => {
+                    self.terminate();
+                    panic!("PTY owner did not exit within {timeout:?}");
+                }
+            }
+        }
+    }
+
+    fn output(&self) -> Vec<u8> {
+        self.output.lock().expect("PTY output lock").clone()
+    }
+
+    fn close_io(&mut self) {
+        self.input.take();
+        if let Some(reader) = self.reader.take() {
+            reader.join().expect("join PTY reader");
+        }
+    }
+
+    fn terminate(&mut self) {
+        self.input.take();
+        if let Some(mut child) = self.child.take()
+            && !matches!(child.try_wait(), Ok(Some(_)))
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+    }
+}
+
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+pub(super) fn assert_terminal_restored(output: &[u8]) {
+    for sequence in [b"\x1b[?1049h".as_slice(), b"\x1b[?1049l".as_slice()] {
+        assert!(
+            output
+                .windows(sequence.len())
+                .any(|window| window == sequence),
+            "terminal output omitted restoration sequence {sequence:?}: {}",
+            String::from_utf8_lossy(output)
+        );
+    }
+}
+
+fn read_pty(mut reader: Box<dyn Read + Send>, output: &Mutex<Vec<u8>>) {
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) | Err(_) => return,
+            Ok(read) => output
+                .lock()
+                .expect("PTY output lock")
+                .extend_from_slice(&buffer[..read]),
+        }
+    }
+}
+
+fn owner_is_ready(product: &InstalledProduct, session: &str) -> bool {
+    let directory = product.state.join("runtime/instances");
+    let Ok(entries) = fs::read_dir(directory) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        fs::read(entry.path())
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+            .is_some_and(|metadata| {
+                metadata["session_id"] == session
+                    && metadata["control_protocol"].as_u64()
+                        == Some(u64::from(proqi::ports::control::CONTROL_PROTOCOL_VERSION))
+                    && metadata["control_endpoint"]
+                        .as_str()
+                        .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
+            })
+    })
+}

--- a/tests/package_contract/pty/process/cleanup.rs
+++ b/tests/package_contract/pty/process/cleanup.rs
@@ -1,0 +1,99 @@
+//! Persistent state for one bounded PTY teardown attempt.
+
+use std::time::{Duration, Instant};
+
+use rustix::{
+    io::Errno,
+    process::{Pid, test_kill_process_group},
+};
+
+use super::PtyChild;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CleanupOutcome {
+    pub(super) child: CleanupState,
+    pub(super) group: CleanupState,
+    pub(super) reader: CleanupState,
+}
+
+impl CleanupOutcome {
+    pub(super) fn new(child: &PtyChild) -> Self {
+        Self {
+            child: CleanupState::from_complete(child.child.is_none()),
+            group: CleanupState::from_complete(child.process_group.is_none()),
+            reader: CleanupState::from_complete(child.reader.is_none()),
+        }
+    }
+
+    pub(super) const fn processes_gone(self) -> bool {
+        matches!(self.child, CleanupState::Complete) && matches!(self.group, CleanupState::Complete)
+    }
+
+    pub(super) const fn settled(self) -> bool {
+        self.processes_gone() && !matches!(self.reader, CleanupState::Pending)
+    }
+
+    pub(super) const fn successful(self) -> bool {
+        self.processes_gone() && matches!(self.reader, CleanupState::Complete)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CleanupState {
+    Pending,
+    Complete,
+    Failed,
+}
+
+impl CleanupState {
+    const fn from_complete(complete: bool) -> Self {
+        if complete {
+            Self::Complete
+        } else {
+            Self::Pending
+        }
+    }
+}
+
+pub(super) struct CleanupProgress {
+    pub(super) deadline: TeardownDeadline,
+    pub(super) force_at: TeardownDeadline,
+    pub(super) term_sent: bool,
+    pub(super) kill_sent: bool,
+    pub(super) outcome: CleanupOutcome,
+}
+
+impl CleanupProgress {
+    pub(super) fn next_deadline(&self) -> TeardownDeadline {
+        if self.kill_sent || self.outcome.processes_gone() {
+            self.deadline
+        } else {
+            self.force_at
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct TeardownDeadline(Instant);
+
+impl TeardownDeadline {
+    pub(super) fn after(timeout: Duration) -> Self {
+        Self(Instant::now() + timeout)
+    }
+
+    pub(super) fn capped_after(self, timeout: Duration) -> Self {
+        Self(self.0.min(Instant::now() + timeout))
+    }
+
+    pub(super) fn remaining(self) -> Duration {
+        self.0.saturating_duration_since(Instant::now())
+    }
+
+    pub(super) fn expired(self) -> bool {
+        self.remaining().is_zero()
+    }
+}
+
+pub(super) fn process_group_is_absent(group: Pid) -> bool {
+    matches!(test_kill_process_group(group), Err(Errno::SRCH))
+}

--- a/tests/package_contract/pty/process/tests.rs
+++ b/tests/package_contract/pty/process/tests.rs
@@ -1,0 +1,288 @@
+//! Absolute watchdog coverage for package PTY teardown.
+
+use std::{
+    env, fs,
+    path::Path,
+    process::{Child as ProcessChild, Command, ExitStatus, Stdio},
+    sync::{Arc, Mutex, atomic::Ordering},
+    thread,
+    time::{Duration, Instant},
+};
+
+use portable_pty::CommandBuilder;
+use rustix::process::{
+    Pid, Signal, kill_process, kill_process_group, test_kill_process, test_kill_process_group,
+};
+
+use super::{CleanupState, POLL_INTERVAL, PtyChild, TEARDOWN_TIMEOUT, TERM_GRACE, owner_is_ready};
+use crate::{InstalledProduct, sandbox::PackageSandbox};
+
+const HELPER_ENV: &str = "PROQI_PACKAGE_PTY_DROP_HELPER";
+const TEST_NAME: &str =
+    "pty::process::tests::drop_kills_term_resistant_descendant_before_absolute_deadline";
+const SCENARIOS: [&str; 2] = ["drop", "repeat"];
+const WATCHDOG_TIMEOUT: Duration = Duration::from_secs(12);
+
+#[test]
+fn readiness_requires_atomically_committed_owner_metadata() {
+    let parent = tempfile::tempdir().expect("package parent");
+    let sandbox = Arc::new(PackageSandbox::create(parent.path()).expect("package sandbox"));
+    let product = InstalledProduct {
+        binary: sandbox.root().join("unused-binary"),
+        archive: sandbox.root().join("unused-archive"),
+        state: sandbox.state().to_owned(),
+        working: sandbox.working().to_owned(),
+        sandbox,
+    };
+    let instances = product.state.join("runtime/instances");
+    fs::create_dir_all(&instances).expect("runtime instances");
+    let endpoint = product.state.join("runtime/control.sock");
+    fs::write(&endpoint, []).expect("control endpoint fixture");
+    let session = "ses_06g55re1ttq335mbmbihb1bag4";
+    let metadata = serde_json::json!({
+        "session_id": session,
+        "control_protocol": proqi::ports::control::CONTROL_PROTOCOL_VERSION,
+        "control_endpoint": endpoint,
+    });
+    let temporary = instances.join("ins_06g55re1vtv813nojkfu93pi9s.json.tmp");
+    let committed = instances.join("ins_06g55re1vtv813nojkfu93pi9s.json");
+    fs::write(
+        &temporary,
+        serde_json::to_vec(&metadata).expect("owner metadata"),
+    )
+    .expect("temporary owner metadata");
+    assert!(
+        !owner_is_ready(&product, session),
+        "uncommitted owner metadata was treated as ready"
+    );
+    fs::rename(temporary, committed).expect("commit owner metadata");
+    assert!(owner_is_ready(&product, session));
+}
+
+#[test]
+fn reader_failure_remains_bounded_and_idempotent() {
+    let reader = thread::Builder::new()
+        .name("failing-package-pty-output".to_owned())
+        .spawn(|| panic!("synthetic PTY reader failure"))
+        .expect("spawn failing PTY reader");
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !reader.is_finished() && Instant::now() < deadline {
+        thread::sleep(POLL_INTERVAL);
+    }
+    assert!(reader.is_finished(), "failing PTY reader did not finish");
+    let mut owner = PtyChild {
+        child: None,
+        process_group: None,
+        input: None,
+        output: Arc::new(Mutex::new(Vec::new())),
+        reader: Some(reader),
+        exit_status: None,
+        cleanup: None,
+        drop_success: None,
+    };
+    let first = owner.terminate();
+    assert_eq!(first.reader, CleanupState::Failed);
+    assert!(!first.successful());
+    let repeated = Instant::now();
+    let second = owner.terminate();
+    assert_eq!(second, first, "reader failure became false cleanup success");
+    assert!(repeated.elapsed() < Duration::from_millis(100));
+}
+
+#[test]
+fn drop_kills_term_resistant_descendant_before_absolute_deadline() {
+    if env::var_os(HELPER_ENV).is_some() {
+        run_drop_helper();
+        return;
+    }
+    let state = tempfile::tempdir().expect("PTY watchdog state");
+    let stdout = state.path().join("helper.stdout");
+    let stderr = state.path().join("helper.stderr");
+    let started = Instant::now();
+    let mut helper = Command::new(env::current_exe().expect("package contract test binary"));
+    helper
+        .args(["--exact", TEST_NAME, "--nocapture"])
+        .env(HELPER_ENV, "1")
+        .env("PROQI_PTY_WATCHDOG_STATE", state.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(
+            fs::File::create(&stdout).expect("create helper stdout"),
+        ))
+        .stderr(Stdio::from(
+            fs::File::create(&stderr).expect("create helper stderr"),
+        ));
+    let mut helper = helper.spawn().expect("spawn PTY teardown watchdog helper");
+    let deadline = Instant::now() + WATCHDOG_TIMEOUT;
+    let Some(status) = status_before(&mut helper, deadline) else {
+        cleanup_registered(state.path());
+        let _ = helper.kill();
+        assert!(
+            status_before(&mut helper, Instant::now() + Duration::from_secs(1)).is_some(),
+            "watchdog helper resisted SIGKILL"
+        );
+        assert_existing_registered_gone(state.path());
+        panic!("PTY teardown exceeded its {WATCHDOG_TIMEOUT:?} absolute watchdog");
+    };
+    if !status.success() {
+        let output = format!(
+            "{}{}",
+            fs::read_to_string(stdout).unwrap_or_default(),
+            fs::read_to_string(stderr).unwrap_or_default()
+        );
+        cleanup_registered(state.path());
+        assert_existing_registered_gone(state.path());
+        panic!("PTY teardown helper exited {status}: {output}");
+    }
+    assert!(started.elapsed() < WATCHDOG_TIMEOUT);
+    assert_all_registered_gone(state.path());
+}
+
+fn run_drop_helper() {
+    let state = env::var_os("PROQI_PTY_WATCHDOG_STATE").expect("watchdog state");
+    let state = Path::new(&state);
+    let descendant_script = state.join("descendant.sh");
+    fs::write(
+        &descendant_script,
+        r#"#!/bin/sh
+trap '' HUP
+trap '' TERM
+printf '%s\n' "$$" > "$PROQI_DESCENDANT_PID"
+while :; do /bin/sleep 1; done
+"#,
+    )
+    .expect("write resistant PTY descendant");
+    run_cleanup_scenario(state, &descendant_script, "drop", false);
+    run_cleanup_scenario(state, &descendant_script, "repeat", true);
+}
+
+fn run_cleanup_scenario(state: &Path, script: &Path, name: &str, repeat: bool) {
+    let descendant = state.join(format!("{name}-descendant.pid"));
+    let group = state.join(format!("{name}-group.pid"));
+    let mut command = CommandBuilder::new("/bin/sh");
+    command.env_clear();
+    command.args([
+        "-c",
+        r#"trap '' HUP
+trap '' TERM
+/bin/sh "$PROQI_DESCENDANT_SCRIPT" &
+while test ! -s "$PROQI_DESCENDANT_PID"; do /bin/sleep 0.01; done
+while :; do /bin/sleep 1; done"#,
+    ]);
+    command.env("PROQI_DESCENDANT_PID", &descendant);
+    command.env("PROQI_DESCENDANT_SCRIPT", script);
+    let mut owner = PtyChild::spawn_command(command);
+    fs::write(&group, owner.process_id().to_string()).expect("record PTY process group");
+    wait_for_file(&descendant, Instant::now() + Duration::from_secs(1));
+    let drop_success = owner.observe_drop_success();
+    let started = Instant::now();
+    if repeat {
+        let first = owner.terminate();
+        assert!(first.successful(), "explicit PTY cleanup failed: {first:?}");
+        let repeated = Instant::now();
+        let second = owner.terminate();
+        assert_eq!(second, first, "repeated cleanup changed its outcome");
+        assert!(
+            repeated.elapsed() < Duration::from_millis(100),
+            "repeated cleanup did not reuse its completed outcome"
+        );
+    }
+    drop(owner);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < TEARDOWN_TIMEOUT + Duration::from_millis(500),
+        "PTY Drop exceeded its teardown deadline"
+    );
+    assert!(
+        elapsed >= TERM_GRACE.saturating_sub(Duration::from_millis(25)),
+        "PTY descendant did not retain the slave through the TERM grace period"
+    );
+    assert!(
+        drop_success.load(Ordering::Acquire),
+        "Drop returned without reaping the child and joining the PTY reader"
+    );
+    let group = read_pid(&group).expect("registered PTY group");
+    let descendant = read_pid(&descendant).expect("registered PTY descendant");
+    assert_pids_gone(Some(group), Some(descendant));
+}
+
+fn status_before(child: &mut ProcessChild, deadline: Instant) -> Option<ExitStatus> {
+    loop {
+        match child.try_wait().expect("poll watchdog helper") {
+            Some(status) => return Some(status),
+            None if Instant::now() < deadline => thread::sleep(POLL_INTERVAL),
+            None => return None,
+        }
+    }
+}
+
+fn wait_for_file(path: &Path, deadline: Instant) {
+    while !path.exists() && Instant::now() < deadline {
+        thread::sleep(POLL_INTERVAL);
+    }
+    assert!(path.exists(), "PTY descendant did not register");
+}
+
+fn cleanup_registered(state: &Path) {
+    for name in SCENARIOS {
+        if let Some(group) = read_pid(&state.join(format!("{name}-group.pid"))) {
+            let _ = kill_process_group(group, Signal::KILL);
+        }
+        if let Some(descendant) = read_pid(&state.join(format!("{name}-descendant.pid"))) {
+            let _ = kill_process(descendant, Signal::KILL);
+        }
+    }
+}
+
+fn assert_all_registered_gone(state: &Path) {
+    for name in SCENARIOS {
+        let group =
+            read_pid(&state.join(format!("{name}-group.pid"))).expect("registered PTY group");
+        let descendant = read_pid(&state.join(format!("{name}-descendant.pid")))
+            .expect("registered PTY descendant");
+        assert_pids_gone(Some(group), Some(descendant));
+    }
+}
+
+fn assert_existing_registered_gone(state: &Path) {
+    for name in SCENARIOS {
+        assert_pids_gone(
+            read_pid(&state.join(format!("{name}-group.pid"))),
+            read_pid(&state.join(format!("{name}-descendant.pid"))),
+        );
+    }
+}
+
+fn assert_pids_gone(group: Option<Pid>, descendant: Option<Pid>) {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while (group.is_some_and(|group| !process_group_is_absent(group))
+        || descendant.is_some_and(|descendant| !process_is_absent(descendant)))
+        && Instant::now() < deadline
+    {
+        thread::sleep(POLL_INTERVAL);
+    }
+    assert!(
+        group.is_none_or(process_group_is_absent),
+        "PTY process group survived bounded teardown"
+    );
+    assert!(
+        descendant.is_none_or(process_is_absent),
+        "PTY descendant survived bounded teardown"
+    );
+}
+
+fn process_group_is_absent(group: Pid) -> bool {
+    matches!(test_kill_process_group(group), Err(rustix::io::Errno::SRCH))
+}
+
+fn process_is_absent(process: Pid) -> bool {
+    matches!(test_kill_process(process), Err(rustix::io::Errno::SRCH))
+}
+
+fn read_pid(path: &Path) -> Option<Pid> {
+    fs::read_to_string(path)
+        .ok()?
+        .trim()
+        .parse::<i32>()
+        .ok()
+        .and_then(Pid::from_raw)
+}

--- a/tests/package_contract/sandbox.rs
+++ b/tests/package_contract/sandbox.rs
@@ -1,0 +1,162 @@
+//! Run-owned filesystem isolation for installed-product verification.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// One package-contract invocation's state and working directories.
+pub(super) struct PackageSandbox {
+    root: tempfile::TempDir,
+    state: PathBuf,
+    working: PathBuf,
+}
+
+impl PackageSandbox {
+    pub(super) fn create(parent: &Path) -> io::Result<Self> {
+        fs::create_dir_all(parent)?;
+        let root = tempfile::Builder::new()
+            .prefix("contract-run-")
+            .tempdir_in(parent)?;
+        let state = root.path().join("state");
+        let working = root.path().join("working");
+        for directory in ["config", "data", "cache", "runtime"] {
+            fs::create_dir_all(state.join(directory))?;
+        }
+        fs::create_dir(&working)?;
+        fs::write(
+            state.join("config/config.toml"),
+            b"check_for_updates = false\n",
+        )?;
+        Ok(Self {
+            root,
+            state,
+            working,
+        })
+    }
+
+    pub(super) fn root(&self) -> &Path {
+        self.root.path()
+    }
+
+    pub(super) fn state(&self) -> &Path {
+        &self.state
+    }
+
+    pub(super) fn working(&self) -> &Path {
+        &self.working
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        fs,
+        path::{Path, PathBuf},
+        sync::Arc,
+        thread,
+    };
+
+    use proqi::{
+        adapters::{memory::FakeIdGenerator, runtime::FileRuntimeCoordinator},
+        domain::Timestamp,
+        ports::{environment::IdGenerator as _, runtime::RuntimeCoordinator as _},
+    };
+
+    use super::PackageSandbox;
+
+    #[test]
+    fn concurrent_and_repeated_runs_never_reuse_foreign_runtime_state() {
+        let temporary = tempfile::tempdir().expect("package parent");
+        let parent = temporary.path().join("shared-package-parent");
+        let foreign_runtime = parent.join("runtime");
+        let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+        let foreign = FileRuntimeCoordinator::new(
+            foreign_runtime.clone(),
+            ids.instance_id(),
+            temporary.path().to_owned(),
+            Timestamp::from_millis(1),
+            "foreign-version",
+        )
+        .expect("foreign coordinator");
+        let foreign_session = ids.session_id();
+        let foreign_lease = foreign
+            .acquire_session(foreign_session)
+            .expect("foreign live owner");
+        assert_eq!(foreign_lease.info().control_protocol, None);
+        let stale_coordinator = FileRuntimeCoordinator::new(
+            foreign_runtime.clone(),
+            ids.instance_id(),
+            temporary.path().to_owned(),
+            Timestamp::from_millis(2),
+            "stale-version",
+        )
+        .expect("stale coordinator");
+        let stale_lease = stale_coordinator
+            .acquire_session(ids.session_id())
+            .expect("stale owner fixture");
+        let stale_info = stale_lease.info().clone();
+        drop(stale_lease);
+        fs::write(
+            foreign_runtime
+                .join("instances")
+                .join(format!("{}.json", stale_info.instance_id)),
+            serde_json::to_vec(&stale_info).expect("serialize stale metadata"),
+        )
+        .expect("write stale metadata");
+
+        let parent = Arc::new(parent);
+        assert_parallel_sandboxes(&parent, &foreign_runtime);
+        assert_repeated_sandbox_cleanup(&parent);
+        let scan = foreign.scan_runtime().expect("scan foreign owners");
+        assert_eq!(scan.active.len(), 1);
+        assert_eq!(scan.recovered, vec![stale_info.session_id]);
+        drop(foreign_lease);
+        assert!(
+            foreign
+                .active_instances()
+                .expect("foreign cleanup")
+                .is_empty()
+        );
+    }
+
+    fn assert_parallel_sandboxes(parent: &Arc<PathBuf>, foreign_runtime: &Path) {
+        let handles = (0..16)
+            .map(|_| {
+                let parent = Arc::clone(parent);
+                thread::spawn(move || PackageSandbox::create(&parent).expect("concurrent sandbox"))
+            })
+            .collect::<Vec<_>>();
+        let sandboxes = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("sandbox thread"))
+            .collect::<Vec<_>>();
+        let roots = sandboxes
+            .iter()
+            .map(|sandbox| sandbox.root().to_owned())
+            .collect::<HashSet<_>>();
+        assert_eq!(roots.len(), sandboxes.len());
+        for sandbox in &sandboxes {
+            assert_ne!(sandbox.state().join("runtime"), foreign_runtime);
+            assert!(
+                sandbox
+                    .state()
+                    .join("runtime/instances")
+                    .read_dir()
+                    .is_err()
+            );
+        }
+        drop(sandboxes);
+        assert!(roots.iter().all(|root| !root.exists()));
+    }
+
+    fn assert_repeated_sandbox_cleanup(parent: &Path) {
+        for _ in 0..16 {
+            let sandbox = PackageSandbox::create(parent).expect("repeated sandbox");
+            let root = sandbox.root().to_owned();
+            drop(sandbox);
+            assert!(!root.exists());
+        }
+    }
+}

--- a/xtask/src/package.rs
+++ b/xtask/src/package.rs
@@ -38,7 +38,6 @@ pub(super) fn run(root: &Path, notices: Option<&Path>) -> Result<(), String> {
     if host == super::release_targets::LINUX_X86_64 {
         super::linux_compat::verify_archive(root, &archive)?;
     }
-    prepare_isolated_state(temporary.path())?;
     run_installed_contract(root, temporary.path(), &installed, &archive)?;
     persist_archive(root, &archive)
 }
@@ -185,24 +184,6 @@ fn validate_member_path(path: &Path) -> Result<(), String> {
         .ok_or_else(|| format!("archive contains unsafe member path: {}", path.display()))
 }
 
-fn prepare_isolated_state(temporary: &Path) -> Result<(), String> {
-    for path in [
-        temporary.join("state/config"),
-        temporary.join("state/data"),
-        temporary.join("state/cache"),
-        temporary.join("state/runtime"),
-        temporary.join("working"),
-    ] {
-        fs::create_dir_all(&path)
-            .map_err(|error| format!("create isolated {}: {error}", path.display()))?;
-    }
-    fs::write(
-        temporary.join("state/config/config.toml"),
-        b"check_for_updates = false\n",
-    )
-    .map_err(|error| format!("disable package-smoke update check: {error}"))
-}
-
 fn run_installed_contract(
     root: &Path,
     temporary: &Path,
@@ -223,8 +204,7 @@ fn run_installed_contract(
         ])
         .env("PROQI_PACKAGE_BINARY", installed)
         .env("PROQI_PACKAGE_ARCHIVE", archive)
-        .env("PROQI_PACKAGE_STATE", temporary.join("state"))
-        .env("PROQI_PACKAGE_WORKING", temporary.join("working"))
+        .env("PROQI_PACKAGE_ROOT", temporary.join("contract-runs"))
         .env("PROQI_DISABLE_HERDR", "1")
         .current_dir(root)
         .status()


### PR DESCRIPTION
## Summary

- Give every installed-product contract invocation a unique run-owned state and working root beneath the package orchestrator temporary directory.
- Clear ambient environment variables from installed commands and PTY owners while restoring only the explicit offline test environment.
- Make package PTY ownership panic-safe, deadline-bounded, process-group aware, and idempotent across normal completion, timeout, reader failure, and unwinding.
- Require atomically committed owner metadata before the package harness treats a control endpoint as ready.
- Add collision, readiness, teardown, reader-failure, and cleanup regressions without changing production lease or control-protocol validation.

## Cause

The production `session_busy` response was correct fail-closed behavior for live owner metadata without a control protocol. The package contract did not own its isolation boundary: it consumed caller-provided state and working directories directly, and its PTY wrapper had no panic-safe cleanup. A reused or overlapping harness root could therefore expose a foreign active owner, and an early failure could leave a test-owned process holding that lease.

Repeated package stress also exposed a second harness race. The readiness probe accepted a fully written `*.json.tmp` owner file before the production runtime atomically renamed it to `*.json`. The test could then proceed while the production owner scanner still correctly ignored that uncommitted metadata, producing `session_busy` or `unsupported_update_control`. The fix makes the test observe the same committed metadata boundary as production.

The review correction closes an independent cleanup flaw in the first fix. The PTY reader join and child wait were unbounded. The revised guard owns the Unix PTY process group immediately after spawn, observes direct-child exit without reaping through `waitid(..., WNOWAIT)`, sends the final group signal while the leader still pins the PGID, polls one absolute deadline, reaps with `try_wait`, and joins the reader only after `JoinHandle::is_finished()`. Pending or failed state remains owned and stable across repeated cleanup calls.

## Acceptance criteria

- Deterministically models the prior collision with live missing-protocol metadata and valid stale metadata in a shared foreign parent.
- Proves concurrent and repeated runs allocate distinct child roots and remove them.
- Preserves the real production lease and protocol contract unchanged.
- Rejects uncommitted temporary owner metadata and accepts the identical metadata after atomic rename.
- Proves a TERM-resistant PTY leader and descendant retaining the slave are force-terminated within an absolute deadline.
- Proves Drop reaps the direct child, removes the process group and descendant, drains and joins the reader, and leaves no orphan.
- Proves repeated cleanup is immediate and outcome-idempotent, including a failed reader join that cannot become false success.
- Verifies the package root is gone after the full installed-product contract.

## Verification

- `cargo test --locked --test package_contract pty::process::tests -- --nocapture`: passed, 3 of 3 in 4.08 seconds.
- `cargo clippy --locked --test package_contract --all-features -- -D warnings`: passed.
- `cargo xtask source-limits`: passed. Every touched Rust file remains below 500 lines.
- `cargo xtask package`: passed five consecutive final runs. Installed-product execution completed in 2.28 to 2.39 seconds per run.
- `cargo xtask audit`: passed. Existing duplicate dependency warnings remain informational.
- Final `cargo xtask check`: formatting, diff checks, source limits, snapshots, assets, architecture, Clippy, documentation, and 816 of 817 tests passed. The sole remaining process was the separately scoped macOS Screenshot Inbox SIGTERM hang addressed by PR #28. It was interrupted after 60 seconds, and its exact three processes and temporary runtime were removed.
- GitHub Actions run 33317208853: all required checks passed. `Package contract (ubuntu-22.04)` passed in 4 minutes 55 seconds, `Debian package contract` passed in 1 minute 51 seconds, and `Minimum supported Rust` passed in 7 minutes 58 seconds.

## Live stress matrix

| Case | Observed result |
| --- | --- |
| Foreign live owner with `control_protocol: null` plus valid stale metadata | 16 concurrent contract sandboxes stayed independent; the foreign owner remained active and stale metadata recovered only in its own runtime |
| Reused package parent | 16 sequential sandboxes received fresh roots and each root disappeared on drop |
| Full installed contract sharing one parent | 8 concurrent runs passed |
| Repeated full installed contract | 20 sequential runs passed before the review correction; five consecutive final package runs passed after it |
| Fully written `*.json.tmp` owner metadata | Readiness remained false until the file was atomically renamed to `*.json` |
| TERM-resistant leader and descendant retaining the PTY slave | Eight concurrent final regressions passed in 4.08 to 4.20 seconds each; each covered Drop plus repeated explicit cleanup |
| Reader thread panic | First cleanup reported reader failure; repeated cleanup returned the identical failure in under 100 milliseconds |
| Cleanup after early owner drop | Process was gone, resume succeeded, and instance metadata was empty |
| Existing Unicode and control-heavy package input | Tabs, CRLF, combining characters, CJK text, and preserved whitespace round-tripped |
| Final artifact cleanup | No process from this worktree, teardown helper, package runtime directory, database, container, or disposable pane remained |

## Design decisions

- Production lease acquisition, liveness checks, control-protocol negotiation, and fail-closed `session_busy` behavior are unchanged.
- The package harness filters readiness to committed `.json` entries, matching the production runtime scanner.
- The guard retains one persistent TERM, KILL, child, group, and reader outcome under one monotonic deadline. A repeated call does not reset the deadline, resend signals, detach a pending reader, discard an unreaped child, or overwrite failure with success.
- `waitid` with `EXITED | NOHANG | NOWAIT` lets completion paths observe exit while retaining the leader as a PGID reuse barrier. The final group KILL is sent before `try_wait` reaps it.
- PTY output is capped at 64 KiB. Output inspection uses a nonblocking mutex attempt, so diagnostics cannot extend teardown.
- PR #28 remains separate. It changes production Screenshot Inbox shutdown, while this pull request changes private package-contract isolation and teardown.

## Risks

The environment key between `xtask` and its private ignored integration test changes from state and working paths to one package root. This is not a public product interface. Environment clearing is intentional; the test restores only its Herdr disable switch, offline proxy settings, and PTY `TERM` value.

The teardown guard relies on the Unix behavior already established by `portable-pty`: the spawned child calls `setsid`, becomes the PTY session and process-group leader, and is reported by `process_group_leader()`. The regression exercises this on macOS, while pull request CI exercises Linux.

## Limitations

The final local canonical run cannot complete while the separate macOS Screenshot Inbox SIGTERM hang remains on this branch. PR #28 owns that production fix. This pull request neither suppresses that test nor imports the unrelated change.

## Follow-ups

Land PR #28 independently, then update this branch from `main` if its fix is required for a completely green local macOS canonical run.
