### PR TITLE
Cover physical macOS editor redo

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[[profile.default.overrides]]
+filter = 'test(=editor_persistence::physical_macos_redo_encoding_restores_the_durable_deletion)'
+threads-required = "num-test-threads"

--- a/tests/pty/editor_persistence.rs
+++ b/tests/pty/editor_persistence.rs
@@ -2,6 +2,117 @@
 
 use super::support::{expect_command, json_command};
 
+const ORIGINAL: &str = "This is a test thought.";
+const DELETED: &str = "This is a test";
+
+#[test]
+fn physical_macos_redo_encoding_restores_the_durable_deletion() {
+    let state = tempfile::tempdir().expect("temporary state");
+    let binary = env!("CARGO_BIN_EXE_proqi");
+    create_original_thought(binary, state.path());
+
+    let sessions = json_command(binary, state.path(), &["sessions", "list"]);
+    let session = sessions["data"]["sessions"][0]["id"]
+        .as_str()
+        .expect("session ID");
+    let thoughts = json_command(binary, state.path(), &["thoughts", "list", session]);
+    let thought = thoughts["data"]["thoughts"][0]["id"]
+        .as_str()
+        .expect("thought ID");
+    assert_eq!(thoughts["data"]["thoughts"][0]["content"], ORIGINAL);
+
+    apply_edit_input(
+        binary,
+        state.path(),
+        session,
+        "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f",
+    );
+    assert_persisted_content(binary, state.path(), session, thought, DELETED);
+
+    apply_edit_input(binary, state.path(), session, "\x1b[122;9u");
+    assert_persisted_content(binary, state.path(), session, thought, ORIGINAL);
+
+    apply_edit_input(binary, state.path(), session, "\x1b[122:90;10u");
+    assert_persisted_content(binary, state.path(), session, thought, DELETED);
+}
+
+fn create_original_thought(binary: &str, state: &std::path::Path) {
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set binary $env(PROQI_TEST_BINARY)
+        set state $env(PROQI_TEST_STATE)
+        spawn $binary --state-dir $state
+        expect -exact "\x1b\[?1049h"
+        send -- "\x1b\[200~This is a test thought.\x1b\[201~"
+        after 500
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    run_editor_workflow(script, binary, state, None, None);
+}
+
+fn apply_edit_input(binary: &str, state: &std::path::Path, session: &str, input: &str) {
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set binary $env(PROQI_TEST_BINARY)
+        set state $env(PROQI_TEST_STATE)
+        set session $env(PROQI_TEST_SESSION)
+        set input $env(PROQI_TEST_INPUT)
+        spawn $binary --state-dir $state -r $session
+        expect -exact "\x1b\[?1049h"
+        send "\r"
+        after 100
+        send -- $input
+        after 500
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    run_editor_workflow(script, binary, state, Some(session), Some(input));
+}
+
+fn assert_persisted_content(
+    binary: &str,
+    state: &std::path::Path,
+    session: &str,
+    thought: &str,
+    expected: &str,
+) {
+    let inspected = json_command(binary, state, &["thoughts", "inspect", session, thought]);
+    assert_eq!(inspected["data"]["thought"]["content"], expected);
+}
+
+fn run_editor_workflow(
+    script: &str,
+    binary: &str,
+    state: &std::path::Path,
+    session: Option<&str>,
+    input: Option<&str>,
+) {
+    let mut command = expect_command();
+    command
+        .args(["-c", script])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state);
+    if let Some(session) = session {
+        command.env("PROQI_TEST_SESSION", session);
+    }
+    if let Some(input) = input {
+        command.env("PROQI_TEST_INPUT", input);
+    }
+    let status = command.status().expect("run editor redo PTY workflow");
+    assert!(status.success(), "editor redo PTY exited with {status}");
+}
+
 #[test]
 fn bracketed_paste_autosaves_and_resumes_in_a_real_pty() {
     let state = tempfile::tempdir().expect("temporary state");

--- a/tests/pty/key_inspector.rs
+++ b/tests/pty/key_inspector.rs
@@ -95,6 +95,15 @@ fn primary_enter_variants_are_distinct_in_the_real_pty() {
 }
 
 #[test]
+fn macos_cmd_shift_z_encoding_is_redo_in_the_real_pty() {
+    inspect_sequence(
+        r"\x1b\[122:90;10u",
+        "Char('Z'), modifiers: KeyModifiers(SUPER)",
+        "Redo",
+    );
+}
+
+#[test]
 fn delete_and_backspace_are_distinct_in_the_real_pty() {
     inspect_sequence(r"\x1b\[3~", "Delete", "Delete");
     inspect_sequence(


### PR DESCRIPTION
## Summary

This change adds regression coverage for editor redo from the real macOS Cmd+Shift+Z terminal encoding. No production code change was required.

Exact base: `517505a7b2a85e3255de20348f014dde0d3b7cb4`

Head: `65a3b58bb386f071f1b69602a223430ba14d3f32`

## Diagnosis

The reported no-op does not reproduce on the exact base. A system-level Cmd+Shift+Z press through Ghostty 1.3.1 and Herdr 0.8.0 reached Proqi as `Char('z')` with `SHIFT | SUPER` and translated to `Redo`. The complete user story also passed with durable state inspection after deletion, undo, and redo.

Direct Ghostty physical-key reporting emits `ESC[122:90;10u`. Crossterm 0.29 decodes that sequence as `Char('Z')` with `SUPER`, which the exact base already maps to `UiKey::Redo`. That uppercase normalization entered the base in `da81006`. A binary predating that normalization is the strongest explanation for the screenshots, but the original runtime version cannot be proven from the available evidence.

## Design

The key-inspector PTY suite now drives `ESC[122:90;10u` through Crossterm and asserts the decoded event and `Redo` translation.

The persistence PTY suite now creates the reported text, deletes the trailing word, exits and inspects durable content, restarts to undo, inspects again, then restarts to redo with the physical macOS sequence and verifies the durable deleted state. Separate process phases prevent screen-only assertions from masking persistence defects.

The durable PTY oracle reserves the full Nextest worker pool while it runs. This prevents its four serial real-process workflows from invalidating unrelated strict wall-clock contention tests without changing either test's assertions or bounds.

Existing Board and Editor history ownership, alternative redo chords, repeat handling, release filtering, and text-entry boundaries are unchanged.

## Verification

Focused input translation, editor contract, UI history, SQLite restart persistence, and PTY redo tests passed.

The exact durable PTY oracle and strict startup-contention test passed together under the resource reservation.

`cargo xtask check` passed with 1090 tests passed and 5 skipped.

`cargo xtask audit` passed.

`cargo xtask package` passed, including the installed-product contract.

`cargo xtask test-pty` passed all 47 tests.

No snapshots changed and no pending snapshot files exist.

## Live evidence

The exact user story passed through a visible Ghostty and Herdr path with persisted content checked after every phase. Stress covered both macOS sequence variants, Cmd+Y, repeated cycles, beginning, middle, and end deletion, selection replacement, Unicode and combining text, rapid input, resize, pending autosave, restart, separate Board and Editor histories, Compose boundaries, and clean shutdown.

## Platform limitation and risk

CI cannot physically press a host keyboard chord. The automated PTY regression therefore injects the exact Ghostty protocol bytes, while the host interception boundary was verified separately with a system-level physical chord. The patch is test-only, and the residual risk is limited to terminal versions or user keybindings that intercept the chord before it reaches the PTY.
