### PR TITLE
Fix bounded macOS PTY shutdown during screenshot persistence failure

### DIFF
--- a/src/adapters/terminal/runner.rs
+++ b/src/adapters/terminal/runner.rs
@@ -14,6 +14,7 @@ mod owner_control;
 mod pending;
 mod restart;
 mod screenshot_results;
+mod termination;
 mod update_results;
 
 use std::{
@@ -60,6 +61,7 @@ use finish::CleanupStage::{Control, TerminalRestoration};
 use heartbeat::PaneHeartbeat;
 use owned_lanes::OwnedLanes;
 use pending::{PendingControl, PendingWork};
+use termination::{TerminationAdmission, admit_requested};
 
 pub(crate) struct TerminalResources {
     pub(crate) state: AppState,
@@ -259,27 +261,23 @@ fn drive(
     let mut edit_deadline = None;
     let mut agent_deadline = None;
     let mut invocation_deadline = None;
-    let mut termination_seen = false;
+    let mut termination = TerminationAdmission::default();
     let mut held_input = None;
     enqueue_effects(app, lanes, BoardApp::discover_agents(), &mut pending)?;
     let invocation_effects = app.refresh_invocations();
     enqueue_effects(app, lanes, invocation_effects, &mut pending)?;
     let mut redraw = true;
     loop {
-        if lanes.termination.requested() && !termination_seen {
-            termination_seen = true;
-            let _deadline = shutdown.request();
-            lanes.cancellation.cancel();
-            if let Some(control) = lanes.control {
-                control.request_stop();
-            }
-            let mut effects = app.handle(UiInput::Key(UiKey::Quit), ids, &clock);
-            if !app.quit && app.screenshot_retry_ready() {
-                effects.extend(app.handle(UiInput::Key(UiKey::Quit), ids, &clock));
-            }
-            enqueue_effects(app, lanes, effects, &mut pending)?;
-        }
-        if !termination_seen {
+        admit_requested(
+            &mut termination,
+            app,
+            lanes,
+            ids,
+            clock,
+            shutdown,
+            &mut pending,
+        )?;
+        if !termination.is_admitted() {
             let effects = app.advance_screenshot_activity(lanes.monotonic.now());
             enqueue_effects(app, lanes, effects, &mut pending)?;
         }
@@ -293,17 +291,25 @@ fn drive(
             pane_heartbeat,
         )?;
         redraw |= workers_changed || app.expire_update_barrier(clock.now());
-        if app.quit && app.screenshot_retry_ready() && !termination_seen {
+        if app.quit && app.screenshot_retry_ready() && !termination.is_admitted() {
             app.retain_failed_capture_after_quit();
             redraw = true;
         }
-        if termination_seen && !app.quit && app.screenshot_retry_ready() {
+        if termination.is_admitted() && app.screenshot_retry_ready() {
             let mut effects = app.handle(UiInput::Key(UiKey::Quit), ids, &clock);
             if !app.quit && app.screenshot_retry_ready() {
                 effects.extend(app.handle(UiInput::Key(UiKey::Quit), ids, &clock));
             }
             enqueue_effects(app, lanes, effects, &mut pending)?;
             redraw = true;
+        }
+        if termination.is_admitted() && !app.screenshot_commit_pending() {
+            let effects = app.flush_pending_edit(ids, &clock);
+            if !effects.is_empty() {
+                enqueue_effects(app, lanes, effects, &mut pending)?;
+                edit_deadline = None;
+                redraw = true;
+            }
         }
         let release_effects = screenshot_results::release_if_drained(app, &mut capture);
         if !release_effects.is_empty() {
@@ -373,7 +379,7 @@ fn drive(
                 held_input = Some((sequence, event));
             }
         }
-        if app.quit {
+        if termination.shutdown_requested(app.quit) {
             let deadline = shutdown.request();
             if !capture.shutdown_requested && capture.lease.is_some() {
                 lanes.screenshot.shutdown(deadline)?;
@@ -392,7 +398,7 @@ fn drive(
                 && (!capture.shutdown_requested || capture.watcher_stopped)
                 && app.screenshot_shutdown_drained();
             if pending.is_empty() && control_quiescent && screenshot_quiescent {
-                return Ok(());
+                return termination.outcome(&app.state.durability);
             }
             if deadline.expired() {
                 return Err(TerminalError::Worker(

--- a/src/adapters/terminal/runner/termination.rs
+++ b/src/adapters/terminal/runner/termination.rs
@@ -1,0 +1,96 @@
+//! Monotonic admission for supported process-termination signals.
+
+use crate::{
+    adapters::{
+        runtime::{SystemClock, SystemIdGenerator},
+        terminal::{TerminalError, supervisor::ShutdownCoordinator},
+    },
+    application::DurabilityState,
+    ui::{BoardApp, UiInput, UiKey},
+};
+
+use super::{PendingWork, WorkerLanes, durability::enqueue_effects};
+
+#[derive(Default)]
+pub(super) struct TerminationAdmission {
+    admitted: bool,
+}
+
+impl TerminationAdmission {
+    pub(super) fn admit(&mut self) -> bool {
+        if self.admitted {
+            return false;
+        }
+        self.admitted = true;
+        true
+    }
+
+    pub(super) const fn is_admitted(&self) -> bool {
+        self.admitted
+    }
+
+    pub(super) const fn shutdown_requested(&self, ui_quit: bool) -> bool {
+        self.admitted || ui_quit
+    }
+
+    pub(super) fn outcome(&self, durability: &DurabilityState) -> Result<(), TerminalError> {
+        if self.admitted && matches!(durability, DurabilityState::Failed { .. }) {
+            return Err(TerminalError::Worker(
+                "termination completed with non-durable work",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn admit_requested(
+    admission: &mut TerminationAdmission,
+    app: &mut BoardApp,
+    lanes: &WorkerLanes<'_>,
+    ids: &mut SystemIdGenerator,
+    clock: SystemClock,
+    shutdown: &ShutdownCoordinator,
+    pending: &mut PendingWork,
+) -> Result<(), TerminalError> {
+    if !lanes.termination.requested() || !admission.admit() {
+        return Ok(());
+    }
+    let _deadline = shutdown.request();
+    lanes.cancellation.cancel();
+    if let Some(control) = lanes.control {
+        control.request_stop();
+    }
+    let mut effects = app.handle(UiInput::Key(UiKey::Quit), ids, &clock);
+    if !app.quit && app.screenshot_retry_ready() {
+        effects.extend(app.handle(UiInput::Key(UiKey::Quit), ids, &clock));
+    }
+    enqueue_effects(app, lanes, effects, pending)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        application::{DurabilityState, FailureCode},
+        domain::OperationSequence,
+    };
+
+    use super::TerminationAdmission;
+
+    #[test]
+    fn termination_admission_is_monotonic_when_ui_quit_is_revoked() {
+        let mut admission = TerminationAdmission::default();
+        assert!(!admission.shutdown_requested(false));
+        assert!(admission.admit());
+        assert!(!admission.admit());
+        assert!(admission.shutdown_requested(false));
+        assert!(
+            admission
+                .outcome(&DurabilityState::Failed {
+                    durable: OperationSequence::default(),
+                    failed: OperationSequence::new(1),
+                    code: FailureCode::StorageFailed,
+                })
+                .is_err()
+        );
+    }
+}

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -36,7 +36,7 @@ fn bracketed_paste_autosaves_and_resumes_in_a_real_pty() {
         set binary $env(PROQI_TEST_BINARY)
         set state $env(PROQI_TEST_STATE)
         spawn $binary --state-dir $state
-        after 500
+        expect -exact "\x1b\[?1049h"
         send -- "\x1b\[200~Grüße 界\nsecond\x1b\[201~"
         after 700
         send "\x1b"
@@ -74,7 +74,7 @@ fn bracketed_paste_autosaves_and_resumes_in_a_real_pty() {
         set state $env(PROQI_TEST_STATE)
         set session $env(PROQI_TEST_SESSION)
         spawn $binary --state-dir $state -r $session
-        after 500
+        expect -exact "\x1b\[?1049h"
         send "\r"
         after 100
         send "!"
@@ -159,7 +159,7 @@ fn assert_persistent_editor_undo(
         set state $env(PROQI_TEST_STATE)
         set session $env(PROQI_TEST_SESSION)
         spawn $binary --state-dir $state -r $session
-        after 500
+        expect -exact "\x1b\[?1049h"
         send "\r"
         after 100
         send "\x1a"
@@ -311,11 +311,11 @@ fn session_browser_searches_and_resumes_in_a_real_pty() {
         set state $env(PROQI_TEST_STATE)
         spawn $binary --state-dir $state -r
         stty rows 24 columns 100
-        after 500
+        expect -exact "\x1b\[?1049h"
         send -- "Needle"
-        after 200
+        expect -re "Needle"
         send "\r"
-        after 500
+        expect -exact "\x1b\[?1049l"; expect -exact "\x1b\[?1049h"
         send -- "\x11"
         expect {
             eof {}
@@ -365,6 +365,10 @@ mod fairness;
 #[cfg(target_os = "macos")]
 #[path = "pty/shutdown.rs"]
 mod shutdown;
+
+#[cfg(target_os = "macos")]
+#[path = "pty/watchdog.rs"]
+mod watchdog;
 
 #[cfg(target_os = "macos")]
 #[path = "pty/update_control.rs"]

--- a/tests/pty/active_control.rs
+++ b/tests/pty/active_control.rs
@@ -194,6 +194,11 @@ fn spawn_owner(
         set deadline [expr {[clock milliseconds] + 12000}]
         while {![file exists $env(PROQI_TEST_DONE)]} {
             if {[clock milliseconds] >= $deadline} { exit 91 }
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 92 }
+            }
             after 20
         }
         system /bin/kill -KILL [exp_pid]

--- a/tests/pty/fairness.rs
+++ b/tests/pty/fairness.rs
@@ -160,17 +160,31 @@ fn assert_owner_success(
 fn spawn_owner(fixture: OwnerFixture<'_>, exit: ExitScenario) -> std::process::Child {
     let script = r#"
         log_user 0
-        log_file -noappend $env(PROQI_TEST_TRANSCRIPT)
+        log_file -a $env(PROQI_TEST_TRANSCRIPT)
         set timeout 15
         spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE) -r $env(PROQI_TEST_SESSION)
         expect -exact "\x1b\[?1049h"
         close [open $env(PROQI_TEST_READY) w]
-        while {![file exists $env(PROQI_TEST_START)]} { after 10 }
+        while {![file exists $env(PROQI_TEST_START)]} {
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 92 }
+            }
+            after 10
+        }
         send -- "nlocal input survives"
         stty rows 6 columns 24
         stty rows 28 columns 100
         send -- "\x1b"
-        while {![file exists $env(PROQI_TEST_DONE)]} { after 10 }
+        while {![file exists $env(PROQI_TEST_DONE)]} {
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 93 }
+            }
+            after 10
+        }
         if {$env(PROQI_TEST_EXIT) eq "terminate"} {
             system /bin/kill -TERM [exp_pid]
         } else {

--- a/tests/pty/path_drop.rs
+++ b/tests/pty/path_drop.rs
@@ -19,7 +19,7 @@ fn escaped_unicode_file_drop_becomes_one_durable_absolute_path() {
         set state $env(PROQI_TEST_STATE)
         set dropped $env(PROQI_TEST_DROP)
         spawn $binary --state-dir $state
-        after 500
+        expect -exact "\x1b\[?1049h"
         send -- "\x1b\[200~$dropped\x1b\[201~"
         after 700
         send "\x1b"

--- a/tests/pty/recovery.rs
+++ b/tests/pty/recovery.rs
@@ -28,11 +28,19 @@ fn exported_save_failure_accepts_the_raw_board_quit_key() {
         set state $env(PROQI_TEST_STATE)
         set session $env(PROQI_TEST_SESSION)
         spawn $binary --state-dir $state -r $session
-        while {![file exists "$state/immutable-ready"]} { after 25 }
+        while {![file exists "$state/immutable-ready"]} {
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 123 }
+            }
+            after 25
+        }
         send -- "\x1b\[200~recovery-quit-sentinel\x1b\[201~"
-        after 1400
+        expect -re "storage I/O failed"
         send "w"
-        after 700
+        expect -re "exporting recovery file"
+        expect -re "recovery exported"
         send "q"
         expect {
             eof {}
@@ -122,7 +130,7 @@ fn create_empty_session(binary: &str, state: &std::path::Path) {
         log_user 0
         set timeout 10
         spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE)
-        after 700
+        expect -exact "\x1b\[?1049h"
         send "q"
         expect eof
         catch wait result

--- a/tests/pty/shutdown.rs
+++ b/tests/pty/shutdown.rs
@@ -1,8 +1,8 @@
 //! Terminal shutdown, restoration, and accepted-work durability.
 
-use std::{fs, os::unix::fs::PermissionsExt as _, path::Path};
+use std::{fs, os::unix::fs::PermissionsExt as _, path::Path, time::Duration};
 
-use super::{expect_command, json_command};
+use super::{expect_command, json_command, watchdog};
 
 #[test]
 fn termination_signal_restores_and_releases_the_session() {
@@ -147,7 +147,9 @@ fn acknowledged_paste_survives_forced_process_termination() {
         set timeout 10
         spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE)
         set child [exp_pid]
-        after 500
+        expect -exact "\x1b\[?1049h"
+        expect -exact "\x1b\[1 q"
+        after 100
         send -- "\x1b\[200~committed before crash 界\x1b\[201~"
         after 800
         system /bin/kill -KILL $child
@@ -211,11 +213,21 @@ fn delayed_capture_shutdown(
     let staged = staging.path().join("delayed.png");
     fs::write(&staged, png_bytes()).expect("staged screenshot");
     let target = watched.path().join("delayed.png");
+    let watchdog_pids = state.path().join("watchdog-pids");
     let binary = env!("CARGO_BIN_EXE_proqi");
-    let exit_action = if terminate {
-        "system /bin/kill -TERM $child"
+    let exit_action = capture_exit_action(terminate);
+    let capture_barrier = if persistent_failure {
+        r#"
+        after 2000
+        send -- ":"
+        after 100
+        send -- "Retry Screenshot Capture"
+        send -- "\r"
+        after 100
+        "#
+        .to_owned()
     } else {
-        "send -- \"\\x11\""
+        format!("after {delivery_wait_ms}")
     };
     let finish_action = if persistent_failure {
         r#"
@@ -224,9 +236,11 @@ fn delayed_capture_shutdown(
         expect eof
         catch wait result
         set proqi_status [lindex $result 3]
+        set shutdown_elapsed [expr {[clock milliseconds] - $shutdown_started}]
         set spawn_id $sqlite
         send -- "ROLLBACK;\r.quit\r"
         expect eof
+        if {$shutdown_elapsed > 2300} { exit 96 }
         exit $proqi_status
         "#
     } else {
@@ -239,26 +253,70 @@ fn delayed_capture_shutdown(
         expect -exact "\x1b\[0 q"
         expect eof
         catch wait result
+        set shutdown_elapsed [expr {[clock milliseconds] - $shutdown_started}]
+        if {$shutdown_elapsed > 2300} { exit 96 }
         exit [lindex $result 3]
         "#
     };
-    let workflow = format!(
+    let workflow = capture_shutdown_workflow(&capture_barrier, exit_action, finish_action);
+    let mut command = expect_command();
+    command
+        .args(["-c", &workflow])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state.path())
+        .env(
+            "PROQI_TEST_DATABASE",
+            state.path().join("data/proqi.sqlite3"),
+        )
+        .env("PROQI_TEST_STAGED", &staged)
+        .env("PROQI_TEST_TARGET", &target);
+    let status = watchdog::status_before(
+        &mut command,
+        Duration::from_secs(12),
+        &watchdog_pids,
+        "delayed capture shutdown PTY workflow",
+    );
+    assert_capture_shutdown_result(status, state.path(), binary, &target, persistent_failure);
+}
+
+fn capture_exit_action(terminate: bool) -> &'static str {
+    if terminate {
+        r"
+        system /bin/kill -TERM $child
+        system /bin/kill -TERM $child
+        system /bin/kill -TERM $child
+        "
+    } else {
+        "send -- \"\\x11\""
+    }
+}
+
+fn capture_shutdown_workflow(
+    capture_barrier: &str,
+    exit_action: &str,
+    finish_action: &str,
+) -> String {
+    format!(
         r#"
-        log_user 0
+        log_user 1
         set timeout 15
+        proc register_watchdog_pid {{pid}} {{
+            global env
+            set owned [open "$env(PROQI_TEST_STATE)/watchdog-pids" a]
+            puts $owned $pid
+            close $owned
+        }}
         spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE)
         stty rows 24 columns 80
         set proqi $spawn_id
         set child [exp_pid]
+        register_watchdog_pid $child
         expect -exact "\x1b\[?1049h"
         expect -exact "\x1b\[1 q"
-        after 300
-        send -- ":"
-        after 100
-        send -- "Screenshot Inbox"
-        send -- "\r"
+        after 1000
+        send -- "i"
         set capture_lock "$env(PROQI_TEST_STATE)/runtime/screenshot-capture.json"
-        for {{set attempt 0}} {{$attempt < 40 && ![file exists $capture_lock]}} {{incr attempt}} {{
+        for {{set attempt 0}} {{$attempt < 100 && ![file exists $capture_lock]}} {{incr attempt}} {{
             after 50
         }}
         if {{![file exists $capture_lock]}} {{
@@ -275,29 +333,28 @@ fn delayed_capture_shutdown(
         after 700
         spawn /usr/bin/sqlite3 $env(PROQI_TEST_DATABASE)
         set sqlite $spawn_id
+        register_watchdog_pid [exp_pid]
         expect -re "sqlite>"
         send -- "BEGIN IMMEDIATE;\r"
         expect -re "sqlite>"
         file rename $env(PROQI_TEST_STAGED) $env(PROQI_TEST_TARGET)
         set spawn_id $proqi
-        after {delivery_wait_ms}
+        {capture_barrier}
         send -- "!"
+        set shutdown_started [clock milliseconds]
         {exit_action}
         {finish_action}
         "#
-    );
-    let status = expect_command()
-        .args(["-c", &workflow])
-        .env("PROQI_TEST_BINARY", binary)
-        .env("PROQI_TEST_STATE", state.path())
-        .env(
-            "PROQI_TEST_DATABASE",
-            state.path().join("data/proqi.sqlite3"),
-        )
-        .env("PROQI_TEST_STAGED", &staged)
-        .env("PROQI_TEST_TARGET", &target)
-        .status()
-        .expect("run delayed capture shutdown");
+    )
+}
+
+fn assert_capture_shutdown_result(
+    status: std::process::ExitStatus,
+    state: &Path,
+    binary: &str,
+    target: &Path,
+    persistent_failure: bool,
+) {
     if persistent_failure {
         assert_eq!(
             status.code(),
@@ -307,12 +364,13 @@ fn delayed_capture_shutdown(
     } else {
         assert!(status.success(), "delayed capture shutdown exited {status}");
     }
+    assert_runtime_authority_released(state);
 
-    let sessions = json_command(binary, state.path(), &["sessions", "list"]);
+    let sessions = json_command(binary, state, &["sessions", "list"]);
     let session = sessions["data"]["sessions"][0]["id"]
         .as_str()
         .expect("session ID");
-    let thoughts = json_command(binary, state.path(), &["thoughts", "list", session]);
+    let thoughts = json_command(binary, state, &["thoughts", "list", session]);
     let contents = thoughts["data"]["thoughts"]
         .as_array()
         .expect("thoughts")
@@ -325,6 +383,26 @@ fn delayed_capture_shutdown(
         vec!["durable editor!", target.to_str().expect("target")]
     };
     assert_eq!(contents, expected);
+    let resumed = json_command(binary, state, &["-r", session]);
+    assert_eq!(resumed["data"]["session_id"], session);
+}
+
+fn assert_runtime_authority_released(state: &Path) {
+    assert!(
+        !state.join("runtime/screenshot-capture.json").exists(),
+        "Screenshot Inbox capture authority survived process exit"
+    );
+    let instances = state.join("runtime/instances");
+    if !instances.exists() {
+        return;
+    }
+    assert!(
+        fs::read_dir(instances)
+            .expect("runtime instances")
+            .next()
+            .is_none(),
+        "runtime instance lease survived process exit"
+    );
 }
 
 fn configure_capture(state: &Path, watched: &Path, debounce_ms: u64) {

--- a/tests/pty/update_control.rs
+++ b/tests/pty/update_control.rs
@@ -180,6 +180,11 @@ fn spawn_owner(binary: &str, state: &Path, session: &str, ready: &Path, done: &P
         set deadline [expr {[clock milliseconds] + 15000}]
         while {![file exists $env(PROQI_TEST_DONE)]} {
             if {[clock milliseconds] >= $deadline} { exit 91 }
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 93 }
+            }
             after 20
         }
         send -- "\x11"
@@ -231,6 +236,11 @@ fn spawn_restarting_owner(
         set deadline [expr {[clock milliseconds] + 15000}]
         while {![file exists $env(PROQI_TEST_DONE)]} {
             if {[clock milliseconds] >= $deadline} { exit 92 }
+            expect -timeout 0 {
+                -re ".+" { exp_continue }
+                timeout {}
+                eof { exit 93 }
+            }
             after 20
         }
         send -- "\x11"

--- a/tests/pty/watchdog.rs
+++ b/tests/pty/watchdog.rs
@@ -4,13 +4,21 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::{Child, Command, ExitStatus, Stdio},
+    sync::{Arc, Mutex, TryLockError},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
-use rustix::process::{Pid, Signal, kill_process};
+use rustix::{
+    io::Errno,
+    process::{Pid, Signal, WaitId, WaitIdOptions, kill_process, test_kill_process, waitid},
+};
 
 const OUTPUT_LIMIT: usize = 64 * 1024;
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+const TERM_GRACE: Duration = Duration::from_millis(100);
+const SETTLEMENT_RESERVE: Duration = Duration::from_millis(250);
+const CLEANUP_RESERVE: Duration = Duration::from_millis(350);
 
 pub(super) fn status_before(
     command: &mut Command,
@@ -24,32 +32,52 @@ pub(super) fn status_before(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    let deadline = Instant::now() + timeout;
     let child = command
         .spawn()
         .unwrap_or_else(|error| panic!("{context}: {error}"));
-    let mut owned = OwnedChild::new(child, cleanup_pids.to_path_buf());
-    let deadline = Instant::now() + timeout;
+    let mut owned = OwnedChild::new(child, cleanup_pids.to_path_buf(), deadline);
     loop {
-        match owned
-            .child
-            .try_wait()
+        if owned
+            .driver_exited()
             .unwrap_or_else(|error| panic!("{context}: watchdog wait failed: {error}"))
         {
-            Some(status) => {
-                owned.armed = false;
-                let output = owned.take_output();
-                if !output.is_empty() {
-                    eprintln!("{output}");
-                }
-                return status;
+            let cleanup = owned.terminate();
+            let output = owned.output();
+            if !output.is_empty() {
+                eprintln!("{output}");
             }
-            None if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
-            None => {
-                owned.terminate();
-                let output = owned.take_output();
-                panic!("{context}: exceeded absolute wall-clock limit of {timeout:?}\n{output}");
-            }
+            assert!(
+                cleanup.settled(),
+                "{context}: driver exited but teardown did not settle before the absolute wall-clock limit of {timeout:?}: {cleanup:?}\n{output}"
+            );
+            return owned
+                .status
+                .expect("settled watchdog driver must have an exit status");
         }
+        if Instant::now() >= owned.cleanup_at {
+            let cleanup = owned.terminate();
+            let output = owned.output();
+            panic!(
+                "{context}: exceeded absolute wall-clock limit of {timeout:?}; cleanup: {cleanup:?}\n{output}"
+            );
+        }
+        thread::sleep(
+            POLL_INTERVAL.min(owned.cleanup_at.saturating_duration_since(Instant::now())),
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CleanupOutcome {
+    driver: bool,
+    descendants: bool,
+    readers: bool,
+}
+
+impl CleanupOutcome {
+    const fn settled(self) -> bool {
+        self.driver && self.descendants && self.readers
     }
 }
 
@@ -57,111 +85,213 @@ struct OwnedChild {
     child: Child,
     process: Pid,
     cleanup_pids: PathBuf,
-    output: Vec<JoinHandle<Vec<u8>>>,
+    readers: Vec<OutputReader>,
+    deadline: Instant,
+    cleanup_at: Instant,
+    force_at: Option<Instant>,
+    term_sent: bool,
+    kill_sent: bool,
+    status: Option<ExitStatus>,
     armed: bool,
 }
 
 impl OwnedChild {
-    fn new(mut child: Child, cleanup_pids: PathBuf) -> Self {
+    fn new(mut child: Child, cleanup_pids: PathBuf, deadline: Instant) -> Self {
         let process = Pid::from_child(&child);
-        let mut output = Vec::with_capacity(2);
+        let mut readers = Vec::with_capacity(2);
         if let Some(stdout) = child.stdout.take() {
-            output.push(drain(stdout));
+            readers.push(OutputReader::spawn(stdout));
         }
         if let Some(stderr) = child.stderr.take() {
-            output.push(drain(stderr));
+            readers.push(OutputReader::spawn(stderr));
         }
+        let now = Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        let reserve = CLEANUP_RESERVE.min(remaining / 2);
+        let cleanup_at = deadline.checked_sub(reserve).unwrap_or(now);
         Self {
             child,
             process,
             cleanup_pids,
-            output,
+            readers,
+            deadline,
+            cleanup_at,
+            force_at: None,
+            term_sent: false,
+            kill_sent: false,
+            status: None,
             armed: true,
         }
     }
 
-    fn terminate(&mut self) {
+    fn terminate(&mut self) -> CleanupOutcome {
         if !self.armed {
-            return;
+            return self.outcome();
         }
-        self.signal_registered(Signal::TERM);
-        let _terminated = kill_process(self.process, Signal::TERM);
-        let driver_reaped = self.reap_before(Duration::from_millis(250));
-        self.signal_registered(Signal::KILL);
-        if !driver_reaped {
-            let _killed = kill_process(self.process, Signal::KILL);
-            let _reaped = self.reap_before(Duration::from_millis(250));
+        if !self.term_sent {
+            self.signal_owned(Signal::TERM);
+            self.term_sent = true;
+            let reader_settlement_at = self
+                .deadline
+                .checked_sub(SETTLEMENT_RESERVE)
+                .unwrap_or_else(Instant::now);
+            self.force_at = Some((Instant::now() + TERM_GRACE).min(reader_settlement_at));
         }
-        self.armed = false;
+        loop {
+            let driver_exited = self.driver_exited().unwrap_or(false);
+            let force_at = self.force_at.unwrap_or(self.deadline);
+            if !self.kill_sent && (driver_exited || Instant::now() >= force_at) {
+                // Keep Expect waitable until every final signal has been sent.
+                // This prevents reuse of the driver PID and confines raw-PID
+                // descendant signalling to the registered ownership window.
+                self.signal_owned(Signal::KILL);
+                self.kill_sent = true;
+            }
+            if self.kill_sent && driver_exited && self.status.is_none() {
+                self.status = self.child.try_wait().ok().flatten();
+            }
+            self.poll_readers();
+            let outcome = self.outcome();
+            if outcome.settled() {
+                self.armed = false;
+                return outcome;
+            }
+            if Instant::now() >= self.deadline {
+                return outcome;
+            }
+            thread::sleep(
+                POLL_INTERVAL.min(self.deadline.saturating_duration_since(Instant::now())),
+            );
+        }
     }
 
-    fn signal_registered(&self, signal: Signal) {
-        let Ok(contents) = fs::read_to_string(&self.cleanup_pids) else {
-            return;
-        };
-        for process in contents
+    fn signal_owned(&self, signal: Signal) {
+        for process in self.registered_processes() {
+            let _signalled = kill_process(process, signal);
+        }
+        if self.status.is_none() {
+            let _signalled = kill_process(self.process, signal);
+        }
+    }
+
+    fn registered_processes(&self) -> Vec<Pid> {
+        fs::read_to_string(&self.cleanup_pids)
+            .unwrap_or_default()
             .lines()
             .filter_map(|line| line.parse().ok())
             .filter_map(Pid::from_raw)
-        {
-            let _signalled = kill_process(process, signal);
+            .collect()
+    }
+
+    fn descendants_gone(&self) -> bool {
+        self.registered_processes()
+            .into_iter()
+            .all(process_is_absent)
+    }
+
+    fn driver_exited(&self) -> rustix::io::Result<bool> {
+        if self.status.is_some() {
+            return Ok(true);
+        }
+        waitid(
+            WaitId::Pid(self.process),
+            WaitIdOptions::EXITED | WaitIdOptions::NOHANG | WaitIdOptions::NOWAIT,
+        )
+        .map(|status| status.is_some())
+    }
+
+    fn poll_readers(&mut self) {
+        for reader in &mut self.readers {
+            reader.join_if_finished();
         }
     }
 
-    fn take_output(&mut self) -> String {
+    fn outcome(&self) -> CleanupOutcome {
+        CleanupOutcome {
+            driver: self.status.is_some(),
+            descendants: self.descendants_gone(),
+            readers: self.readers.iter().all(OutputReader::settled),
+        }
+    }
+
+    fn output(&self) -> String {
         let bytes = self
-            .output
-            .drain(..)
-            .filter_map(|reader| reader.join().ok())
-            .flatten()
+            .readers
+            .iter()
+            .flat_map(OutputReader::snapshot)
             .collect::<Vec<_>>();
         String::from_utf8_lossy(&bytes).into_owned()
     }
-
-    fn reap_before(&mut self, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
-        loop {
-            match self.child.try_wait() {
-                Ok(Some(_)) => return true,
-                Ok(None) if Instant::now() < deadline => {
-                    thread::sleep(Duration::from_millis(5));
-                }
-                Ok(None) | Err(_) => return false,
-            }
-        }
-    }
-}
-
-fn drain(mut stream: impl std::io::Read + Send + 'static) -> JoinHandle<Vec<u8>> {
-    thread::spawn(move || {
-        let mut bytes = Vec::new();
-        let mut chunk = [0_u8; 1_024];
-        while let Ok(read) = std::io::Read::read(&mut stream, &mut chunk) {
-            if read == 0 {
-                break;
-            }
-            if read >= OUTPUT_LIMIT {
-                bytes.clear();
-                bytes.extend_from_slice(&chunk[read - OUTPUT_LIMIT..read]);
-                continue;
-            }
-            let overflow = bytes
-                .len()
-                .saturating_add(read)
-                .saturating_sub(OUTPUT_LIMIT);
-            if overflow > 0 {
-                bytes.drain(..overflow);
-            }
-            bytes.extend_from_slice(&chunk[..read]);
-        }
-        bytes
-    })
 }
 
 impl Drop for OwnedChild {
     fn drop(&mut self) {
-        self.terminate();
+        let _cleanup = self.terminate();
     }
+}
+
+struct OutputReader {
+    bytes: Arc<Mutex<Vec<u8>>>,
+    handle: Option<JoinHandle<()>>,
+    failed: bool,
+}
+
+impl OutputReader {
+    fn spawn(stream: impl std::io::Read + Send + 'static) -> Self {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let output = Arc::clone(&bytes);
+        let handle = thread::spawn(move || drain(stream, &output));
+        Self {
+            bytes,
+            handle: Some(handle),
+            failed: false,
+        }
+    }
+
+    fn join_if_finished(&mut self) {
+        if !self.handle.as_ref().is_some_and(JoinHandle::is_finished) {
+            return;
+        }
+        let handle = self.handle.take().expect("finished watchdog reader");
+        self.failed = handle.join().is_err();
+    }
+
+    fn settled(&self) -> bool {
+        self.handle.is_none() && !self.failed
+    }
+
+    fn snapshot(&self) -> Vec<u8> {
+        match self.bytes.try_lock() {
+            Ok(bytes) => bytes.clone(),
+            Err(TryLockError::Poisoned(error)) => error.into_inner().clone(),
+            Err(TryLockError::WouldBlock) => b"<watchdog output reader still active>".to_vec(),
+        }
+    }
+}
+
+fn drain(mut stream: impl std::io::Read, output: &Mutex<Vec<u8>>) {
+    let mut chunk = [0_u8; 1_024];
+    while let Ok(read) = std::io::Read::read(&mut stream, &mut chunk) {
+        if read == 0 {
+            return;
+        }
+        let mut bytes = output
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let overflow = bytes
+            .len()
+            .saturating_add(read)
+            .saturating_sub(OUTPUT_LIMIT);
+        if overflow > 0 {
+            let remove = overflow.min(bytes.len());
+            bytes.drain(..remove);
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+}
+
+fn process_is_absent(process: Pid) -> bool {
+    matches!(test_kill_process(process), Err(Errno::SRCH | Errno::PERM))
 }
 
 #[cfg(test)]
@@ -184,7 +314,7 @@ mod tests {
         command
             .args([
                 "-c",
-                "/bin/sh -c 'while :; do printf output; count=0; while test $count -lt 10000; do count=$((count + 1)); done; done' & worker=$!; printf '%s\\n' \"$worker\" > \"$PROQI_TEST_PIDS\"; wait \"$worker\"",
+                "/bin/sh -c 'trap \"\" TERM; while :; do printf output; count=0; while test $count -lt 10000; do count=$((count + 1)); done; done' & worker=$!; printf '%s\\n' \"$worker\" > \"$PROQI_TEST_PIDS\"; wait \"$worker\"",
             ])
             .env("PROQI_TEST_PIDS", &pids);
         let started = Instant::now();
@@ -198,8 +328,55 @@ mod tests {
         }));
         assert!(panic.is_err(), "watchdog command unexpectedly completed");
         assert!(started.elapsed() < Duration::from_secs(1));
+        assert_registered_gone(&pids);
+    }
 
-        let raw = std::fs::read_to_string(&pids)
+    #[test]
+    fn exited_driver_cannot_leave_an_output_inheriting_descendant_or_reader() {
+        let state = tempfile::tempdir().expect("watchdog state");
+        let pids = state.path().join("pids");
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                "/bin/sh -c 'trap \"\" HUP TERM; while :; do :; done' & worker=$!; printf '%s\\n' \"$worker\" > \"$PROQI_TEST_PIDS\"; exit 0",
+            ])
+            .env("PROQI_TEST_PIDS", &pids);
+        let started = Instant::now();
+        let status = status_before(
+            &mut command,
+            Duration::from_secs(1),
+            &pids,
+            "exited-driver inherited-output proof",
+        );
+        assert!(status.success());
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_registered_gone(&pids);
+    }
+
+    #[test]
+    fn already_exited_registered_child_is_not_retained_as_owned_work() {
+        let state = tempfile::tempdir().expect("watchdog state");
+        let pids = state.path().join("pids");
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                "/bin/sh -c 'exit 0' & worker=$!; printf '%s\\n' \"$worker\" > \"$PROQI_TEST_PIDS\"; wait \"$worker\"; exit 0",
+            ])
+            .env("PROQI_TEST_PIDS", &pids);
+        let status = status_before(
+            &mut command,
+            Duration::from_secs(1),
+            &pids,
+            "early descendant exit proof",
+        );
+        assert!(status.success());
+        assert_registered_gone(&pids);
+    }
+
+    fn assert_registered_gone(pids: &std::path::Path) {
+        let raw = std::fs::read_to_string(pids)
             .expect("registered child")
             .trim()
             .parse()

--- a/tests/pty/watchdog.rs
+++ b/tests/pty/watchdog.rs
@@ -1,0 +1,217 @@
+//! Panic-safe absolute wall-clock ownership for PTY driver processes.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+use rustix::process::{Pid, Signal, kill_process};
+
+const OUTPUT_LIMIT: usize = 64 * 1024;
+
+pub(super) fn status_before(
+    command: &mut Command,
+    timeout: Duration,
+    cleanup_pids: &Path,
+    context: &str,
+) -> ExitStatus {
+    // Expect must inherit the foreground process group on macOS. Explicit PID
+    // registration supplies descendant ownership without changing PTY semantics.
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("{context}: {error}"));
+    let mut owned = OwnedChild::new(child, cleanup_pids.to_path_buf());
+    let deadline = Instant::now() + timeout;
+    loop {
+        match owned
+            .child
+            .try_wait()
+            .unwrap_or_else(|error| panic!("{context}: watchdog wait failed: {error}"))
+        {
+            Some(status) => {
+                owned.armed = false;
+                let output = owned.take_output();
+                if !output.is_empty() {
+                    eprintln!("{output}");
+                }
+                return status;
+            }
+            None if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+            None => {
+                owned.terminate();
+                let output = owned.take_output();
+                panic!("{context}: exceeded absolute wall-clock limit of {timeout:?}\n{output}");
+            }
+        }
+    }
+}
+
+struct OwnedChild {
+    child: Child,
+    process: Pid,
+    cleanup_pids: PathBuf,
+    output: Vec<JoinHandle<Vec<u8>>>,
+    armed: bool,
+}
+
+impl OwnedChild {
+    fn new(mut child: Child, cleanup_pids: PathBuf) -> Self {
+        let process = Pid::from_child(&child);
+        let mut output = Vec::with_capacity(2);
+        if let Some(stdout) = child.stdout.take() {
+            output.push(drain(stdout));
+        }
+        if let Some(stderr) = child.stderr.take() {
+            output.push(drain(stderr));
+        }
+        Self {
+            child,
+            process,
+            cleanup_pids,
+            output,
+            armed: true,
+        }
+    }
+
+    fn terminate(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.signal_registered(Signal::TERM);
+        let _terminated = kill_process(self.process, Signal::TERM);
+        let driver_reaped = self.reap_before(Duration::from_millis(250));
+        self.signal_registered(Signal::KILL);
+        if !driver_reaped {
+            let _killed = kill_process(self.process, Signal::KILL);
+            let _reaped = self.reap_before(Duration::from_millis(250));
+        }
+        self.armed = false;
+    }
+
+    fn signal_registered(&self, signal: Signal) {
+        let Ok(contents) = fs::read_to_string(&self.cleanup_pids) else {
+            return;
+        };
+        for process in contents
+            .lines()
+            .filter_map(|line| line.parse().ok())
+            .filter_map(Pid::from_raw)
+        {
+            let _signalled = kill_process(process, signal);
+        }
+    }
+
+    fn take_output(&mut self) -> String {
+        let bytes = self
+            .output
+            .drain(..)
+            .filter_map(|reader| reader.join().ok())
+            .flatten()
+            .collect::<Vec<_>>();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    fn reap_before(&mut self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return true,
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Ok(None) | Err(_) => return false,
+            }
+        }
+    }
+}
+
+fn drain(mut stream: impl std::io::Read + Send + 'static) -> JoinHandle<Vec<u8>> {
+    thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 1_024];
+        while let Ok(read) = std::io::Read::read(&mut stream, &mut chunk) {
+            if read == 0 {
+                break;
+            }
+            if read >= OUTPUT_LIMIT {
+                bytes.clear();
+                bytes.extend_from_slice(&chunk[read - OUTPUT_LIMIT..read]);
+                continue;
+            }
+            let overflow = bytes
+                .len()
+                .saturating_add(read)
+                .saturating_sub(OUTPUT_LIMIT);
+            if overflow > 0 {
+                bytes.drain(..overflow);
+            }
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+        bytes
+    })
+}
+
+impl Drop for OwnedChild {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        process::Command,
+        time::{Duration, Instant},
+    };
+
+    use rustix::process::{Pid, test_kill_process};
+
+    use super::status_before;
+
+    #[test]
+    fn continuous_output_cannot_defeat_the_absolute_watchdog_or_child_cleanup() {
+        let state = tempfile::tempdir().expect("watchdog state");
+        let pids = state.path().join("pids");
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                "/bin/sh -c 'while :; do printf output; count=0; while test $count -lt 10000; do count=$((count + 1)); done; done' & worker=$!; printf '%s\\n' \"$worker\" > \"$PROQI_TEST_PIDS\"; wait \"$worker\"",
+            ])
+            .env("PROQI_TEST_PIDS", &pids);
+        let started = Instant::now();
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            let _status = status_before(
+                &mut command,
+                Duration::from_millis(100),
+                &pids,
+                "continuous-output watchdog proof",
+            );
+        }));
+        assert!(panic.is_err(), "watchdog command unexpectedly completed");
+        assert!(started.elapsed() < Duration::from_secs(1));
+
+        let raw = std::fs::read_to_string(&pids)
+            .expect("registered child")
+            .trim()
+            .parse()
+            .expect("child pid");
+        let child = Pid::from_raw(raw).expect("positive child pid");
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while test_kill_process(child).is_ok() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            test_kill_process(child).is_err(),
+            "watchdog left its registered child alive"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fix macOS terminal shutdown when Screenshot Inbox persistence keeps failing under SQLite contention. Signal admission is now owned by the terminal runner and remains monotonic even if later screenshot state transitions clear the UI quit flag.

Add an absolute wall-clock PTY watchdog that continuously drains output and owns panic-safe cleanup of Expect and registered child processes. The persistent-failure regression proves bounded production teardown without muting output or changing the 1.5 second capture and 2 second shared shutdown contracts.

Original ticket base: `8384e3b695efec866d32b5e316dbdaf463693733`

Current main merged: `e561eb4a022aeffccb6aab00df34bd0bf3722894`

## Acceptance criteria

- Reproduced the current-main hang with Screenshot Inbox enabled, SQLite locked, capture persistence failing, and SIGTERM delivered while output continued.
- Diagnosed the race: the runner remembered that SIGTERM had been seen, but shutdown admission still depended on mutable `app.quit`; a later capture failure could clear that flag, leaving the input loop active while preventing signal readmission.
- Made termination admission monotonic at the terminal-runner boundary. Cancellation, capture release, persistence drain, control shutdown, terminal restoration, instance and session lease release, and exit all share the existing bounded shutdown deadline.
- Preserved truthful failure. Termination that cannot make accepted work durable exits nonzero after best-effort bounded cleanup.
- Added a 12 second absolute watchdog independent of Expect output inactivity. One persistent deadline covers driver, registered-descendant, and output-reader settlement.
- Kept cleanup armed until every owned process and output reader settles. Reader threads are joined only after `JoinHandle::is_finished()`.
- Kept Expect waitable until final TERM and KILL signalling is complete, then reaped it. Added deterministic inherited-output and early-child-exit regressions.

## Production changes

- Introduce `TerminationAdmission` as the single runner-owned authority for signal-triggered shutdown.
- Keep screenshot activity from being reactivated after admission, retry or abandon failed capture as required, and flush the pending editor change once the screenshot commit barrier clears.
- Decide loop exit from monotonic termination admission or ordinary UI quit, never from the mutable UI flag alone.

## Test-oracle corrections

- Keep terminal output enabled in the persistent-failure scenario and drain it continuously in the Rust watchdog.
- Register Proqi and sqlite3 descendants for panic-safe cleanup and retain the last 64 KiB of each output stream for clear failures.
- Replace unconditional output-reader joins with bounded polling and nonblocking output snapshots.
- Preserve one absolute teardown deadline across driver observation, descendant cleanup, reader settlement, and panic cleanup.
- Replace fixed startup sleeps with terminal readiness sequences where exposed.
- Drain PTY output in existing coordination loops so terminal backpressure cannot masquerade as a production lifecycle hang.
- Correct the recovery oracle to the actual storage failure and recovery-export states.

## Verification

- Persistent locked-SQLite failure: 10 consecutive real PTY cycles. Each drove initial capture failure, retry while still locked, continuous output, `!`, three rapid SIGTERM deliveries, bounded teardown, terminal restoration, capture authority cleanup, instance and session lease cleanup, durable editor content, and resumability.
- Focused lifecycle matrix: keyboard quit during delayed capture, SIGTERM during delayed capture, 1000 ms maximum debounce, delayed and permanently failed capture commits, locked and unlocked SQLite, repeated signals, normal exit, terminal close, restoration, restart, inherited stdout and stderr, and an already exited registered child.
- `cargo test --test pty watchdog:: -- --nocapture`: 3 of 3 watchdog ownership regressions passed.
- `cargo xtask test-pty`: 34 of 34 scenarios passed, including 100 terminal cycles and all watchdog proofs.
- `cargo xtask check`: formatting, diff checks, source limits, snapshots, assets, architecture, Clippy, docs, 821 runnable tests, and doctests passed. Five platform-specific tests retained their existing skip configuration.
- `cargo xtask audit`: advisories, bans, licenses, sources, RustSec audit, and unused dependency checks passed. Existing duplicate-dependency warnings remain nonblocking.
- `cargo xtask package`: optimized package built and the installed-product PTY contract passed.
- Neutral Codex and Claude Code with Fable independently reviewed the watchdog follow-up and found the blocking P1 resolved.
- Final process audit checks Proqi, sqlite3, Expect, shell, and PTY ownership before handoff.

## Risks, limitations, and follow-ups

- Persistently failed accepted work remains intentionally visible as a nonzero exit and shutdown error after bounded cleanup. This avoids claiming durability that was not achieved.
- Expect must remain in the foreground process group for the macOS PTY driver, so the watchdog preserves explicit descendant registration. Final signalling occurs before Expect is reaped, and inaccessible reused PIDs are treated as outside watchdog ownership.
- The package contract requires a local control socket, so the final package gate was run outside the filesystem sandbox.
- Sharing the test-only teardown state machine between package-contract and Expect watchdog support could reduce duplication in a later refactor. It is not required for this fix.
- The separate Linux `session_busy` package-contract failure and unrelated Screenshot Inbox feature behavior remain out of scope.
