### PR TITLE
Add trailing space to Screenshot Inbox captures

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -225,9 +225,11 @@ that it is not durable and offers retry or export. It never silently changes a
 failed save into a successful one.
 
 Screenshot creation is deliberately commit-first rather than optimistic. The
-storage lane atomically inserts one capture receipt and its exact append
-operation in detection order. The UI applies the operation only after that
-transaction succeeds. The receipt's rename-stable source fingerprint prevents
+application-owned capture constructor stores the exact source path followed by
+one ASCII space while its attachment annotation and health key cover only the
+path. The storage lane atomically inserts one capture receipt and its exact
+append operation in detection order. The UI applies the operation only after
+that transaction succeeds. The receipt's rename-stable source fingerprint prevents
 duplicate delivery across repeated notifications, reconciliation, retry,
 restart, and ownership handoff. Failure leaves no partial thought and retains
 retryable work in the live session. An ordinary store failure initiates bounded

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -364,7 +364,9 @@ board key `i`, or choosing `Enable Screenshot Inbox`, watches the current user's
 Desktop by default. The directory is configurable. Existing entries are
 snapshotted and ignored at activation; each subsequently completed accepted
 image becomes one immediate durable thought whose canonical content is the
-exact absolute source path and whose presentation is the ordinary image fold.
+exact absolute source path followed by one ordinary ASCII space. The attachment
+annotation covers only the path, so the ordinary image fold is followed by an
+editable space and a safely focused editor is ready to type after that space.
 
 Proqi does not take screenshots. It watches files produced by the user's normal
 macOS screenshot tool and never requests Screen Recording or Accessibility,

--- a/src/application/capture.rs
+++ b/src/application/capture.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{AppState, ApplicationError, ApplicationResult};
 
-/// Build one exact image-path thought without exposing it before durable acceptance.
+/// Build one prompt-ready image-path thought without exposing it before durable acceptance.
 ///
 /// # Errors
 ///
@@ -28,15 +28,17 @@ pub fn prepare_capture(
     operation_id: OperationId,
     at: Timestamp,
 ) -> ApplicationResult<CaptureCommit> {
-    let content = candidate
+    let path = candidate
         .path
         .to_str()
-        .ok_or(ApplicationError::InvalidState)?
-        .to_owned();
+        .ok_or(ApplicationError::InvalidState)?;
+    let mut content = String::with_capacity(path.len().saturating_add(1));
+    content.push_str(path);
+    content.push(' ');
     let display_name = safe_display_name(&candidate.path)?;
     let annotation = ContentAnnotation {
         start: 0,
-        end: content.len(),
+        end: path.len(),
         kind: ContentAnnotationKind::Attachment {
             image: true,
             display_name,
@@ -106,4 +108,53 @@ fn safe_display_name(path: &Path) -> ApplicationResult<String> {
         .filter(|name| !name.is_empty())
         .map(ToOwned::to_owned)
         .ok_or(ApplicationError::InvalidState)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        adapters::memory::FakeIdGenerator,
+        application::{AppState, attachments::attachment_keys},
+        domain::{BoardMutation, Session, SessionBoard, Timestamp},
+        ports::{
+            environment::IdGenerator as _,
+            screenshot::{ScreenshotCandidate, ScreenshotFingerprint, ScreenshotImageType},
+        },
+    };
+
+    use super::prepare_capture;
+
+    #[test]
+    fn capture_content_has_one_suffix_while_annotation_and_health_keep_the_exact_path() {
+        let mut ids = FakeIdGenerator::new(1_725_260_000_000);
+        let session = Session::new(
+            ids.session_id(),
+            std::env::temp_dir(),
+            Timestamp::from_millis(1),
+        )
+        .expect("session");
+        let state = AppState::new(SessionBoard::new(session, Vec::new()).expect("board"));
+        let candidate = ScreenshotCandidate {
+            fingerprint: ScreenshotFingerprint([7; 32]),
+            path: std::env::temp_dir().join("Unicode capture with spaces 🖼️.png"),
+            image_type: ScreenshotImageType::Png,
+        };
+        let commit = prepare_capture(
+            &state,
+            &candidate,
+            ids.thought_id(),
+            ids.operation_id(),
+            Timestamp::from_millis(2),
+        )
+        .expect("capture");
+        let BoardMutation::AddThought { thought } = &commit.operation.forward else {
+            panic!("capture thought");
+        };
+        let path = candidate.path.to_str().expect("UTF-8 path");
+        assert_eq!(thought.content, format!("{path} "));
+        assert_eq!(thought.annotations[0].end, path.len());
+        let keys = attachment_keys(thought);
+        assert_eq!(keys[0].canonical_path, path);
+        assert_eq!(keys[0].annotation_end, path.len());
+    }
 }

--- a/src/domain/annotation.rs
+++ b/src/domain/annotation.rs
@@ -174,6 +174,22 @@ mod tests {
     }
 
     #[test]
+    fn attachment_range_can_preserve_unannotated_trailing_content() {
+        let path = "/tmp/Grüße 🖼️.png";
+        let content = format!("{path} ");
+        let annotation = ContentAnnotation {
+            start: 0,
+            end: path.len(),
+            kind: ContentAnnotationKind::Attachment {
+                image: true,
+                display_name: "Grüße 🖼️.png".to_owned(),
+            },
+        };
+
+        assert_eq!(validate_annotations(&content, &[annotation]), Ok(()));
+    }
+
+    #[test]
     fn unsafe_or_unhelpful_invocation_labels_fail_closed() {
         for label in ["@", " reviewer", "@reviewer\nsecret"] {
             assert_eq!(

--- a/src/ui/app/screenshot/tests/behavior.rs
+++ b/src/ui/app/screenshot/tests/behavior.rs
@@ -38,17 +38,21 @@ fn durable_capture_preserves_an_active_editor_and_exact_path_annotation() {
     assert!(effects.is_empty());
     let editor_during = app.editor_snapshot().expect("live editor during commit");
     assert_eq!(editor_during, editor_before);
-    app.complete_screenshot_capture(Ok(created(&commit)), &mut ids, &clock);
-
+    let effects = app.complete_screenshot_capture(Ok(created(&commit)), &mut ids, &clock);
     assert_eq!(app.state.focused_thought, Some(original_id));
     assert_eq!(
         app.editor_snapshot().expect("replayed editor").content,
         "active!"
     );
     let captured = app.state.board.live_thoughts()[1];
-    assert_eq!(captured.content, candidate(3).path.to_string_lossy());
+    let path = candidate(3).path.to_string_lossy().into_owned();
+    assert_eq!(captured.content, format!("{path} "));
     assert_eq!(captured.annotations[0].start, 0);
-    assert_eq!(captured.annotations[0].end, captured.content.len());
+    assert_eq!(captured.annotations[0].end, path.len());
+    let Effect::CheckAttachments(batch) = &effects[0] else {
+        panic!("attachment check")
+    };
+    assert_eq!(batch.checks[0].canonical_path, path);
     assert_eq!(app.status_text(), None);
 }
 
@@ -67,7 +71,6 @@ fn durable_capture_uses_admission_proof_before_its_immediate_recheck() {
         panic!("immediate accessibility check");
     };
     assert!(!app.attachment_inaccessible(thought_id, 0));
-
     app.complete_attachment_checks(AttachmentCheckBatchResult {
         id: batch.id,
         purpose: batch.purpose,
@@ -89,13 +92,11 @@ fn newest_capture_in_one_detection_burst_is_left_ready_for_annotation() {
     let (mut app, mut ids, clock, _) = app_with_thought();
     app.screenshot_started(Duration::ZERO);
     app.queue_screenshot_candidates([candidate(4), candidate(5)]);
-
     let first = next_commit(&mut app, &mut ids, &clock);
     app.complete_screenshot_capture(Ok(created(&first)), &mut ids, &clock);
     let second = next_commit(&mut app, &mut ids, &clock);
     let newest_id = capture_thought_id(&second);
     app.complete_screenshot_capture(Ok(created(&second)), &mut ids, &clock);
-
     assert_eq!(app.state.focused_thought, Some(newest_id));
     assert_eq!(
         app.state.mode,
@@ -104,6 +105,10 @@ fn newest_capture_in_one_detection_burst_is_left_ready_for_annotation() {
         }
     );
     assert_eq!(app.status_text(), Some("2 new captures"));
+    assert_eq!(
+        app.editor_snapshot().expect("capture editor").content,
+        capture_content(5)
+    );
 }
 
 #[test]
@@ -114,11 +119,9 @@ fn separated_capture_feedback_restarts_at_one() {
     let first = next_commit(&mut app, &mut ids, &clock);
     app.complete_screenshot_capture(Ok(created(&first)), &mut ids, &clock);
     app.state.mode = InteractionMode::Board;
-
     app.queue_screenshot_candidates([candidate(7)]);
     let second = next_commit(&mut app, &mut ids, &clock);
     app.complete_screenshot_capture(Ok(created(&second)), &mut ids, &clock);
-
     assert_eq!(app.status_text(), Some("1 new capture"));
 }
 
@@ -145,7 +148,6 @@ fn retry_rebuilds_after_an_intervening_durable_editor_change() {
     app.queue_screenshot_candidates([candidate(18)]);
     let failed = next_commit(&mut app, &mut ids, &clock);
     app.complete_screenshot_capture(Err(StoreError::Busy), &mut ids, &clock);
-
     app.state.mode = InteractionMode::Edit {
         thought_id: original_id,
     };
@@ -156,7 +158,6 @@ fn retry_rebuilds_after_an_intervening_durable_editor_change() {
         panic!("editor revision");
     };
     app.acknowledge_persistence_result(revision.sequence, Ok(()));
-
     let retry_effects = app.retry_screenshot_capture(&mut ids, &clock);
     let [Effect::CommitCapture(retry)] = retry_effects.as_slice() else {
         panic!("fresh retry capture");
@@ -175,7 +176,6 @@ fn failed_first_capture_in_a_burst_retries_then_drains_in_order() {
     app.queue_screenshot_candidates([candidate(13), candidate(14)]);
     let first = next_commit(&mut app, &mut ids, &clock);
     app.complete_screenshot_capture(Err(StoreError::Busy), &mut ids, &clock);
-
     let retry_effects = app.retry_screenshot_capture(&mut ids, &clock);
     let [Effect::CommitCapture(retry)] = retry_effects.as_slice() else {
         panic!("retry first capture");
@@ -187,6 +187,14 @@ fn failed_first_capture_in_a_burst_retries_then_drains_in_order() {
     assert_eq!(second.source, candidate(14).fingerprint);
     app.complete_screenshot_capture(Ok(created(&second)), &mut ids, &clock);
     assert_eq!(app.state.board.live_thoughts().len(), 3);
+    assert_eq!(
+        app.state.board.live_thoughts()[1].content,
+        capture_content(13)
+    );
+    assert_eq!(
+        app.state.board.live_thoughts()[2].content,
+        capture_content(14)
+    );
 }
 
 #[test]
@@ -208,7 +216,6 @@ fn quit_during_capture_is_deferred_and_flushes_the_live_editor() {
             .is_empty()
     );
     assert!(!app.quit);
-
     let effects = app.complete_screenshot_capture(Ok(created(&capture)), &mut ids, &clock);
     assert!(app.quit);
     let Some(Effect::CommitRevision(revision)) = effects
@@ -287,7 +294,7 @@ fn explicit_editor_interaction_prevents_burst_auto_advance() {
             .thought(first_id)
             .expect("first capture")
             .content,
-        format!("{}x", candidate(16).path.to_string_lossy())
+        format!("{}x", capture_content(16))
     );
     assert_eq!(app.state.board.live_thoughts().len(), 3);
 }
@@ -447,6 +454,10 @@ pub(super) fn candidate(byte: u8) -> ScreenshotCandidate {
         path: std::env::temp_dir().join(format!("Unicode capture {byte} 🖼️.png")),
         image_type: ScreenshotImageType::Png,
     }
+}
+
+fn capture_content(byte: u8) -> String {
+    format!("{} ", candidate(byte).path.display())
 }
 
 fn capture_thought_id(commit: &CaptureCommit) -> crate::domain::ThoughtId {

--- a/tests/pty/shutdown.rs
+++ b/tests/pty/shutdown.rs
@@ -391,10 +391,11 @@ fn assert_capture_shutdown_result(
         .iter()
         .map(|thought| thought["content"].as_str().expect("content"))
         .collect::<Vec<_>>();
+    let captured_content = format!("{} ", target.to_str().expect("target"));
     let expected = if persistent_failure {
         vec!["durable editor"]
     } else {
-        vec!["durable editor!", target.to_str().expect("target")]
+        vec!["durable editor!", captured_content.as_str()]
     };
     assert_eq!(contents, expected);
     let resumed = json_command(binary, state, &["-r", session]);

--- a/tests/sqlite_store/screenshot.rs
+++ b/tests/sqlite_store/screenshot.rs
@@ -56,14 +56,15 @@ fn capture_receipt_and_thought_commit_atomically_and_deduplicate_globally() {
         .expect("apply durable capture")
         .expect("created thought");
     let thought = state.board.thought(thought_id).expect("thought");
-    assert_eq!(thought.content, candidate.path.to_string_lossy());
+    let path = candidate.path.to_string_lossy();
+    assert_eq!(thought.content, format!("{path} "));
     assert!(matches!(
         thought.annotations.as_slice(),
         [ContentAnnotation {
             start: 0,
             end,
             kind: ContentAnnotationKind::Attachment { image: true, .. },
-        }] if *end == thought.content.len()
+        }] if *end == path.len()
     ));
 
     let duplicate = store.commit_capture(&commit).expect("deduplicate retry");
@@ -75,6 +76,10 @@ fn capture_receipt_and_thought_commit_atomically_and_deduplicate_globally() {
         .load_session(state.board.session.id)
         .expect("load captured session");
     assert_eq!(snapshot.board.thoughts().len(), 1);
+    assert_eq!(
+        snapshot.board.live_thoughts()[0].content,
+        format!("{path} ")
+    );
     let receipt_count: i64 = Connection::open(&fixture.config.database_path)
         .expect("inspect database")
         .query_row(
@@ -164,19 +169,74 @@ fn persistent_contention_leaves_no_partial_capture_and_exact_retry_succeeds() {
 
     let outcome = store.commit_capture(&capture).expect("retry capture");
     assert!(matches!(outcome, CaptureCommitOutcome::Created { .. }));
+    let snapshot = store
+        .load_session(state.board.session.id)
+        .expect("durable retry");
+    let thought = snapshot.board.live_thoughts()[0];
     assert_eq!(
-        store
-            .load_session(state.board.session.id)
-            .expect("durable retry")
-            .board
-            .live_thoughts()
-            .len(),
-        1
+        thought.content,
+        format!("{} ", test_path("capture-13.png").display())
     );
+    assert_eq!(thought.annotations[0].end, thought.content.len() - 1);
     assert!(matches!(
         store.commit_capture(&capture).expect("dedupe replay"),
         CaptureCommitOutcome::AlreadyCaptured(_)
     ));
+}
+
+#[test]
+fn capture_separator_survives_restart_undo_and_redo_without_duplication() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_241_750_000);
+    let mut state = session_state(&mut ids, &test_path("screenshot-history"));
+    let session_id = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("create session");
+    let capture = prepared_capture(&state, &mut ids, 14, 2);
+    let outcome = store.commit_capture(&capture).expect("capture");
+    let thought_id = apply_capture(&mut state, &capture, &outcome)
+        .expect("apply capture")
+        .expect("created thought");
+    drop(store);
+
+    let mut store = fixture.open();
+    let snapshot = store.load_session(session_id).expect("restart capture");
+    let mut restored = AppState::from_snapshot(snapshot).expect("restore capture");
+    assert_eq!(
+        restored.board.thought(thought_id).expect("thought").content,
+        format!("{} ", test_path("capture-14.png").display())
+    );
+    let undo = one_effect(
+        &mut restored,
+        Action::Undo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Board,
+            at: Timestamp::from_millis(3),
+        },
+    );
+    persist_effect(&mut store, &undo);
+    let redo_effects = reduce(
+        &mut restored,
+        Action::Redo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Board,
+            at: Timestamp::from_millis(4),
+        },
+    )
+    .expect("redo capture");
+    let redo = redo_effects
+        .iter()
+        .find(|effect| matches!(effect, Effect::CommitHistoryMove { .. }))
+        .expect("durable redo");
+    persist_effect(&mut store, redo);
+    let redone = store.load_session(session_id).expect("redone capture");
+    assert_eq!(redone.board.live_thoughts().len(), 1);
+    assert_eq!(
+        redone.board.live_thoughts()[0].content,
+        format!("{} ", test_path("capture-14.png").display())
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

* Construct each accepted Screenshot Inbox thought as the exact absolute source path followed by one ordinary ASCII space.
* Keep the attachment annotation and health key bounded to the path, leaving the trailing space visible and editable after the folded image placeholder.
* Preserve safe capture focus, active editor focus and selection, retry, receipt deduplication, ordering, restart, undo, persistence failure, and ownership handoff behavior.
* Document the visible and durable Screenshot Inbox contract.

## Coverage

* Added application coverage for exact canonical bytes, Unicode and spaces, path-only annotation ranges, and health keys.
* Added store coverage for atomic failure and retry, global deduplication, restart, undo, redo, and exact durable content.
* Added UI coverage for safe caret placement, immediate typing, active editor focus and selection preservation, and ordered batches.
* Updated the existing delayed-capture shutdown PTY oracle for the inbox-specific suffix.
* Confirmed neighboring file drop, clipboard, ordinary path, invocation, attachment, and placeholder contracts remain unchanged through the complete suite.

## Mainline reconciliation

Merged `origin/main` at `35da7b59f4d118ca52bdb7045e7f965401a06fa7` without rebasing. Focused onboarding tests confirm schema 11, storage protocol 10, control protocol 7, one atomic first interactive Fresh claim, six ordinary annotated thoughts, completed prior-schema migrations, and noninteractive eligibility preservation. Existing independent pristine PTY fixtures continue to use `consume_first_run`.

## Qualification

* `cargo test screenshot --all-targets`
* `cargo test --test ui_board annotations`
* `cargo test onboarding --all-targets`
* Focused delayed capture shutdown PTY tests
* `cargo xtask check`, 1,116 tests and doctests passed
* `cargo xtask audit`, passed
* `cargo xtask package`, passed including installed-product contract
* `cargo xtask test-pty`, 53 tests passed serially

## Live Herdr checkpoint

The exact application code build at `6a55f53bf658b42fdddb700205c6478ec96ba4e4` was exercised in disposable panes `wW:p3`, `wW:p4`, and `wW:p5`. Final head differs only by the corrected inbox-specific PTY oracle.

The isolated run verified exact SQLite content and annotation offsets, immediate typing after safe focus, active editor cursor and selection preservation, Unicode, spaces, a tab and a combining mark in filenames, rapid ordered batches, duplicate notification and reconciliation, disable and re-enable, atomic SQLite failure and ordinary retry, explicit ownership handoff, narrow and shallow resize, restart, undo, redo, and clean shutdown. All three panes and `/private/tmp/proqi-screenshot-trailing-space-6a55f53` were removed after inspection.

## CI

All required CI completed green for head `f6fee5a5838cda2ae4749f8275352e1c10f31e15`, including the aggregate required result, quality, dependency policy, coverage, minimum supported Rust, macOS and Linux tests, macOS PTY, macOS and Linux packages, registry package, and Debian package contracts.
