### PR TITLE
Make Space preserve selected placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,9 @@ literal text. List-only menus and four-way choosers ignore irrelevant modifiers
 equally for arrows and their Vim-style aliases.
 
 Mouse input covers the same core workflow. Images, files, and large pastes fold
-into compact annotations while their content stays intact. See
+into compact annotations while their content stays intact. In Edit mode, an
+unmodified `Space` on one completely selected collapsed annotation inserts a
+space immediately before it without replacing it. See
 [invocation compatibility](docs/INVOCATIONS.md).
 
 Inside Herdr, opening the same invocation picker also discovers recognized live

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -894,6 +894,13 @@ a distinct normalized value and has no Board command meaning. The configured
 character remains remappable independently. `Backspace` has no Board delete
 meaning. Compose and Edit interpret both Delete values as forward text deletion,
 while query owners retain their existing local text-editing behavior.
+Unmodified Space retains its own normalized identity until the active owner
+handles it. Edit mode consults the canonical presentation projection before
+ordinary character insertion. When that projection resolves the exact canonical
+selection to one collapsed substitution, one placeholder-agnostic editor
+command inserts an ASCII space at the selection start without replacing the
+selection. Modified Space remains ordinary text input, and Board, Compose,
+queries, overlays, and the session browser retain their existing Space behavior.
 One typed non-text navigation decoder maps Up and Down to `k` and `j` in
 list-only surfaces and maps Left, Down, Up, and Right to `h`, `j`, `k`, and `l`
 in direction choosers. It ignores irrelevant modifiers symmetrically across
@@ -1014,6 +1021,9 @@ testing consume that same projection. Clipboard, recovery, CLI, search,
 submission, and integration boundaries continue to consume canonical content.
 Edits rebase unaffected ranges and dissolve intersected ranges. Revisions
 persist both sides of the annotation change so undo and redo remain restart-safe.
+Exact selected-substitution activation and placeholder-aware Space resolve from
+that same projection. They do not inspect a formatted label or reconstruct a
+semantic range from visible text.
 
 URL recognition is a render-only pass over canonical content. Only explicit
 HTTP and HTTPS ranges receive accent and underline styling. URL recognition does

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -324,7 +324,11 @@ paths or filenames.
 
 Moving onto or clicking a folded token selects its complete visible placeholder.
 `Enter` expands the selected token's exact path or text for editing. Typing,
-backspace, and delete replace or remove the complete canonical range. A
+backspace, and delete replace or remove the complete canonical range. One
+unmodified `Space` is the narrow exception: when exactly one complete collapsed
+placeholder is selected in Edit mode, it inserts one ordinary ASCII space at
+the canonical start, preserves and shifts the complete annotation, clears the
+selection, and leaves the caret immediately before the placeholder. A
 collapsed token is one logical editor unit, so the cursor can never disappear
 inside hidden content.
 Leaving edit mode returns expanded ranges to their compact presentation. Copy,

--- a/src/adapters/editor/mod.rs
+++ b/src/adapters/editor/mod.rs
@@ -201,6 +201,7 @@ impl Editor for RopeEditor {
             EditCommand::InsertChar(character) => {
                 self.mutate(|editor| editor.replace_selection_or_insert(&character.to_string()))
             }
+            EditCommand::InsertBeforeSelection(c) => self.insert_before_selection(c),
             EditCommand::Paste(text) => {
                 self.mutate(|editor| editor.replace_selection_or_insert(&text))
             }

--- a/src/adapters/editor/mutation.rs
+++ b/src/adapters/editor/mutation.rs
@@ -140,6 +140,13 @@ impl RopeEditor {
         Some(self.replace_byte_range(start, end, text))
     }
 
+    pub(super) fn insert_before_selection(&mut self, character: char) -> TextChangeSet {
+        self.mutate(|editor| {
+            let (start, _) = editor.selection_bytes()?;
+            Some(editor.replace_byte_range(start, start, &character.to_string()))
+        })
+    }
+
     pub(super) fn delete_back(&mut self) -> Option<AppliedRange> {
         if let Some((start, end)) = self.selection_bytes() {
             return Some(self.replace_byte_range(start, end, ""));

--- a/src/adapters/terminal/input.rs
+++ b/src/adapters/terminal/input.rs
@@ -338,3 +338,6 @@ fn send_lossless(
 #[cfg(test)]
 #[path = "input/tests.rs"]
 mod tests;
+#[cfg(test)]
+#[path = "input/translation_tests.rs"]
+mod translation_tests;

--- a/src/adapters/terminal/input/translation.rs
+++ b/src/adapters/terminal/input/translation.rs
@@ -67,6 +67,7 @@ pub(super) fn translate_key(key: KeyEvent) -> Option<UiKey> {
         .modifiers
         .intersects(KeyModifiers::SUPER | KeyModifiers::META);
     match key.code {
+        KeyCode::Char(' ') if key.modifiers.is_empty() => Some(UiKey::UnmodifiedSpace),
         KeyCode::Char(character) => Some(UiKey::Character(character)),
         KeyCode::Enter => Some(UiKey::Enter),
         KeyCode::BackTab => Some(UiKey::BackTab),

--- a/src/adapters/terminal/input/translation_tests.rs
+++ b/src/adapters/terminal/input/translation_tests.rs
@@ -1,0 +1,36 @@
+//! Modifier-preserving translation contracts for ordinary Space input.
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use crate::ui::{UiInput, UiKey};
+
+use super::translate;
+
+#[test]
+fn only_unmodified_space_receives_the_placeholder_aware_identity() {
+    assert_eq!(
+        translate(Event::Key(KeyEvent::new(
+            KeyCode::Char(' '),
+            KeyModifiers::NONE,
+        ))),
+        Some(UiInput::Key(UiKey::UnmodifiedSpace))
+    );
+    for modifiers in [KeyModifiers::SHIFT, KeyModifiers::ALT] {
+        assert_eq!(
+            translate(Event::Key(KeyEvent::new(KeyCode::Char(' '), modifiers))),
+            Some(UiInput::Key(UiKey::Character(' '))),
+            "modifiers: {modifiers:?}"
+        );
+    }
+    for modifiers in [
+        KeyModifiers::CONTROL,
+        KeyModifiers::SUPER,
+        KeyModifiers::META,
+    ] {
+        assert_eq!(
+            translate(Event::Key(KeyEvent::new(KeyCode::Char(' '), modifiers))),
+            Some(UiInput::Key(UiKey::PrimaryCharacter(' '))),
+            "modifiers: {modifiers:?}"
+        );
+    }
+}

--- a/src/ports/editor.rs
+++ b/src/ports/editor.rs
@@ -89,6 +89,8 @@ pub enum SelectionGranularity {
 pub enum EditCommand {
     /// Insert one character.
     InsertChar(char),
+    /// Insert one character at the beginning of the active selection without replacing it.
+    InsertBeforeSelection(char),
     /// Insert an arbitrary payload as one semantic operation.
     Paste(String),
     /// Insert a line feed.

--- a/src/ui/app/commands.rs
+++ b/src/ui/app/commands.rs
@@ -33,7 +33,7 @@ impl BoardApp {
                 self.clear_board_selection();
             }
             UiKey::SelectAll => self.select_all_thoughts(),
-            UiKey::Character(_) | UiKey::Delete => {
+            UiKey::Character(_) | UiKey::UnmodifiedSpace | UiKey::Delete => {
                 return self.handle_board_key_command(key, ids, clock);
             }
             UiKey::Enter => return self.expand_and_enter_edit(ids, clock),
@@ -75,7 +75,9 @@ impl BoardApp {
                 self.select_all_thoughts();
                 Vec::new()
             }
-            UiKey::Character(_) | UiKey::Delete => self.handle_board_key_command(key, ids, clock),
+            UiKey::Character(_) | UiKey::UnmodifiedSpace | UiKey::Delete => {
+                self.handle_board_key_command(key, ids, clock)
+            }
             UiKey::Enter => self.begin_insertion(ids, clock),
             UiKey::Escape => {
                 self.move_focus(-1);
@@ -198,6 +200,11 @@ impl BoardApp {
             return Vec::new();
         };
         if let Some(effects) = self.handle_edit_effect(key, ids, clock) {
+            return effects;
+        }
+        if matches!(key, UiKey::UnmodifiedSpace)
+            && let Some(effects) = self.insert_space_before_selected_fold(ids, clock)
+        {
             return effects;
         }
         if let UiKey::Move {

--- a/src/ui/app/editing.rs
+++ b/src/ui/app/editing.rs
@@ -14,6 +14,7 @@ use crate::ui::annotations;
 
 pub(super) fn command_for_key(key: UiKey, adjacent_fold: bool) -> Option<(EditCommand, bool)> {
     match key {
+        UiKey::UnmodifiedSpace => Some((EditCommand::InsertChar(' '), false)),
         UiKey::Character(character) => Some((EditCommand::InsertChar(character), false)),
         UiKey::Enter => Some((EditCommand::InsertNewline, false)),
         UiKey::Backspace => Some((EditCommand::DeleteBack, adjacent_fold)),

--- a/src/ui/app/folds.rs
+++ b/src/ui/app/folds.rs
@@ -13,34 +13,45 @@ impl BoardApp {
         let Some(thought_id) = self.active_thought_id() else {
             return false;
         };
-        let Some(snapshot) = self.editor_snapshot() else {
-            return false;
-        };
-        let selection = snapshot.selection.map(|selection| {
-            (
-                crate::ports::text_layout::byte_for_position(&snapshot.content, selection.start),
-                crate::ports::text_layout::byte_for_position(&snapshot.content, selection.end),
-            )
-        });
-        let annotations = self.current_annotations(thought_id);
-        let candidate = annotations
-            .iter()
-            .enumerate()
-            .find_map(|(index, annotation)| {
-                (!self.expanded_folds.contains(&(thought_id, index))
-                    && annotation.kind.behavior() == AnnotationBehavior::Substitution
-                    && selection == Some((annotation.start, annotation.end)))
-                .then_some(index)
-            });
-        let Some(index) = candidate else {
+        let Some((index, end)) = self.editor_presentation().and_then(|presentation| {
+            presentation
+                .selected_collapsed_substitution()
+                .map(|substitution| (substitution.annotation_index, substitution.canonical_end))
+        }) else {
             return false;
         };
         if !self.expanded_folds.insert((thought_id, index)) {
             return false;
         }
-        let end = annotations[index].end;
         self.set_editor_range(end, end);
         true
+    }
+
+    pub(super) fn insert_space_before_selected_fold(
+        &mut self,
+        ids: &mut impl crate::ports::environment::IdGenerator,
+        clock: &impl crate::ports::environment::Clock,
+    ) -> Option<Vec<crate::application::Effect>> {
+        let thought_id = self.active_thought_id()?;
+        self.editor_presentation()?
+            .selected_collapsed_substitution()?;
+        let command = EditCommand::InsertBeforeSelection(' ');
+        if self.edit_command_blocked(&command) {
+            return Some(Vec::new());
+        }
+        let mut effects = match self.flush_edit_boundary(ids, clock) {
+            super::pending_types::EditFlush::Complete(effects) => effects,
+            super::pending_types::EditFlush::Blocked(effects) => return Some(effects),
+        };
+        let expanded = self.expanded_fold_indices(thought_id);
+        self.apply_edit(command);
+        self.expanded_folds
+            .extend(expanded.into_iter().map(|index| (thought_id, index)));
+        match self.flush_edit_boundary(ids, clock) {
+            super::pending_types::EditFlush::Complete(flushed)
+            | super::pending_types::EditFlush::Blocked(flushed) => effects.extend(flushed),
+        }
+        Some(effects)
     }
 
     pub(super) fn projected_position_at_cell(

--- a/src/ui/app/help.rs
+++ b/src/ui/app/help.rs
@@ -31,6 +31,9 @@ impl BoardApp {
             {
                 self.close_help();
             }
+            UiInput::Key(UiKey::UnmodifiedSpace) if self.settings.keybindings.help == ' ' => {
+                self.close_help();
+            }
             UiInput::Resize { .. } => {
                 self.layout = None;
                 self.hovered = None;

--- a/src/ui/app/invocation.rs
+++ b/src/ui/app/invocation.rs
@@ -194,6 +194,9 @@ impl BoardApp {
             UiInput::Key(UiKey::Character(character)) if !character.is_control() => {
                 self.update_manual_query(|query| query.push(*character));
             }
+            UiInput::Key(UiKey::UnmodifiedSpace) => {
+                self.update_manual_query(|query| query.push(' '));
+            }
             UiInput::Key(UiKey::Backspace) => self.pop_manual_query(),
             UiInput::Paste(value) => self.extend_manual_query(value),
             UiInput::PasteAnnotated(payload) => self.extend_manual_query(&payload.content),

--- a/src/ui/app/palette.rs
+++ b/src/ui/app/palette.rs
@@ -233,11 +233,10 @@ impl BoardApp {
                 }
             }
             UiKey::Character(character) if !character.is_control() => {
-                if let Some(palette) = &mut self.palette {
-                    palette.query.insert_char(character);
-                    palette.selected = 0;
-                    palette.scroll = 0;
-                }
+                return self.update_palette_query(|query| query.insert_char(character));
+            }
+            UiKey::UnmodifiedSpace => {
+                return self.update_palette_query(|query| query.insert_char(' '));
             }
             _ => {}
         }

--- a/src/ui/app/palette_handoff.rs
+++ b/src/ui/app/palette_handoff.rs
@@ -36,6 +36,10 @@ impl BoardApp {
                 self.settings.keybindings.command(*character)
                     == Some(crate::ui::settings::BoardCommand::Commands)
             }
+            UiInput::Key(UiKey::UnmodifiedSpace) => {
+                self.settings.keybindings.command(' ')
+                    == Some(crate::ui::settings::BoardCommand::Commands)
+            }
             UiInput::Pointer(pointer)
                 if matches!(pointer.kind, PointerKind::Down(PointerButton::Left)) =>
             {

--- a/src/ui/app/recovery.rs
+++ b/src/ui/app/recovery.rs
@@ -38,11 +38,12 @@ impl BoardApp {
 
     pub(super) fn is_failed_recovery_quit(&self, input: &UiInput) -> bool {
         matches!(self.state.durability, DurabilityState::Failed { .. })
-            && matches!(
+            && (matches!(
                 input,
                 UiInput::Key(UiKey::Character(character))
                     if *character == self.settings.keybindings.quit
-            )
+            ) || matches!(input, UiInput::Key(UiKey::UnmodifiedSpace))
+                && self.settings.keybindings.quit == ' ')
     }
 
     pub(super) fn handle_failed_recovery_input(

--- a/src/ui/app/search.rs
+++ b/src/ui/app/search.rs
@@ -116,6 +116,13 @@ impl BoardApp {
                     search.scroll = 0;
                 }
             }
+            UiKey::UnmodifiedSpace => {
+                if let Some(search) = &mut self.search {
+                    search.query.insert_char(' ');
+                    search.selected = 0;
+                    search.scroll = 0;
+                }
+            }
             _ => {}
         }
         Vec::new()

--- a/src/ui/app/session.rs
+++ b/src/ui/app/session.rs
@@ -35,6 +35,11 @@ impl BoardApp {
                     value.push(*character);
                 }
             }
+            UiInput::Key(UiKey::UnmodifiedSpace) => {
+                if let Some(value) = &mut self.rename {
+                    value.push(' ');
+                }
+            }
             UiInput::Paste(text) => self.append_session_name(text),
             UiInput::PasteAnnotated(payload) => self.append_session_name(&payload.content),
             UiInput::Pointer(pointer)

--- a/src/ui/app/transfer.rs
+++ b/src/ui/app/transfer.rs
@@ -171,6 +171,9 @@ impl BoardApp {
             UiKey::Character(character) if !character.is_control() => {
                 self.update_transfer_query(|query| query.insert_char(character));
             }
+            UiKey::UnmodifiedSpace => {
+                self.update_transfer_query(|query| query.insert_char(' '));
+            }
             _ => {}
         }
         Vec::new()

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -342,6 +342,11 @@ impl SessionBrowser {
                     BrowserAction::Continue
                 }
             },
+            UiInput::Key(UiKey::UnmodifiedSpace) => {
+                self.query.push(' ');
+                self.refilter();
+                BrowserAction::Continue
+            }
             UiInput::Paste(text) => {
                 self.query.push_str(&text.replace(['\r', '\n'], " "));
                 self.refilter();

--- a/src/ui/browser/management.rs
+++ b/src/ui/browser/management.rs
@@ -66,6 +66,12 @@ impl SessionBrowser {
                 }
                 BrowserAction::Continue
             }
+            UiInput::Key(UiKey::UnmodifiedSpace) => {
+                if let Some(rename) = &mut self.rename {
+                    rename.value.push(' ');
+                }
+                BrowserAction::Continue
+            }
             UiInput::Paste(text) => {
                 if let Some(rename) = &mut self.rename {
                     rename.value.push_str(&text.replace(['\r', '\n'], " "));

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -52,6 +52,8 @@ pub enum UiKey {
     Quit,
     /// Insert one Unicode scalar value.
     Character(char),
+    /// Insert an ordinary ASCII space reported without modifiers.
+    UnmodifiedSpace,
     /// A printable character reported with Primary for board-keymap resolution.
     PrimaryCharacter(char),
     /// Insert a line break or enter the focused thought.

--- a/src/ui/projection.rs
+++ b/src/ui/projection.rs
@@ -18,6 +18,7 @@ pub(super) struct EditorPresentation {
     pub(super) substitutions: Vec<PresentedSubstitution>,
     pub(super) styles: Vec<PresentedStyle>,
     canonical_content: String,
+    canonical_selection: Option<(usize, usize)>,
     rows: Vec<WrappedRow>,
     cursor_display_byte: usize,
 }
@@ -58,6 +59,14 @@ pub(super) fn board_cell_target(
 }
 
 impl EditorPresentation {
+    pub(super) fn selected_collapsed_substitution(&self) -> Option<&PresentedSubstitution> {
+        let selection = self.canonical_selection?;
+        self.substitutions.iter().find(|substitution| {
+            substitution.collapsed
+                && selection == (substitution.canonical_start, substitution.canonical_end)
+        })
+    }
+
     pub(super) fn fold_at_cell(&self, row: u16, column: u16) -> Option<&PresentedSubstitution> {
         let row = self
             .rows
@@ -102,6 +111,12 @@ pub(super) fn editor_presentation(
     expanded: &[usize],
     inaccessible: impl FnMut(usize) -> bool,
 ) -> Result<EditorPresentation, ProjectionError> {
+    let canonical_selection = canonical.selection.map(|selection| {
+        (
+            byte_for_position(&canonical.content, selection.start),
+            byte_for_position(&canonical.content, selection.end),
+        )
+    });
     let presentation = super::annotations::project_with_health(
         &canonical.content,
         annotations,
@@ -136,6 +151,7 @@ pub(super) fn editor_presentation(
         substitutions: presentation.substitutions,
         styles: presentation.styles,
         canonical_content: canonical.content.clone(),
+        canonical_selection,
         rows,
         cursor_display_byte,
     })

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -209,6 +209,7 @@ impl KeyBindings {
     pub(super) fn command_for_key(&self, key: super::UiKey) -> Option<BoardCommand> {
         match key {
             super::UiKey::Delete => Some(BoardCommand::Delete),
+            super::UiKey::UnmodifiedSpace => self.command(' '),
             super::UiKey::Character(character) => self.command(character),
             _ => None,
         }
@@ -235,6 +236,7 @@ impl KeyBindings {
             super::UiKey::Character(character) => {
                 Self::navigation_for_command(self.command(character), false)
             }
+            super::UiKey::UnmodifiedSpace => Self::navigation_for_command(self.command(' '), false),
             super::UiKey::PrimaryCharacter(character) => {
                 Self::navigation_for_command(self.command(character), true)
             }

--- a/tests/editor_contract.rs
+++ b/tests/editor_contract.rs
@@ -100,6 +100,36 @@ fn selection_replacement_and_cut_deletion_report_exact_ranges() {
 }
 
 #[test]
+fn insertion_before_selection_preserves_content_and_is_one_undo_unit() {
+    let mut editor = editor("a日本z");
+    editor.apply(EditCommand::SetCursor {
+        position: TextPosition::new(0, 3),
+        extend_selection: false,
+    });
+    for _ in 0..2 {
+        editor.apply(EditCommand::Move {
+            movement: CursorMovement::GraphemeBack,
+            extend_selection: true,
+        });
+    }
+    let inserted = editor.apply(EditCommand::InsertBeforeSelection(' '));
+    assert_change(&inserted, 1..1, 1..2);
+    assert_eq!(inserted.snapshot.content, "a 日本z");
+    assert_eq!(inserted.snapshot.cursor, TextPosition::new(0, 2));
+    assert_eq!(inserted.snapshot.selection, None);
+
+    let undone = editor.apply(EditCommand::Undo);
+    assert_eq!(undone.snapshot.content, "a日本z");
+    assert_eq!(
+        undone.snapshot.selection,
+        Some(proqi::ports::editor::TextSelection {
+            start: TextPosition::new(0, 1),
+            end: TextPosition::new(0, 3),
+        })
+    );
+}
+
+#[test]
 fn backward_and_forward_delete_report_complete_grapheme_byte_ranges() {
     let combining = "e\u{301}";
     let combining_content = format!("A{combining}B");

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -44,6 +44,10 @@ mod key_inspector;
 mod path_drop;
 
 #[cfg(target_os = "macos")]
+#[path = "pty/placeholder_space.rs"]
+mod placeholder_space;
+
+#[cfg(target_os = "macos")]
 #[path = "pty/recovery.rs"]
 mod recovery;
 

--- a/tests/pty/placeholder_space.rs
+++ b/tests/pty/placeholder_space.rs
@@ -1,0 +1,157 @@
+//! Exact placeholder-aware Space durability and undo through a real PTY.
+
+use super::support::{expect_command, json_command};
+
+use proqi::domain::{ContentAnnotation, ContentAnnotationKind};
+use rusqlite::Connection;
+
+#[test]
+fn selected_file_placeholder_moves_right_and_undoes_in_a_real_pty() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let files = tempfile::tempdir().expect("temporary files");
+    let file = files.path().join("placeholder-space-界.png");
+    std::fs::write(&file, b"fixture image bytes").expect("file fixture");
+    let binary = env!("CARGO_BIN_EXE_proqi");
+
+    create_placeholder(binary, state.path(), &file);
+    let sessions = json_command(binary, state.path(), &["sessions", "list"]);
+    let session = sessions["data"]["sessions"][0]["id"]
+        .as_str()
+        .expect("session ID");
+    let thoughts = json_command(binary, state.path(), &["thoughts", "list", session]);
+    let thought = thoughts["data"]["thoughts"][0]["id"]
+        .as_str()
+        .expect("thought ID");
+    let original = file.to_string_lossy();
+    assert_durable_value(state.path(), original.as_ref(), 0, original.len());
+
+    type_space_before_selected_placeholder(binary, state.path(), session);
+    let moved = json_command(
+        binary,
+        state.path(),
+        &["thoughts", "inspect", session, thought],
+    );
+    assert_eq!(moved["data"]["thought"]["content"], format!(" {original}"));
+    assert_durable_value(state.path(), &format!(" {original}"), 1, original.len() + 1);
+
+    undo_after_restart(binary, state.path(), session);
+    let undone = json_command(
+        binary,
+        state.path(),
+        &["thoughts", "inspect", session, thought],
+    );
+    assert_eq!(undone["data"]["thought"]["content"], original.as_ref());
+    assert_durable_value(state.path(), original.as_ref(), 0, original.len());
+}
+
+fn create_placeholder(binary: &str, state: &std::path::Path, file: &std::path::Path) {
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set binary $env(PROQI_TEST_BINARY)
+        set state $env(PROQI_TEST_STATE)
+        set dropped $env(PROQI_TEST_DROP)
+        spawn $binary --state-dir $state
+        expect -exact "\x1b\[?1049h"
+        send -- "\x1b\[200~$dropped\x1b\[201~"
+        after 700
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    let status = expect_command()
+        .args(["-c", script])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state)
+        .env("PROQI_TEST_DROP", file)
+        .status()
+        .expect("create placeholder in PTY");
+    assert!(status.success());
+}
+
+fn type_space_before_selected_placeholder(binary: &str, state: &std::path::Path, session: &str) {
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set binary $env(PROQI_TEST_BINARY)
+        set state $env(PROQI_TEST_STATE)
+        set session $env(PROQI_TEST_SESSION)
+        spawn $binary --state-dir $state -r $session
+        expect -exact "\x1b\[?1049h"
+        send "\r"
+        after 100
+        send "\x01"
+        after 100
+        send -- " "
+        after 700
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    let status = expect_command()
+        .args(["-c", script])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state)
+        .env("PROQI_TEST_SESSION", session)
+        .status()
+        .expect("type placeholder-aware Space in PTY");
+    assert!(status.success());
+}
+
+fn undo_after_restart(binary: &str, state: &std::path::Path, session: &str) {
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set binary $env(PROQI_TEST_BINARY)
+        set state $env(PROQI_TEST_STATE)
+        set session $env(PROQI_TEST_SESSION)
+        spawn $binary --state-dir $state -r $session
+        expect -exact "\x1b\[?1049h"
+        send "\r"
+        after 100
+        send "\x1a"
+        after 700
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    let status = expect_command()
+        .args(["-c", script])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state)
+        .env("PROQI_TEST_SESSION", session)
+        .status()
+        .expect("undo placeholder Space after restart in PTY");
+    assert!(status.success());
+}
+
+fn assert_durable_value(state: &std::path::Path, content: &str, start: usize, end: usize) {
+    let database = state.join("data/proqi.sqlite3");
+    let connection = Connection::open(database).expect("open durable state");
+    let (stored_content, annotations): (String, String) = connection
+        .query_row(
+            "SELECT content, annotations_json FROM thoughts WHERE deleted_at IS NULL",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("load durable placeholder");
+    let annotations: Vec<ContentAnnotation> =
+        serde_json::from_str(&annotations).expect("parse annotations");
+    assert_eq!(stored_content, content);
+    assert_eq!(annotations.len(), 1);
+    assert_eq!(annotations[0].start, start);
+    assert_eq!(annotations[0].end, end);
+    assert!(matches!(
+        annotations[0].kind,
+        ContentAnnotationKind::Attachment { image: true, .. }
+    ));
+}

--- a/tests/sqlite_store/annotations.rs
+++ b/tests/sqlite_store/annotations.rs
@@ -326,3 +326,154 @@ fn edit_shortcut_prefix(
     assert_eq!(effects.len(), 1);
     persist_effect(&mut store, &effects[0]);
 }
+
+#[test]
+fn placeholder_space_revision_undo_and_redo_survive_every_reopen() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_400_000);
+    let mut state = session_state(&mut ids, &test_path("proqi-placeholder-space-history"));
+    let session_id = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let thought_id = ids.thought_id();
+    let value = "/tmp/restart.png";
+    let content = format!("α {value} z");
+    let start = "α ".len();
+    let annotation = ContentAnnotation {
+        start,
+        end: start + value.len(),
+        kind: ContentAnnotationKind::Attachment {
+            image: true,
+            display_name: "restart.png".to_owned(),
+        },
+    };
+    let create = reduce(
+        &mut state,
+        Action::CreateThought {
+            thought_id,
+            operation_id: ids.operation_id(),
+            content: content.clone(),
+            annotations: vec![annotation.clone()],
+            insertion_index: None,
+            at: Timestamp::from_millis(2),
+        },
+    )
+    .expect("create");
+    let create = create
+        .iter()
+        .find(|effect| effect.persistence_batch().is_some())
+        .expect("durable create");
+    persist_effect(&mut store, create);
+    drop(store);
+    let mut store = fixture.open();
+    let snapshot = store.load_session(session_id).expect("created reopen");
+    let mut app = BoardApp::new(
+        AppState::from_snapshot(snapshot).expect("rehydrate created thought"),
+        RopeEditorFactory,
+    );
+    let clock = FakeClock::new(Timestamp::from_millis(3));
+    select_restart_placeholder(&mut app, &mut ids, &clock);
+    let effects = app.handle(UiInput::Key(UiKey::UnmodifiedSpace), &mut ids, &clock);
+    let [Effect::CommitRevision(revision)] = effects.as_slice() else {
+        panic!("one placeholder Space revision");
+    };
+    assert_eq!(revision.after_content, format!("α  {value} z"));
+    assert_eq!(revision.after_annotations[0].start, start + 1);
+    persist_effect(&mut store, &effects[0]);
+    drop(store);
+    assert_placeholder_history_restarts(
+        &fixture,
+        &mut ids,
+        session_id,
+        thought_id,
+        &content,
+        &annotation,
+        &format!("α  {value} z"),
+    );
+}
+
+fn select_restart_placeholder(app: &mut BoardApp, ids: &mut FakeIdGenerator, clock: &FakeClock) {
+    app.handle(UiInput::Key(UiKey::Enter), ids, clock);
+    app.handle(
+        UiInput::Key(UiKey::Move {
+            movement: CursorMovement::DocumentStart,
+            extend_selection: false,
+        }),
+        ids,
+        clock,
+    );
+    for _ in 0..2 {
+        app.handle(
+            UiInput::Key(UiKey::Move {
+                movement: CursorMovement::GraphemeForward,
+                extend_selection: false,
+            }),
+            ids,
+            clock,
+        );
+    }
+}
+
+fn assert_placeholder_history_restarts(
+    fixture: &DatabaseFixture,
+    ids: &mut FakeIdGenerator,
+    session_id: proqi::domain::SessionId,
+    thought_id: ThoughtId,
+    content: &str,
+    annotation: &ContentAnnotation,
+    moved_content: &str,
+) {
+    let mut store = fixture.open();
+    let snapshot = store.load_session(session_id).expect("edited reopen");
+    let edited = snapshot.board.thought(thought_id).expect("edited thought");
+    assert_eq!(edited.content, moved_content);
+    assert_eq!(edited.annotations[0].start, annotation.start + 1);
+    let mut state = AppState::from_snapshot(snapshot).expect("rehydrate edited history");
+    let undo = reduce(
+        &mut state,
+        Action::Undo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Editor { thought_id },
+            at: Timestamp::from_millis(4),
+        },
+    )
+    .expect("undo");
+    let undo = undo
+        .iter()
+        .find(|effect| effect.persistence_batch().is_some())
+        .expect("durable undo");
+    persist_effect(&mut store, undo);
+    drop(store);
+
+    let mut store = fixture.open();
+    let snapshot = store.load_session(session_id).expect("undo reopen");
+    let undone = snapshot.board.thought(thought_id).expect("undone thought");
+    assert_eq!(undone.content, content);
+    assert_eq!(undone.annotations, vec![annotation.clone()]);
+    state = AppState::from_snapshot(snapshot).expect("rehydrate undone history");
+    let redo = reduce(
+        &mut state,
+        Action::Redo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Editor { thought_id },
+            at: Timestamp::from_millis(5),
+        },
+    )
+    .expect("redo");
+    let redo = redo
+        .iter()
+        .find(|effect| effect.persistence_batch().is_some())
+        .expect("durable redo");
+    persist_effect(&mut store, redo);
+    drop(store);
+
+    let redone = fixture
+        .open()
+        .load_session(session_id)
+        .expect("redo reopen");
+    let redone = redone.board.thought(thought_id).expect("redone thought");
+    assert_eq!(redone.content, moved_content);
+    assert_eq!(redone.annotations[0].start, annotation.start + 1);
+}

--- a/tests/ui_board.rs
+++ b/tests/ui_board.rs
@@ -474,6 +474,8 @@ mod navigation;
 mod palette;
 #[path = "ui_board/placeholder_entry.rs"]
 mod placeholder_entry;
+#[path = "ui_board/placeholder_space.rs"]
+mod placeholder_space;
 #[path = "ui_board/pointer_selection.rs"]
 mod pointer_selection;
 #[path = "ui_board/scroll_regressions.rs"]

--- a/tests/ui_board/placeholder_space.rs
+++ b/tests/ui_board/placeholder_space.rs
@@ -1,0 +1,479 @@
+//! Placeholder-aware Space behavior across semantic projection and durable editing.
+
+use proqi::{
+    application::{DurabilityState, Effect},
+    domain::{ContentAnnotation, ContentAnnotationKind, TextPosition},
+    ports::{
+        attachment_accessibility::{
+            AttachmentAccessFailure, AttachmentCheckBatchResult, AttachmentCheckResult,
+        },
+        editor::CursorMovement,
+    },
+    ui::{PastePayload, PointerButton, PointerKind, ThemePreference, UiInput, UiKey},
+};
+use ratatui_core::layout::Rect;
+use unicode_segmentation::UnicodeSegmentation as _;
+
+use super::{Fixture, draw, draw_theme, snapshot_support::snapshot_buffer, text};
+
+#[path = "placeholder_space/stress.rs"]
+mod stress;
+
+fn substitution(kind: ContentAnnotationKind, start: usize, end: usize) -> ContentAnnotation {
+    ContentAnnotation { start, end, kind }
+}
+
+fn attachment(image: bool) -> ContentAnnotationKind {
+    ContentAnnotationKind::Attachment {
+        image,
+        display_name: if image { "image.png" } else { "context.txt" }.to_owned(),
+    }
+}
+
+fn annotated(prefix: &str, value: &str, suffix: &str, kind: ContentAnnotationKind) -> Fixture {
+    let content = format!("{prefix}{value}{suffix}");
+    Fixture::with_annotated_thought(
+        &content,
+        vec![substitution(kind, prefix.len(), prefix.len() + value.len())],
+    )
+}
+
+fn move_key(movement: CursorMovement, extend_selection: bool) -> UiInput {
+    UiInput::Key(UiKey::Move {
+        movement,
+        extend_selection,
+    })
+}
+
+fn select_forward(fixture: &mut Fixture, prefix: &str) {
+    fixture.input(UiInput::Key(UiKey::Enter));
+    fixture.input(move_key(CursorMovement::DocumentStart, false));
+    for _ in prefix.graphemes(true) {
+        fixture.input(move_key(CursorMovement::GraphemeForward, false));
+    }
+    if fixture
+        .app
+        .editor_snapshot()
+        .expect("editor")
+        .selection
+        .is_none()
+    {
+        fixture.input(move_key(CursorMovement::GraphemeForward, false));
+    }
+    assert!(
+        fixture
+            .app
+            .editor_snapshot()
+            .expect("editor")
+            .selection
+            .is_some()
+    );
+}
+
+fn select_reverse(fixture: &mut Fixture, suffix: &str) {
+    fixture.input(UiInput::Key(UiKey::Enter));
+    fixture.input(move_key(CursorMovement::DocumentEnd, false));
+    for _ in suffix.graphemes(true) {
+        fixture.input(move_key(CursorMovement::GraphemeBack, false));
+    }
+    if fixture
+        .app
+        .editor_snapshot()
+        .expect("editor")
+        .selection
+        .is_none()
+    {
+        fixture.input(move_key(CursorMovement::GraphemeBack, false));
+    }
+    assert!(
+        fixture
+            .app
+            .editor_snapshot()
+            .expect("editor")
+            .selection
+            .is_some()
+    );
+}
+
+fn space_revision(fixture: &mut Fixture) -> proqi::domain::ThoughtRevision {
+    let effects = fixture.effects(UiInput::Key(UiKey::UnmodifiedSpace));
+    let [Effect::CommitRevision(revision)] = effects.as_slice() else {
+        panic!("expected one durable revision, got {effects:?}");
+    };
+    revision.clone()
+}
+
+fn assert_shifted(
+    fixture: &Fixture,
+    revision: &proqi::domain::ThoughtRevision,
+    before: &str,
+    expected: &str,
+    old_start: usize,
+) {
+    assert_eq!(revision.before_content, before);
+    assert_eq!(revision.after_content, expected);
+    assert_eq!(revision.before_annotations.len(), 1);
+    assert_eq!(revision.after_annotations.len(), 1);
+    assert_eq!(
+        revision.after_annotations[0].kind,
+        revision.before_annotations[0].kind
+    );
+    assert_eq!(revision.after_annotations[0].start, old_start + 1);
+    assert_eq!(
+        revision.after_annotations[0].end,
+        revision.before_annotations[0].end + 1
+    );
+    let snapshot = fixture.app.editor_snapshot().expect("editor");
+    assert_eq!(snapshot.content, expected);
+    assert_eq!(snapshot.selection, None);
+    assert_eq!(
+        snapshot.cursor,
+        TextPosition::new(0, expected[..=old_start].graphemes(true).count())
+    );
+}
+
+#[test]
+fn beginning_middle_end_and_reversed_placeholders_shift_exactly_once() {
+    for (prefix, value, suffix, reverse) in [
+        ("", "/tmp/start.png", " tail", false),
+        ("Grüße ", "/tmp/middle.png", "\r\n界", false),
+        ("head\t", "/tmp/end.png", "", true),
+    ] {
+        let before = format!("{prefix}{value}{suffix}");
+        let expected = format!("{prefix} {value}{suffix}");
+        let mut fixture = annotated(prefix, value, suffix, attachment(true));
+        if reverse {
+            select_reverse(&mut fixture, suffix);
+        } else {
+            select_forward(&mut fixture, prefix);
+        }
+        let revision = space_revision(&mut fixture);
+        assert_shifted(&fixture, &revision, &before, &expected, prefix.len());
+    }
+}
+
+#[test]
+fn every_substitution_kind_and_adjacent_placeholders_use_the_same_projection_rule() {
+    let kinds = [
+        attachment(true),
+        attachment(false),
+        ContentAnnotationKind::LargePaste {
+            lines: 14,
+            graphemes: 1_234,
+        },
+        ContentAnnotationKind::InvocationReference {
+            display_name: "@reviewer · codex".to_owned(),
+        },
+    ];
+    for kind in kinds {
+        let mut fixture = annotated("before", "\t\0e\u{301}👩🏽‍💻\r\n", "after", kind);
+        select_forward(&mut fixture, "before");
+        let revision = space_revision(&mut fixture);
+        assert_eq!(revision.after_content, "before \t\0e\u{301}👩🏽‍💻\r\nafter");
+        assert_eq!(revision.after_annotations[0].start, "before ".len());
+    }
+
+    let first = "/tmp/one.png";
+    let second = "/tmp/two.png";
+    let content = format!("{first}{second}");
+    let mut fixture = Fixture::with_annotated_thought(
+        &content,
+        vec![
+            substitution(attachment(true), 0, first.len()),
+            substitution(attachment(true), first.len(), content.len()),
+        ],
+    );
+    select_reverse(&mut fixture, "");
+    let revision = space_revision(&mut fixture);
+    assert_eq!(revision.after_content, format!("{first} {second}"));
+    assert_eq!(revision.after_annotations[0].start, 0);
+    assert_eq!(revision.after_annotations[1].start, first.len() + 1);
+}
+
+#[test]
+fn repeated_space_keeps_the_placeholder_and_ordinary_followup_spaces() {
+    let value = "/tmp/repeat.png";
+    let mut fixture = annotated("", value, "", attachment(true));
+    select_forward(&mut fixture, "");
+    let first = space_revision(&mut fixture);
+    assert_eq!(first.after_content, format!(" {value}"));
+    assert!(
+        fixture
+            .effects(UiInput::Key(UiKey::UnmodifiedSpace))
+            .is_empty()
+    );
+    assert!(
+        fixture
+            .effects(UiInput::Key(UiKey::UnmodifiedSpace))
+            .is_empty()
+    );
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("editor").content,
+        format!("   {value}")
+    );
+    let followup = fixture
+        .app
+        .flush_pending_edit(&mut fixture.ids, &fixture.clock);
+    let [Effect::CommitRevision(revision)] = followup.as_slice() else {
+        panic!("ordinary spaces coalesce through the existing typing policy");
+    };
+    assert_eq!(revision.before_content, format!(" {value}"));
+    assert_eq!(revision.after_content, format!("   {value}"));
+}
+
+#[test]
+fn delete_backspace_enter_replacement_and_paste_keep_existing_semantics() {
+    for key in [UiKey::Delete, UiKey::Backspace] {
+        let mut fixture = annotated("a", "TOKEN", "z", attachment(false));
+        select_forward(&mut fixture, "a");
+        fixture.input(UiInput::Key(key));
+        let effects = fixture
+            .app
+            .flush_pending_edit(&mut fixture.ids, &fixture.clock);
+        let [Effect::CommitRevision(revision)] = effects.as_slice() else {
+            panic!("one deletion revision");
+        };
+        assert_eq!(revision.after_content, "az");
+        assert!(revision.after_annotations.is_empty());
+    }
+
+    let mut entered = annotated("a", "TOKEN", "z", attachment(false));
+    select_forward(&mut entered, "a");
+    assert!(entered.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    assert_eq!(
+        entered.app.editor_snapshot().expect("editor").content,
+        "aTOKENz"
+    );
+    assert!(text(draw(&mut entered, 40, 8).backend().buffer()).contains("TOKEN"));
+
+    for input in [
+        UiInput::Key(UiKey::Character('x')),
+        UiInput::Key(UiKey::Character(' ')),
+        UiInput::Paste("first\r\nsecond".to_owned()),
+    ] {
+        let mut fixture = annotated("a", "TOKEN", "z", attachment(false));
+        select_forward(&mut fixture, "a");
+        let mut effects = fixture.effects(input);
+        if effects.is_empty() {
+            effects = fixture
+                .app
+                .flush_pending_edit(&mut fixture.ids, &fixture.clock);
+        }
+        assert!(
+            fixture
+                .app
+                .editor_snapshot()
+                .expect("editor")
+                .selection
+                .is_none()
+        );
+        let [Effect::CommitRevision(revision)] = effects.as_slice() else {
+            panic!("one replacement revision");
+        };
+        assert!(revision.after_annotations.is_empty());
+    }
+}
+
+#[test]
+fn partial_wide_multi_expanded_inline_and_plain_selections_are_not_eligible() {
+    let mut partial = annotated("", "TOKEN", "", attachment(false));
+    partial.input(UiInput::Key(UiKey::Enter));
+    partial.input(move_key(CursorMovement::DocumentStart, false));
+    partial.input(move_key(CursorMovement::GraphemeForward, true));
+    partial.input(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert_eq!(
+        partial.app.editor_snapshot().expect("editor").content,
+        " OKEN"
+    );
+    let partial = partial
+        .app
+        .flush_pending_edit(&mut partial.ids, &partial.clock);
+    let [Effect::CommitRevision(partial)] = partial.as_slice() else {
+        panic!("partial selection follows ordinary replacement");
+    };
+    assert!(partial.after_annotations.is_empty());
+
+    let first = "ONE";
+    let second = "TWO";
+    let mut wide = Fixture::with_annotated_thought(
+        "pONEmTWOs",
+        vec![
+            substitution(attachment(false), 1, 1 + first.len()),
+            substitution(attachment(false), 5, 5 + second.len()),
+        ],
+    );
+    wide.input(UiInput::Key(UiKey::Enter));
+    wide.input(move_key(CursorMovement::DocumentStart, false));
+    wide.input(move_key(CursorMovement::DocumentEnd, true));
+    wide.input(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert_eq!(wide.app.editor_snapshot().expect("editor").content, " ");
+
+    let mut expanded = annotated("", "TOKEN", "", attachment(false));
+    select_forward(&mut expanded, "");
+    expanded.input(UiInput::Key(UiKey::Enter));
+    expanded.input(move_key(CursorMovement::DocumentStart, false));
+    expanded.input(move_key(CursorMovement::DocumentEnd, true));
+    expanded.input(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert_eq!(expanded.app.editor_snapshot().expect("editor").content, " ");
+
+    let inline: ContentAnnotation = serde_json::from_value(serde_json::json!({
+        "start": 0, "end": 5, "kind": { "kind": "shortcut_emphasis" }
+    }))
+    .expect("inline fixture");
+    for (content, annotations) in [
+        ("Enter", vec![inline]),
+        ("[Image 1]", Vec::new()),
+        ("https://example.test", Vec::new()),
+    ] {
+        let mut fixture = Fixture::with_annotated_thought(content, annotations);
+        fixture.input(UiInput::Key(UiKey::Enter));
+        fixture.input(UiInput::Key(UiKey::SelectAll));
+        fixture.input(UiInput::Key(UiKey::UnmodifiedSpace));
+        assert_eq!(fixture.app.editor_snapshot().expect("editor").content, " ");
+    }
+}
+
+#[test]
+fn board_compose_and_search_retain_their_space_behavior() {
+    let mut board =
+        Fixture::with_annotated_thought("TOKEN", vec![substitution(attachment(false), 0, 5)]);
+    assert!(
+        board
+            .effects(UiInput::Key(UiKey::UnmodifiedSpace))
+            .is_empty()
+    );
+    assert!(
+        board
+            .app
+            .thought_selected(board.app.state.board.live_thoughts()[0].id)
+    );
+
+    let mut compose = Fixture::new();
+    let effects = compose.effects(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert!(matches!(
+        effects.as_slice(),
+        [Effect::CommitBoardOperation(_)]
+    ));
+    assert_eq!(compose.app.editor_snapshot().expect("editor").content, " ");
+
+    let mut search = Fixture::new();
+    search.paste("alpha beta");
+    search.input(UiInput::Key(UiKey::Escape));
+    search.input(UiInput::Key(UiKey::Character('/')));
+    search.input(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert_eq!(search.app.search_view().expect("search").0, " ");
+}
+
+#[test]
+fn inaccessible_mouse_selection_survives_resize_and_shifts_without_recheck() {
+    let path = "/tmp/placeholder-space-missing.png";
+    let mut fixture = Fixture::new();
+    let insertion = fixture.effects(UiInput::PasteAnnotated(
+        PastePayload::annotated(
+            path.to_owned(),
+            vec![substitution(attachment(true), 0, path.len())],
+        )
+        .expect("payload"),
+    ));
+    let batch = insertion
+        .iter()
+        .find_map(|effect| match effect {
+            Effect::CheckAttachments(batch) => Some(batch.clone()),
+            _ => None,
+        })
+        .expect("attachment check");
+    fixture
+        .app
+        .complete_attachment_checks(AttachmentCheckBatchResult {
+            id: batch.id,
+            purpose: batch.purpose,
+            results: batch
+                .checks
+                .into_iter()
+                .map(|key| AttachmentCheckResult {
+                    key,
+                    result: Err(AttachmentAccessFailure::Missing),
+                })
+                .collect(),
+        });
+    let _wide = draw_theme(&mut fixture, 60, 8, ThemePreference::Dark);
+    let area = fixture.app.prepare_frame(Rect::new(0, 0, 60, 8)).thoughts[0].text_area;
+    fixture.pointer(area.x + 2, area.y, PointerKind::Down(PointerButton::Left));
+    fixture.input(UiInput::Resize {
+        width: 22,
+        height: 5,
+    });
+    let _narrow = draw_theme(&mut fixture, 22, 5, ThemePreference::Dark);
+    let effects = fixture.effects(UiInput::Key(UiKey::UnmodifiedSpace));
+    assert!(
+        effects
+            .iter()
+            .all(|effect| !matches!(effect, Effect::CheckAttachments(_)))
+    );
+    let [Effect::CommitRevision(revision)] = effects.as_slice() else {
+        panic!("one shifted revision");
+    };
+    assert_eq!(revision.after_content, format!(" {path}"));
+    let rendered = text(draw(&mut fixture, 40, 8).backend().buffer());
+    assert!(rendered.contains("[Image 1 · inaccessible]"));
+}
+
+#[test]
+fn failure_retry_undo_and_redo_keep_one_revision_and_exact_metadata() {
+    let value = "/tmp/history.png";
+    let mut fixture = annotated("a", value, "z", attachment(true));
+    select_forward(&mut fixture, "a");
+    let revision = space_revision(&mut fixture);
+    fixture
+        .app
+        .acknowledge_persistence(revision.sequence, false);
+    assert!(matches!(
+        fixture.app.state.durability,
+        DurabilityState::Failed { .. }
+    ));
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("editor").content,
+        format!("a {value}z")
+    );
+    assert_eq!(
+        fixture.effects(UiInput::Key(UiKey::Character('r'))),
+        vec![Effect::RetryPersistence {
+            sequence: revision.sequence,
+        }]
+    );
+    fixture.app.acknowledge_persistence(revision.sequence, true);
+
+    let undo = fixture.effects(UiInput::Key(UiKey::Undo));
+    assert!(matches!(
+        undo.as_slice(),
+        [Effect::CommitHistoryMove { undo: true, .. }]
+    ));
+    assert_eq!(
+        fixture.app.state.board.live_thoughts()[0].content,
+        format!("a{value}z")
+    );
+    let undo_sequence = undo[0]
+        .persistence_batch()
+        .and_then(|batch| batch.sequence())
+        .expect("undo sequence");
+    fixture.app.acknowledge_persistence(undo_sequence, true);
+    let redo = fixture.effects(UiInput::Key(UiKey::Redo));
+    assert!(matches!(
+        redo.as_slice(),
+        [Effect::CommitHistoryMove { undo: false, .. }]
+    ));
+    assert_eq!(
+        fixture.app.state.board.live_thoughts()[0].content,
+        format!("a {value}z")
+    );
+}
+
+#[test]
+fn shifted_placeholder_has_a_reviewed_narrow_editor_snapshot() {
+    let value = "/tmp/snapshot.png";
+    let mut fixture = annotated("before ", value, " after", attachment(true));
+    select_forward(&mut fixture, "before ");
+    let _revision = space_revision(&mut fixture);
+    let terminal = draw_theme(&mut fixture, 32, 7, ThemePreference::Dark);
+    insta::assert_snapshot!(snapshot_buffer(terminal.backend().buffer()));
+}

--- a/tests/ui_board/placeholder_space/stress.rs
+++ b/tests/ui_board/placeholder_space/stress.rs
@@ -1,0 +1,77 @@
+//! Large-content and mixed-collapse-state placeholder Space regressions.
+
+use unicode_segmentation::UnicodeSegmentation as _;
+
+use super::{
+    ContentAnnotationKind, CursorMovement, Fixture, UiInput, UiKey, annotated, assert_shifted,
+    attachment, draw, move_key, select_forward, space_revision, substitution, text,
+};
+
+#[test]
+fn space_preserves_an_expanded_sibling_while_shifting_the_collapsed_target() {
+    let expanded = "/tmp/expanded.png";
+    let collapsed = "/tmp/collapsed.txt";
+    let content = format!("{expanded}|{collapsed}");
+    let second_start = expanded.len() + 1;
+    let mut fixture = Fixture::with_annotated_thought(
+        &content,
+        vec![
+            substitution(attachment(true), 0, expanded.len()),
+            substitution(attachment(false), second_start, content.len()),
+        ],
+    );
+    select_forward(&mut fixture, "");
+    fixture.input(UiInput::Key(UiKey::Enter));
+    assert!(text(draw(&mut fixture, 42, 7).backend().buffer()).contains(expanded));
+
+    fixture.input(move_key(CursorMovement::DocumentEnd, false));
+    fixture.input(move_key(CursorMovement::GraphemeBack, false));
+    let revision = space_revision(&mut fixture);
+    assert_eq!(revision.after_content, format!("{expanded}| {collapsed}"));
+    assert_eq!(revision.after_annotations[0].start, 0);
+    assert_eq!(revision.after_annotations[1].start, second_start + 1);
+    let rendered = text(draw(&mut fixture, 42, 7).backend().buffer());
+    assert!(rendered.contains(expanded), "{rendered:?}");
+    assert!(!rendered.contains(collapsed), "{rendered:?}");
+    assert!(rendered.contains("[File "), "{rendered:?}");
+}
+
+#[test]
+fn threshold_sized_large_paste_keeps_exact_bytes_range_and_cursor_after_resize() {
+    let line = "界e\u{301}\t[]{}".repeat(30);
+    let value = (0..12)
+        .map(|index| format!("{index:02}:{line}"))
+        .collect::<Vec<_>>()
+        .join("\r\n");
+    let graphemes = value.graphemes(true).count();
+    assert!(graphemes >= 1_200);
+    let prefix = "α ";
+    let suffix = "\r\nΩ";
+    let mut fixture = annotated(
+        prefix,
+        &value,
+        suffix,
+        ContentAnnotationKind::LargePaste {
+            lines: 12,
+            graphemes,
+        },
+    );
+    select_forward(&mut fixture, prefix);
+    fixture.input(UiInput::Resize {
+        width: 18,
+        height: 5,
+    });
+    let before_resize = text(draw(&mut fixture, 18, 5).backend().buffer());
+    assert!(before_resize.contains("characters]"), "{before_resize:?}");
+
+    let before = format!("{prefix}{value}{suffix}");
+    let expected = format!("{prefix} {value}{suffix}");
+    let revision = space_revision(&mut fixture);
+    assert_shifted(&fixture, &revision, &before, &expected, prefix.len());
+    assert_eq!(
+        revision.after_annotations[0].end,
+        prefix.len() + 1 + value.len()
+    );
+    let after_resize = text(draw(&mut fixture, 18, 5).backend().buffer());
+    assert!(after_resize.contains("[Pasted text"), "{after_resize:?}");
+}

--- a/tests/ui_board/snapshots/ui_board__placeholder_space__shifted_placeholder_has_a_reviewed_narrow_editor_snapshot.snap
+++ b/tests/ui_board/snapshots/ui_board__placeholder_space__shifted_placeholder_has_a_reviewed_narrow_editor_snapshot.snap
@@ -1,0 +1,24 @@
+---
+source: tests/ui_board/placeholder_space.rs
+assertion_line: 475
+expression: snapshot_buffer(terminal.backend().buffer())
+---
+SIZE 32x7
+
+TEXT
+00││
+01│⋮ before  [Image 1 ·│
+02│  inaccessible] after│
+03││
+04│  proqi-ui-annotated-contract│
+05│  1 thought · edit · saving│
+06│  Esc Board│
+
+STYLE RUNS
+0: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-9 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 10-20 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 21-31 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+2: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-14 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 15-31 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+3: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-29 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 30-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+6: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-4 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 5-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE


### PR DESCRIPTION
## Summary

This resolves exact collapsed substitution selections through the canonical editor presentation. Unmodified Space inserts one ASCII space before the selected placeholder as one durable revision while preserving metadata and sibling expansion state.

Modified Space, replacement, deletion, expansion, paste, query, overlay, Board, Compose, and browser behavior remain unchanged.

Focused coverage includes editor mutation, UI projection, every substitution kind, selection boundaries, large content, SQLite restart, persistence failure and retry, real PTY input, undo, redo, and a manually reviewed narrow snapshot.

## Verification

`cargo xtask check`

`cargo xtask audit`

`cargo xtask package`

`cargo xtask test-pty`

Live topic binary stress covered all substitution kinds, beginning and end boundaries, neighboring prose and placeholders, forward, reverse, partial, and wider selections, repeated Space, Delete, Backspace, Enter, ordinary replacement, paste, inaccessible attachments, Unicode, large content, narrow and shallow resize, keyboard and mouse selection, persistence failure and retry, restart, undo, and redo.