### PR TITLE
Stabilize concurrent initialized startup

### DIFF
--- a/src/adapters/sqlite/mod.rs
+++ b/src/adapters/sqlite/mod.rs
@@ -15,6 +15,9 @@ mod session_admin;
 mod submission;
 mod support;
 
+#[cfg(test)]
+mod tests;
+
 pub use doctor::{SqliteHealth, inspect_read_only_snapshot};
 
 use std::{path::PathBuf, thread, time::Duration};

--- a/src/adapters/sqlite/tests.rs
+++ b/src/adapters/sqlite/tests.rs
@@ -1,0 +1,89 @@
+//! Deterministic transaction-boundary contention tests.
+
+use std::time::Duration;
+
+use tempfile::tempdir;
+
+use crate::{
+    adapters::memory::FakeIdGenerator,
+    domain::{Session, Timestamp},
+    ports::{
+        environment::IdGenerator,
+        store::{MigrationMode, OperationBatch, StoreError},
+    },
+};
+
+use super::{RetryPolicy, SqliteStore, StoreConfig, board_commit::commit_batch};
+
+#[test]
+fn transient_busy_retries_whole_session_transaction_without_duplication() {
+    let temporary = tempdir().expect("temporary state root");
+    let mut config = StoreConfig::new(
+        temporary.path().join("data/proqi.sqlite3"),
+        temporary.path().join("backups"),
+        MigrationMode::Allow,
+        Timestamp::from_millis(1),
+    );
+    config.retry = RetryPolicy {
+        busy_timeout: Duration::from_millis(1),
+        max_attempts: 2,
+        base_delay: Duration::ZERO,
+        jitter_seed: 1,
+    };
+    let mut store = SqliteStore::open(&config).expect("open store");
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let session = Session::new(
+        ids.session_id(),
+        temporary.path().to_path_buf(),
+        Timestamp::from_millis(2),
+    )
+    .expect("session");
+    let session_id = session.id;
+    let batch = OperationBatch::CreateSession(session);
+    let mut attempts = 0;
+
+    let receipt = store.with_write_retry(|transaction| {
+        attempts += 1;
+        let receipt = commit_batch(transaction, &batch)?;
+        if attempts == 1 {
+            return Err(StoreError::Busy);
+        }
+        Ok(receipt)
+    });
+
+    assert_eq!(receipt, Ok(None));
+    assert_eq!(attempts, 2);
+    let session_rows: i64 = store
+        .connection
+        .query_row("SELECT count(*) FROM sessions", [], |row| row.get(0))
+        .expect("session rows");
+    let search_rows: i64 = store
+        .connection
+        .query_row(
+            "SELECT count(*) FROM session_search WHERE session_id = ?1",
+            [session_id.to_string()],
+            |row| row.get(0),
+        )
+        .expect("search rows");
+    let total_search_rows: i64 = store
+        .connection
+        .query_row("SELECT count(*) FROM session_search", [], |row| row.get(0))
+        .expect("total search rows");
+    assert_eq!(session_rows, 1);
+    assert_eq!(search_rows, 1);
+    assert_eq!(total_search_rows, 1);
+    for table in [
+        "thoughts",
+        "board_operations",
+        "thought_revisions",
+        "commit_receipts",
+    ] {
+        let rows: i64 = store
+            .connection
+            .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .expect("fresh-session side table");
+        assert_eq!(rows, 0, "fresh session unexpectedly populated {table}");
+    }
+}

--- a/src/adapters/sqlite/tests.rs
+++ b/src/adapters/sqlite/tests.rs
@@ -87,3 +87,44 @@ fn transient_busy_retries_whole_session_transaction_without_duplication() {
         assert_eq!(rows, 0, "fresh session unexpectedly populated {table}");
     }
 }
+
+#[test]
+fn persistent_busy_stops_after_production_attempt_bound_without_partial_state() {
+    let temporary = tempdir().expect("temporary state root");
+    let mut config = StoreConfig::new(
+        temporary.path().join("data/proqi.sqlite3"),
+        temporary.path().join("backups"),
+        MigrationMode::Allow,
+        Timestamp::from_millis(1),
+    );
+    config.retry.jitter_seed = 1;
+    let expected_attempts = config.retry.max_attempts;
+    let mut store = SqliteStore::open(&config).expect("open store");
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let session = Session::new(
+        ids.session_id(),
+        temporary.path().to_path_buf(),
+        Timestamp::from_millis(2),
+    )
+    .expect("session");
+    let batch = OperationBatch::CreateSession(session);
+    let mut attempts = 0;
+
+    let receipt = store.with_write_retry(|transaction| {
+        attempts += 1;
+        let _receipt = commit_batch(transaction, &batch)?;
+        Err::<Option<crate::ports::store::CommitReceipt>, _>(StoreError::Busy)
+    });
+
+    assert_eq!(receipt, Err(StoreError::Busy));
+    assert_eq!(attempts, expected_attempts);
+    for table in ["sessions", "session_search"] {
+        let rows: i64 = store
+            .connection
+            .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .expect("persistent-busy table");
+        assert_eq!(rows, 0, "persistent busy left partial state in {table}");
+    }
+}

--- a/src/application/service/sessions.rs
+++ b/src/application/service/sessions.rs
@@ -14,6 +14,9 @@ use crate::{
 
 use super::{LeasedSession, SessionService, SessionServiceError};
 
+#[cfg(test)]
+mod tests;
+
 impl<S, R, C, I> SessionService<'_, S, R, C, I>
 where
     S: Store,
@@ -186,18 +189,20 @@ where
         &mut self,
         id: SessionId,
         lease: R::SessionLease,
-        record_open: bool,
+        resuming: bool,
     ) -> Result<LeasedSession<R::SessionLease>, SessionServiceError> {
-        self.store.compact_session(id)?;
+        if resuming {
+            self.store.compact_session(id)?;
+        }
         let snapshot = self.store.load_session(id)?;
         if snapshot.board.session.deleted_at.is_some() {
             return Err(SessionServiceError::SessionTrashed(id));
         }
-        if record_open {
+        if resuming {
             self.store
                 .record_session_open(id, &self.cwd, self.clock.now())?;
         }
-        let snapshot = if record_open {
+        let snapshot = if resuming {
             self.store.load_session(id)?
         } else {
             snapshot

--- a/src/application/service/sessions/tests.rs
+++ b/src/application/service/sessions/tests.rs
@@ -1,0 +1,181 @@
+//! Fresh and resumed session load policy.
+
+use std::path::{Path, PathBuf};
+
+use crate::{
+    application::test_support::{TestClock, TestIds},
+    domain::{OperationId, RevisionId, Session, SessionBoard, SessionId, Timestamp},
+    ports::{
+        runtime::{Lease, RuntimeCoordinator, RuntimeError, RuntimeScan},
+        store::{
+            CommitReceipt, OperationBatch, SessionHit, SessionQuery, SessionSnapshot, Store,
+            StoreError, StoredOperationRequest,
+        },
+    },
+};
+
+use super::{SessionService, SessionServiceError};
+
+#[derive(Default)]
+struct BusyCompactionStore {
+    session: Option<Session>,
+    compact_calls: usize,
+}
+
+impl Store for BusyCompactionStore {
+    fn load_session(&mut self, id: SessionId) -> Result<SessionSnapshot, StoreError> {
+        let session = self
+            .session
+            .as_ref()
+            .filter(|session| session.id == id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))?;
+        let board = SessionBoard::new(session, Vec::new())
+            .map_err(|error| StoreError::Invariant(error.to_string()))?;
+        Ok(SessionSnapshot {
+            board,
+            board_operations: Vec::new(),
+            board_history_cursor: 0,
+            revisions: Vec::new(),
+            editor_history_cursors: Vec::new(),
+            integration_context: None,
+        })
+    }
+
+    fn compact_session(&mut self, _id: SessionId) -> Result<(), StoreError> {
+        self.compact_calls += 1;
+        Err(StoreError::Busy)
+    }
+
+    fn search_sessions(&mut self, _query: &SessionQuery) -> Result<Vec<SessionHit>, StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn record_session_open(
+        &mut self,
+        _id: SessionId,
+        _cwd: &Path,
+        _at: Timestamp,
+    ) -> Result<(), StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn rename_session(&mut self, _id: SessionId, _name: Option<&str>) -> Result<(), StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn operation_request(
+        &mut self,
+        _id: OperationId,
+    ) -> Result<Option<StoredOperationRequest>, StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn revision_request(
+        &mut self,
+        _id: RevisionId,
+    ) -> Result<Option<StoredOperationRequest>, StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn commit(&mut self, batch: &OperationBatch) -> Result<Option<CommitReceipt>, StoreError> {
+        let OperationBatch::CreateSession(session) = batch else {
+            return Err(unused_store_call());
+        };
+        self.session = Some(session.clone());
+        Ok(None)
+    }
+
+    fn trash_session(&mut self, _id: SessionId, _at: Timestamp) -> Result<(), StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn restore_session(&mut self, _id: SessionId) -> Result<(), StoreError> {
+        Err(unused_store_call())
+    }
+
+    fn prune_session(&mut self, _id: SessionId) -> Result<(), StoreError> {
+        Err(unused_store_call())
+    }
+}
+
+fn unused_store_call() -> StoreError {
+    StoreError::Invariant("unexpected store call in session load policy test".to_owned())
+}
+
+#[derive(Clone, Copy)]
+struct TestLease;
+
+impl Lease for TestLease {}
+
+struct TestRuntime;
+
+impl RuntimeCoordinator for TestRuntime {
+    type SessionLease = TestLease;
+    type SharedSchemaLease = TestLease;
+    type ExclusiveSchemaLease = TestLease;
+
+    fn acquire_session(&self, _session_id: SessionId) -> Result<TestLease, RuntimeError> {
+        Ok(TestLease)
+    }
+
+    fn acquire_schema_shared(&self) -> Result<TestLease, RuntimeError> {
+        Ok(TestLease)
+    }
+
+    fn acquire_schema_exclusive(&self) -> Result<TestLease, RuntimeError> {
+        Ok(TestLease)
+    }
+
+    fn scan_runtime(&self) -> Result<RuntimeScan, RuntimeError> {
+        Ok(RuntimeScan::default())
+    }
+}
+
+fn test_directory() -> PathBuf {
+    std::env::temp_dir().join("proqi-session-load-policy")
+}
+
+#[test]
+fn fresh_session_load_skips_unnecessary_compaction() {
+    let mut store = BusyCompactionStore::default();
+    let runtime = TestRuntime;
+    let clock = TestClock(Timestamp::from_millis(1));
+    let mut ids = TestIds::new(1_725_000_000_000);
+    let session = SessionService::new(&mut store, &runtime, &clock, &mut ids, test_directory())
+        .expect("service")
+        .create_session()
+        .expect("fresh session");
+
+    assert_eq!(store.compact_calls, 0);
+    assert_eq!(session.state.board.live_thoughts().len(), 0);
+}
+
+#[test]
+fn resumed_session_retains_history_compaction() {
+    let mut store = BusyCompactionStore::default();
+    let runtime = TestRuntime;
+    let clock = TestClock(Timestamp::from_millis(1));
+    let mut ids = TestIds::new(1_725_000_000_000);
+    let session_id = {
+        let mut service =
+            SessionService::new(&mut store, &runtime, &clock, &mut ids, test_directory())
+                .expect("service");
+        service
+            .create_session()
+            .expect("fresh session")
+            .state
+            .board
+            .session
+            .id
+    };
+    let resumed = SessionService::new(&mut store, &runtime, &clock, &mut ids, test_directory())
+        .expect("service")
+        .resume(session_id);
+
+    assert!(matches!(
+        resumed,
+        Err(SessionServiceError::Store(StoreError::Busy))
+    ));
+    assert_eq!(store.compact_calls, 1);
+}

--- a/tests/startup_concurrency.rs
+++ b/tests/startup_concurrency.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::BTreeSet,
     path::Path,
-    process::{Command, Output, Stdio},
+    process::{Child, Command, Output, Stdio},
     sync::{Arc, Barrier},
     time::{Duration, Instant},
 };
@@ -24,17 +24,21 @@ const FRESH_PARTICIPANTS: usize = 5;
 const FRESH_REPETITIONS: usize = 3;
 const INITIALIZED_PARTICIPANTS: usize = 15;
 
-fn launch(root: &Path) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_proqi"))
+fn command(root: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_proqi"));
+    command
         .arg("--state-dir")
         .arg(root)
         .arg("--json")
         .env_remove("HERDR_ENV")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .expect("launch Proqi")
+        .stderr(Stdio::piped());
+    command
+}
+
+fn launch(root: &Path) -> Output {
+    command(root).output().expect("launch Proqi")
 }
 
 fn launch_together(root: &Path, participants: usize) -> Vec<Output> {
@@ -117,6 +121,27 @@ fn assert_runtime_clean(root: &Path) {
     assert_no_transient_runtime_artifacts(&root.join("runtime"));
 }
 
+fn wait_for_runtime_advertisement(root: &Path, child: &mut Child) {
+    let instances = root.join("runtime/instances");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let advertised =
+            std::fs::read_dir(&instances).is_ok_and(|mut entries| entries.next().is_some());
+        if advertised {
+            return;
+        }
+        assert!(
+            child.try_wait().expect("inspect startup process").is_none(),
+            "startup exited before advertising its session lease"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "startup did not advertise its session lease"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
 fn assert_no_transient_runtime_artifacts(root: &Path) {
     let mut pending = vec![root.to_path_buf()];
     while let Some(directory) = pending.pop() {
@@ -171,6 +196,52 @@ fn initialized_schema_accepts_fifteen_concurrent_processes() {
         INITIALIZED_PARTICIPANTS,
         INITIALIZED_PARTICIPANTS + 1,
     );
+}
+
+#[test]
+fn transient_writer_contention_retries_one_session_creation_without_duplication() {
+    let state = tempfile::tempdir().expect("initialized state root");
+    let initial = launch(state.path());
+    assert_successful_sessions(state.path(), &[initial], 1, 1);
+    let writer =
+        Connection::open(state.path().join("data/proqi.sqlite3")).expect("open writer connection");
+    writer
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("acquire writer lock");
+    let mut child = command(state.path()).spawn().expect("spawn startup");
+    wait_for_runtime_advertisement(state.path(), &mut child);
+    std::thread::sleep(Duration::from_millis(300));
+    writer.execute_batch("ROLLBACK").expect("release writer");
+
+    let output = child.wait_with_output().expect("reap startup");
+    assert_successful_sessions(state.path(), &[output], 1, 2);
+}
+
+#[test]
+fn persistent_writer_contention_is_bounded_and_leaves_no_session() {
+    let state = tempfile::tempdir().expect("initialized state root");
+    let initial = launch(state.path());
+    assert_successful_sessions(state.path(), &[initial], 1, 1);
+    let writer =
+        Connection::open(state.path().join("data/proqi.sqlite3")).expect("open writer connection");
+    writer
+        .execute_batch("BEGIN IMMEDIATE")
+        .expect("acquire writer lock");
+    let started = Instant::now();
+    let blocked = launch(state.path());
+    assert!(!blocked.status.success());
+    let response: Value = serde_json::from_slice(&blocked.stdout).expect("failure JSON");
+    assert_eq!(response["error"]["code"], "storage_busy");
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "storage contention exceeded its bounded retry contract"
+    );
+    assert_database(state.path(), 1);
+    assert_runtime_clean(state.path());
+
+    writer.execute_batch("ROLLBACK").expect("release writer");
+    let recovered = launch(state.path());
+    assert_successful_sessions(state.path(), &[recovered], 1, 2);
 }
 
 #[test]

--- a/tests/startup_concurrency.rs
+++ b/tests/startup_concurrency.rs
@@ -10,7 +10,7 @@ use std::{
 
 use proqi::{
     adapters::{memory::FakeIdGenerator, runtime::FileRuntimeCoordinator},
-    domain::Timestamp,
+    domain::{SessionId, Timestamp},
     ports::{
         environment::IdGenerator,
         runtime::RuntimeCoordinator,
@@ -23,6 +23,61 @@ use serde_json::Value;
 const FRESH_PARTICIPANTS: usize = 5;
 const FRESH_REPETITIONS: usize = 3;
 const INITIALIZED_PARTICIPANTS: usize = 15;
+const CHILD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_TERMINATION_TIMEOUT: Duration = Duration::from_secs(2);
+const CHILD_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+struct BoundedChild {
+    child: Option<Child>,
+}
+
+impl BoundedChild {
+    fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        self.child.as_mut().expect("live child").try_wait()
+    }
+
+    fn wait_with_output(mut self) -> Output {
+        let deadline = Instant::now() + CHILD_WAIT_TIMEOUT;
+        loop {
+            if self.try_wait().expect("inspect startup process").is_some() {
+                let child = self.child.take().expect("completed child");
+                return child.wait_with_output().expect("reap startup");
+            }
+            assert!(
+                Instant::now() < deadline,
+                "startup process exceeded its bounded wait"
+            );
+            std::thread::sleep(CHILD_POLL_INTERVAL);
+        }
+    }
+
+    fn terminate(&mut self) {
+        let Some(child) = self.child.as_mut() else {
+            return;
+        };
+        if child.try_wait().is_ok_and(|status| status.is_some()) {
+            return;
+        }
+        let _kill = child.kill();
+        let deadline = Instant::now() + CHILD_TERMINATION_TIMEOUT;
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) | Err(_) => return,
+                Ok(None) => std::thread::sleep(CHILD_POLL_INTERVAL),
+            }
+        }
+    }
+}
+
+impl Drop for BoundedChild {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
 
 fn command(root: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_proqi"));
@@ -63,10 +118,9 @@ fn launch_together(root: &Path, participants: usize) -> Vec<Output> {
 fn assert_successful_sessions(
     root: &Path,
     outputs: &[Output],
-    expected_outputs: usize,
-    expected_total: usize,
-) {
-    let sessions = outputs
+    existing: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let launched = outputs
         .iter()
         .map(|output| {
             assert!(
@@ -82,12 +136,18 @@ fn assert_successful_sessions(
                 .to_owned()
         })
         .collect::<BTreeSet<_>>();
-    assert_eq!(sessions.len(), expected_outputs);
-    assert_database(root, expected_total);
+    assert_eq!(launched.len(), outputs.len());
+    assert!(
+        launched.is_disjoint(existing),
+        "startup reused an existing session identity"
+    );
+    let sessions = existing.union(&launched).cloned().collect();
+    assert_database(root, &sessions);
     assert_runtime_clean(root);
+    sessions
 }
 
-fn assert_database(root: &Path, expected_sessions: usize) {
+fn assert_database(root: &Path, expected_sessions: &BTreeSet<String>) {
     let connection = Connection::open(root.join("data/proqi.sqlite3")).expect("open database");
     let integrity: String = connection
         .query_row("PRAGMA quick_check", [], |row| row.get(0))
@@ -99,16 +159,52 @@ fn assert_database(root: &Path, expected_sessions: usize) {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .expect("schema metadata");
-    let sessions: i64 = connection
-        .query_row("SELECT count(*) FROM sessions", [], |row| row.get(0))
-        .expect("session count");
+    let mut session_statement = connection
+        .prepare("SELECT id FROM sessions ORDER BY id")
+        .expect("prepare session IDs");
+    let sessions = session_statement
+        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .expect("query session IDs")
+        .map(|row| {
+            let bytes: [u8; 16] = row
+                .expect("session ID bytes")
+                .try_into()
+                .expect("session ID length");
+            SessionId::from_database_bytes(bytes)
+                .expect("valid session ID")
+                .to_string()
+        })
+        .collect::<BTreeSet<_>>();
+    let mut search_statement = connection
+        .prepare("SELECT session_id FROM session_search")
+        .expect("prepare search IDs");
+    let search_rows = search_statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query search IDs")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("search ID rows");
     assert_eq!(integrity, "ok");
     assert_eq!(schema, SUPPORTED_SCHEMA_VERSION);
     assert_eq!(protocol, STORAGE_PROTOCOL_VERSION);
-    assert_eq!(
-        sessions,
-        i64::try_from(expected_sessions).expect("session bound")
-    );
+    assert_eq!(&sessions, expected_sessions);
+    assert_eq!(search_rows.len(), expected_sessions.len());
+    assert_eq!(search_rows.into_iter().collect::<BTreeSet<_>>(), sessions);
+    for table in [
+        "thoughts",
+        "board_operations",
+        "thought_revisions",
+        "commit_receipts",
+        "integration_context",
+        "submission_attempts",
+        "screenshot_capture_receipts",
+    ] {
+        let rows: i64 = connection
+            .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .expect("fresh-session side table");
+        assert_eq!(rows, 0, "fresh sessions unexpectedly populated {table}");
+    }
 }
 
 fn assert_runtime_clean(root: &Path) {
@@ -121,7 +217,7 @@ fn assert_runtime_clean(root: &Path) {
     assert_no_transient_runtime_artifacts(&root.join("runtime"));
 }
 
-fn wait_for_runtime_advertisement(root: &Path, child: &mut Child) {
+fn wait_for_runtime_advertisement(root: &Path, child: &mut BoundedChild) {
     let instances = root.join("runtime/instances");
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
@@ -138,7 +234,7 @@ fn wait_for_runtime_advertisement(root: &Path, child: &mut Child) {
             Instant::now() < deadline,
             "startup did not advertise its session lease"
         );
-        std::thread::sleep(Duration::from_millis(5));
+        std::thread::sleep(CHILD_POLL_INTERVAL);
     }
 }
 
@@ -175,12 +271,7 @@ fn concurrent_first_launches_coordinate_schema_initialization() {
     for _ in 0..FRESH_REPETITIONS {
         let state = tempfile::tempdir().expect("fresh state root");
         let outputs = launch_together(state.path(), FRESH_PARTICIPANTS);
-        assert_successful_sessions(
-            state.path(),
-            &outputs,
-            FRESH_PARTICIPANTS,
-            FRESH_PARTICIPANTS,
-        );
+        assert_successful_sessions(state.path(), &outputs, &BTreeSet::new());
     }
 }
 
@@ -188,40 +279,35 @@ fn concurrent_first_launches_coordinate_schema_initialization() {
 fn initialized_schema_accepts_fifteen_concurrent_processes() {
     let state = tempfile::tempdir().expect("initialized state root");
     let initial = launch(state.path());
-    assert_successful_sessions(state.path(), &[initial], 1, 1);
+    let sessions = assert_successful_sessions(state.path(), &[initial], &BTreeSet::new());
     let outputs = launch_together(state.path(), INITIALIZED_PARTICIPANTS);
-    assert_successful_sessions(
-        state.path(),
-        &outputs,
-        INITIALIZED_PARTICIPANTS,
-        INITIALIZED_PARTICIPANTS + 1,
-    );
+    assert_successful_sessions(state.path(), &outputs, &sessions);
 }
 
 #[test]
-fn transient_writer_contention_retries_one_session_creation_without_duplication() {
+fn transient_writer_contention_recovers_without_duplication() {
     let state = tempfile::tempdir().expect("initialized state root");
     let initial = launch(state.path());
-    assert_successful_sessions(state.path(), &[initial], 1, 1);
+    let sessions = assert_successful_sessions(state.path(), &[initial], &BTreeSet::new());
     let writer =
         Connection::open(state.path().join("data/proqi.sqlite3")).expect("open writer connection");
     writer
         .execute_batch("BEGIN IMMEDIATE")
         .expect("acquire writer lock");
-    let mut child = command(state.path()).spawn().expect("spawn startup");
+    let mut child = BoundedChild::new(command(state.path()).spawn().expect("spawn startup"));
     wait_for_runtime_advertisement(state.path(), &mut child);
     std::thread::sleep(Duration::from_millis(300));
     writer.execute_batch("ROLLBACK").expect("release writer");
 
-    let output = child.wait_with_output().expect("reap startup");
-    assert_successful_sessions(state.path(), &[output], 1, 2);
+    let output = child.wait_with_output();
+    assert_successful_sessions(state.path(), &[output], &sessions);
 }
 
 #[test]
 fn persistent_writer_contention_is_bounded_and_leaves_no_session() {
     let state = tempfile::tempdir().expect("initialized state root");
     let initial = launch(state.path());
-    assert_successful_sessions(state.path(), &[initial], 1, 1);
+    let sessions = assert_successful_sessions(state.path(), &[initial], &BTreeSet::new());
     let writer =
         Connection::open(state.path().join("data/proqi.sqlite3")).expect("open writer connection");
     writer
@@ -236,12 +322,12 @@ fn persistent_writer_contention_is_bounded_and_leaves_no_session() {
         started.elapsed() < Duration::from_secs(3),
         "storage contention exceeded its bounded retry contract"
     );
-    assert_database(state.path(), 1);
+    assert_database(state.path(), &sessions);
     assert_runtime_clean(state.path());
 
     writer.execute_batch("ROLLBACK").expect("release writer");
     let recovered = launch(state.path());
-    assert_successful_sessions(state.path(), &[recovered], 1, 2);
+    assert_successful_sessions(state.path(), &[recovered], &sessions);
 }
 
 #[test]
@@ -272,5 +358,5 @@ fn bounded_schema_failure_leaves_no_runtime_advertisement_and_recovers() {
 
     drop(exclusive);
     let recovered = launch(state.path());
-    assert_successful_sessions(state.path(), &[recovered], 1, 1);
+    assert_successful_sessions(state.path(), &[recovered], &BTreeSet::new());
 }

--- a/tests/startup_concurrency.rs
+++ b/tests/startup_concurrency.rs
@@ -313,8 +313,10 @@ fn persistent_writer_contention_is_bounded_and_leaves_no_session() {
     writer
         .execute_batch("BEGIN IMMEDIATE")
         .expect("acquire writer lock");
+    let mut blocked = BoundedChild::new(command(state.path()).spawn().expect("spawn startup"));
+    wait_for_runtime_advertisement(state.path(), &mut blocked);
     let started = Instant::now();
-    let blocked = launch(state.path());
+    let blocked = blocked.wait_with_output();
     assert!(!blocked.status.success());
     let response: Value = serde_json::from_slice(&blocked.stdout).expect("failure JSON");
     assert_eq!(response["error"]["code"], "storage_busy");


### PR DESCRIPTION
## Cause

Fresh startup atomically created its session, then immediately opened a second SQLite write transaction for history compaction before loading the new empty session. Under simultaneous initialized-schema startup, that redundant transaction doubled write admission pressure, could exhaust the bounded contention policy, and could report `storage_busy` after the session was already durable.

## Design

Fresh sessions now load directly after the atomic `CreateSession` commit. Resumed sessions retain history compaction and record-open behavior. WAL, synchronous FULL, the 250 ms busy timeout, four bounded attempts, typed persistent contention, and transaction-level retry semantics are unchanged.

## Evidence

Focused deterministic tests prove fresh startup skips compaction while resume retains it. A SQLite-owner test injects `Busy` after the first transaction has written both the session and FTS row, then proves the complete transaction rolls back and the second attempt persists exactly one clean session. A second owner test proves persistent `Busy` stops after exactly four production attempts with no session or FTS residue.

The real-process oracle compares returned IDs with the exact persisted session and FTS sets. It also proves fresh startups leave thought, history, receipt, integration, submission, screenshot, and runtime side state empty. Spawned contention processes have panic-safe ownership and bounded wait, kill, and reap behavior. Persistent-contention timing starts after runtime advertisement, so the three-second assertion measures SQLite admission rather than unrelated process startup scheduling.

After the review hardening, macOS passed 100 serial cohorts plus 8 parallel workers with 25 cohorts each. That is 300 cohorts and 4,500 simultaneous-start processes using the strengthened oracle. The corrected persistent-lock boundary also passed 200 repetitions across 8 workers. Earlier production qualification passed 600 cohorts and 9,000 processes each on macOS and Linux arm64. A 500-process Linux saturation probe returned 91 successes and 409 truthful `storage_busy` failures; the database contained exactly the initializer plus 91 successful sessions and passed `quick_check`.

`cargo xtask check` passes all 1,088 tests with no leaky-test report. `cargo xtask audit` and `cargo xtask package` pass. The merged Unicode-aware sentence deletion contract remains green. No snapshot changed.

## Integration and risk

Exact base: `517505a7b2a85e3255de20348f014dde0d3b7cb4`

Exact head: `6e56f3f73a76b7633ba11bfea51816ce7d15c397`

The production change removes only an unnecessary fresh-session write. The review follow-up changes tests only. Neither weakens the busy contract nor alters the canonical SQLite owner. Residual platform risk is covered by the required GitHub Linux jobs.