### PR TITLE
Eliminate false attachment accessibility flicker

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -352,9 +352,11 @@ that it is a readable regular file, and returns typed missing, permission,
 unmounted, unreadable, or I/O failures. The bounded lane adds timeout and
 cancellation failures without waiting for a blocked filesystem call to return.
 Those reasons are content-free diagnostics only. Application and UI consumers
-reduce every failure to binary inaccessible health.
+reduce every completed failure to binary inaccessible health. Unknown and
+checking state remain visually neutral without becoming accessibility proof.
 
-Application state owns the transient exact-key cache and scheduling policy.
+Application state owns the transient exact-key cache, its explicit unknown,
+checking, accessible, and inaccessible states, and the scheduling policy.
 Keys include the thought, annotation index and range, presentation metadata,
 canonical path, and digest of the canonical content revision. Insertion and
 relink mutations invalidate affected work. Restoration schedules the focused

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -523,12 +523,14 @@ can be undone after restarting the application.
 ### Attachment accessibility
 
 Attachment annotations keep an external absolute path as canonical prompt
-content. Proqi presents a readable attachment as `[Image N]` or `[File N]`.
-When the current process cannot prove that the referenced regular file is
-readable, the same annotation becomes `[Image N · inaccessible]` or
-`[File N · inaccessible]` and uses the warning visual role. Missing files,
-permissions, unavailable volumes, filesystem failures, and bounded check
-timeouts remain diagnostic details rather than additional user-visible states.
+content. Proqi presents a readable or not-yet-resolved attachment as
+`[Image N]` or `[File N]`. Unknown and checking health are not accessibility
+proof and remain fail-closed for actions that require a readable file, but they
+do not show a false warning. Only a completed failed check changes the same
+annotation to `[Image N · inaccessible]` or `[File N · inaccessible]` and uses
+the warning visual role. Missing files, permissions, unavailable volumes,
+filesystem failures, and bounded check timeouts remain diagnostic details
+rather than additional user-visible states.
 
 Health is transient and never changes prompt content. Proqi checks new
 annotations immediately, checks a restored board with the focused thought

--- a/src/application/attachments.rs
+++ b/src/application/attachments.rs
@@ -30,6 +30,8 @@ const INACTIVE_REFRESH_AFTER: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AttachmentHealth {
+    Unknown,
+    Checking,
     Accessible,
     Inaccessible(AttachmentAccessFailure),
 }
@@ -127,6 +129,7 @@ impl AttachmentAccessibilityState {
     ) -> Vec<Effect> {
         self.last_deliberate = Some(now);
         self.known = attachment_keys_by_thought(board);
+        self.seed_unknown();
         self.enqueue_board(board, focused, false);
         self.schedule()
     }
@@ -148,6 +151,7 @@ impl AttachmentAccessibilityState {
         }
         let (replacements, identities_stable) = self.migrate_health(&current, &changed);
         self.known = current;
+        self.seed_unknown();
         self.remap_scheduled_keys(&replacements);
         let restart_manual = self.manual_refresh.is_some();
         if restart_manual && !identities_stable {
@@ -181,6 +185,7 @@ impl AttachmentAccessibilityState {
         self.queued.clear();
         self.known = attachment_keys_by_thought(board);
         self.retain_current_health();
+        self.seed_unknown();
         self.refreshed_since_last_deliberate = true;
         let total: usize = self.known.values().map(Vec::len).sum();
         if cause == AttachmentRefreshCause::Manual {
@@ -287,7 +292,7 @@ impl AttachmentAccessibilityState {
         (effects, preflight, refresh)
     }
 
-    /// Binary user-visible health for one current attachment annotation.
+    /// Confirmed user-visible failure for one current attachment annotation.
     #[must_use]
     pub fn inaccessible(&self, thought_id: ThoughtId, annotation_index: usize) -> bool {
         self.known
@@ -297,7 +302,7 @@ impl AttachmentAccessibilityState {
                     .find(|key| key.annotation_index == annotation_index)
             })
             .and_then(|key| self.health.get(key))
-            .is_none_or(|health| !matches!(health, AttachmentHealth::Accessible))
+            .is_some_and(|health| matches!(health, AttachmentHealth::Inaccessible(_)))
     }
 
     /// Exact current keys for source capture and fresh preflight.
@@ -422,6 +427,7 @@ impl AttachmentAccessibilityState {
             keys: keys.clone(),
             background_epoch: self.background_epoch,
         });
+        self.mark_checking(&keys);
         vec![Effect::CheckAttachments(AttachmentCheckBatch {
             id,
             purpose,

--- a/src/application/attachments/keys.rs
+++ b/src/application/attachments/keys.rs
@@ -72,6 +72,25 @@ impl AttachmentAccessibilityState {
         self.manual_refresh.is_some()
     }
 
+    pub(super) fn seed_unknown(&mut self) {
+        for key in self.known.values().flatten() {
+            self.health
+                .entry(key.clone())
+                .or_insert(AttachmentHealth::Unknown);
+        }
+    }
+
+    pub(super) fn mark_checking(&mut self, keys: &[AttachmentCheckKey]) {
+        for key in keys {
+            if !matches!(
+                self.health.get(key),
+                Some(AttachmentHealth::Accessible | AttachmentHealth::Inaccessible(_))
+            ) {
+                self.health.insert(key.clone(), AttachmentHealth::Checking);
+            }
+        }
+    }
+
     /// Seed current exact keys from transient proof established by an insertion adapter.
     pub fn mark_paths_accessible(&mut self, thought_id: ThoughtId, paths: &[String]) {
         let Some(keys) = self.known.get(&thought_id) else {

--- a/src/application/attachments/tests.rs
+++ b/src/application/attachments/tests.rs
@@ -83,14 +83,14 @@ fn inaccessible_health_is_binary_and_manual_refresh_recovers_it() {
 }
 
 #[test]
-fn startup_is_fail_closed_and_rechecks_preserve_the_last_resolved_health() {
+fn startup_unknown_and_checking_are_neutral_while_rechecks_preserve_resolved_health() {
     let (board, ids) = board_with_attachments(2);
     let mut state = AttachmentAccessibilityState::default();
-    assert!(state.inaccessible(ids[0], 0));
+    assert!(!state.inaccessible(ids[0], 0));
 
     let startup = one_batch(state.start(&board, Some(ids[0]), Duration::ZERO));
-    assert!(state.inaccessible(ids[0], 0));
-    assert!(state.inaccessible(ids[1], 0));
+    assert!(!state.inaccessible(ids[0], 0));
+    assert!(!state.inaccessible(ids[1], 0));
     assert!(state.complete(accessible(startup)).0.is_empty());
     assert!(!state.inaccessible(ids[0], 0));
     assert!(!state.inaccessible(ids[1], 0));

--- a/tests/ui_board/attachment_accessibility.rs
+++ b/tests/ui_board/attachment_accessibility.rs
@@ -9,6 +9,8 @@ use proqi::{
 };
 use ratatui_core::style::Modifier;
 
+#[path = "attachment_accessibility/flicker_regressions.rs"]
+mod flicker_regressions;
 #[path = "attachment_accessibility/review.rs"]
 mod review;
 #[path = "attachment_accessibility/transformations.rs"]
@@ -24,6 +26,9 @@ fn inaccessible_image_and_file_use_exact_plain_labels_and_warning_semantics_afte
         let path = "/private/var/folders/TemporaryItems/Grüße 第一.png";
         let effects = fixture.effects(UiInput::PasteAnnotated(attachment_payload(path, image)));
         let batch = attachment_batch(&effects);
+        let checking = text(draw(&mut fixture, 80, 8).backend().buffer());
+        assert!(checking.contains(if image { "[Image 1]" } else { "[File 1]" }));
+        assert!(!checking.contains("inaccessible"));
         let completion = complete(batch, Err(AttachmentAccessFailure::Missing));
         assert!(
             fixture

--- a/tests/ui_board/attachment_accessibility/flicker_regressions.rs
+++ b/tests/ui_board/attachment_accessibility/flicker_regressions.rs
@@ -1,0 +1,131 @@
+//! First-frame attachment health and editor-history flicker regressions.
+
+use super::{Fixture, attachment_batch, attachment_payload, complete, draw, execute_palette, text};
+use crate::agent::target;
+use proqi::{
+    application::Effect,
+    domain::Direction,
+    ports::attachment_accessibility::AttachmentAccessFailure,
+    ui::{UiInput, UiKey},
+};
+
+#[test]
+fn modeled_macos_file_drop_is_neutral_while_fresh_submission_preflight_is_mandatory() {
+    let files = tempfile::tempdir().expect("temporary files");
+    let file = files.path().join("Grüße 第一.png");
+    std::fs::write(&file, b"readable image fixture").expect("readable attachment");
+    let path = file.to_string_lossy();
+    let mut fixture = Fixture::new();
+
+    let insertion = fixture.effects(UiInput::PasteAnnotated(attachment_payload(&path, true)));
+    let background = attachment_batch(&insertion);
+    assert_normal_attachment(&mut fixture, "[Image 1]");
+    acknowledge_persistence(&mut fixture, &insertion);
+
+    fixture.input(UiInput::Key(UiKey::Escape));
+    fixture
+        .app
+        .complete_agent_discovery(Ok(vec![target(Direction::Left, "w1:p2")]));
+    let waiting = execute_palette(&mut fixture, "submit and keep");
+    assert!(
+        waiting.is_empty(),
+        "background proof is not submission proof"
+    );
+    assert_eq!(fixture.app.status_text(), Some("checking attachments"));
+
+    let preflight = fixture
+        .app
+        .complete_attachment_checks(complete(background, Ok(())));
+    assert!(
+        preflight
+            .iter()
+            .all(|effect| !matches!(effect, Effect::PrepareSubmission(_)))
+    );
+    let preflight = attachment_batch(&preflight);
+    let prepared = fixture
+        .app
+        .complete_attachment_checks(complete(preflight, Ok(())));
+    assert!(matches!(
+        prepared.as_slice(),
+        [Effect::PrepareSubmission(_)]
+    ));
+}
+
+#[test]
+fn deleting_a_complete_placeholder_then_undoing_restores_neutral_pending_health() {
+    let path = "/tmp/history-restored.png";
+    let mut fixture = Fixture::new();
+    let insertion = fixture.effects(UiInput::PasteAnnotated(attachment_payload(path, true)));
+    let background = attachment_batch(&insertion);
+    fixture
+        .app
+        .complete_attachment_checks(complete(background, Ok(())));
+    acknowledge_persistence(&mut fixture, &insertion);
+
+    fixture.input(UiInput::Key(UiKey::SelectAll));
+    fixture.input(UiInput::Key(UiKey::Delete));
+    let deletion = fixture
+        .app
+        .flush_pending_edit(&mut fixture.ids, &fixture.clock);
+    assert!(
+        fixture.app.state.board.live_thoughts()[0]
+            .annotations
+            .is_empty()
+    );
+    acknowledge_persistence(&mut fixture, &deletion);
+
+    let undo = fixture.effects(UiInput::Key(UiKey::Undo));
+    let recheck = attachment_batch(&undo);
+    assert_eq!(
+        fixture.app.state.board.live_thoughts()[0].annotations.len(),
+        1
+    );
+    assert_normal_attachment(&mut fixture, "[Image 1]");
+    acknowledge_persistence(&mut fixture, &undo);
+
+    fixture.input(UiInput::Key(UiKey::Escape));
+    fixture
+        .app
+        .complete_agent_discovery(Ok(vec![target(Direction::Left, "w1:p2")]));
+    assert!(execute_palette(&mut fixture, "submit and keep").is_empty());
+    let preflight = fixture
+        .app
+        .complete_attachment_checks(complete(recheck, Ok(())));
+    let preflight = attachment_batch(&preflight);
+    assert!(
+        fixture
+            .app
+            .complete_attachment_checks(complete(preflight, Err(AttachmentAccessFailure::Missing)))
+            .is_empty()
+    );
+    assert_eq!(
+        fixture.app.status_text(),
+        Some("Proqi cannot access 1 attachment")
+    );
+    assert!(
+        text(draw(&mut fixture, 60, 8).backend().buffer()).contains("[Image 1 · inaccessible]")
+    );
+}
+
+fn assert_normal_attachment(fixture: &mut Fixture, label: &str) {
+    let rendered = text(draw(fixture, 60, 8).backend().buffer());
+    assert!(rendered.contains(label), "rendered frame:\n{rendered}");
+    assert!(
+        !rendered.contains("inaccessible"),
+        "rendered frame:\n{rendered}"
+    );
+}
+
+fn acknowledge_persistence(fixture: &mut Fixture, effects: &[Effect]) {
+    let sequence = effects
+        .iter()
+        .find_map(Effect::persistence_batch)
+        .and_then(|batch| batch.sequence())
+        .expect("persistence sequence");
+    assert!(
+        fixture
+            .app
+            .acknowledge_persistence(sequence, true)
+            .is_empty()
+    );
+}

--- a/tests/ui_board/attachment_accessibility/review.rs
+++ b/tests/ui_board/attachment_accessibility/review.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn startup_is_fail_closed_and_rechecks_do_not_flicker_or_leave_stale_status() {
+fn startup_is_visually_neutral_and_rechecks_do_not_flicker_or_leave_stale_status() {
     let path = "/private/TemporaryItems/missing.png";
     let mut source = Fixture::new();
     source.input(UiInput::PasteAnnotated(attachment_payload(path, true)));
@@ -21,7 +21,8 @@ fn startup_is_fail_closed_and_rechecks_do_not_flicker_or_leave_stale_status() {
     let startup = attachment_batch(&startup);
 
     let startup_render = text(draw(&mut fixture, 60, 8).backend().buffer());
-    assert!(startup_render.contains("[Image 1 · inaccessible]"));
+    assert!(startup_render.contains("[Image 1]"));
+    assert!(!startup_render.contains("inaccessible"));
     fixture
         .app
         .complete_attachment_checks(complete(startup, Ok(())));

--- a/tests/ui_board/snapshots/ui_board__placeholder_space__shifted_placeholder_has_a_reviewed_narrow_editor_snapshot.snap
+++ b/tests/ui_board/snapshots/ui_board__placeholder_space__shifted_placeholder_has_a_reviewed_narrow_editor_snapshot.snap
@@ -1,14 +1,14 @@
 ---
 source: tests/ui_board/placeholder_space.rs
-assertion_line: 475
+assertion_line: 478
 expression: snapshot_buffer(terminal.backend().buffer())
 ---
 SIZE 32x7
 
 TEXT
 00││
-01│⋮ before  [Image 1 ·│
-02│  inaccessible] after│
+01│⋮ before  [Image 1] after│
+02││
 03││
 04│  proqi-ui-annotated-contract│
 05│  1 thought · edit · saving│
@@ -16,8 +16,8 @@ TEXT
 
 STYLE RUNS
 0: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
-1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-9 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 10-20 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 21-31 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
-2: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-14 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 15-31 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-9 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 10-18 fg=Rgb(112, 214, 155) bg=Rgb(39, 40, 48) mod=BOLD | 19-31 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+2: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 3: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 4: 0-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 5: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-29 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 30-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE

--- a/tests/ui_board/snapshots/ui_board__snapshots__populated_board_with_folded_attachment.snap
+++ b/tests/ui_board/snapshots/ui_board__snapshots__populated_board_with_folded_attachment.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/ui_board/snapshots.rs
-assertion_line: 73
+assertion_line: 67
 expression: "snapshot(&mut fixture, 60, 12, ThemePreference::Dark)"
 ---
 SIZE 60x12
@@ -10,7 +10,7 @@ TEXT
 01│  first prompt│
 02│  ──────────────────────────────────────────────────────────│
 03││
-04│⋮ [Image 1 · inaccessible]│
+04│⋮ [Image 1]│
 05││
 06│                        + New thought│
 07││
@@ -24,7 +24,7 @@ STYLE RUNS
 1: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 2: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-59 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
 3: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
-4: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-25 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 26-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+4: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-10 fg=Rgb(112, 214, 155) bg=Rgb(39, 40, 48) mod=BOLD | 11-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
 5: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 6: 0-23 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 24-24 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 25-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 7: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE


### PR DESCRIPTION
## Summary

- Represent unresolved attachment health as explicit unknown and checking application states.
- Keep unknown and checking placeholders on the canonical normal attachment presentation.
- Reserve inaccessible text and warning styling for completed failed checks.
- Keep submission and every attachment-dependent action fail-closed behind a fresh successful preflight.

## Root cause

Terminal file drops arrive as path text. Existing files become attachment annotations without readability proof, then enter an asynchronous check. The presentation predicate treated the missing pending result as inaccessible. Deleting a complete placeholder removed its transient health entry, and Editor undo restored the annotation without evidence, producing the same false warning until revalidation completed.

Clipboard image capture and Screenshot Inbox remain distinct because their adapters create or admit the file and seed narrowly scoped temporary evidence.

Exact base: `c99329cc30b9a2542508cabd72362f34d360816a`

Exact head: `66c6a20311546db89fc35aff94871a346ebbd125`

## Design

`AttachmentAccessibilityState` remains the single semantic health owner. It now distinguishes unknown, checking, accessible, and confirmed inaccessible internally. Scheduling marks unresolved exact keys as checking while preserving prior completed health during rechecks. The canonical projection asks only whether a completed failure exists.

No path-only proof was added. Fresh submission preflight, source digests, exact annotation keys, generation checks, stale-result rejection, capture evidence, and persistence boundaries are unchanged.

## Regression coverage

- A modeled readable Unicode macOS file drop renders `[Image 1]` on its first frame while submission waits for a fresh successful preflight.
- Complete placeholder deletion followed by Editor undo restores `[Image 1]`, schedules revalidation, and remains non-submittable until the fresh check succeeds.
- Completed missing and typed failure results still render the inaccessible warning and cannot submit.
- Successful recovery, stale and out-of-order results, source replacement, duplicate paths, Unicode paths, persistence failure, restart, resize, pointer geometry, themes, screenshot capture, transformations, and submission variants retain their existing contracts.
- Two representative snapshots were reviewed individually. Only the premature warning label, warning role, and deterministic wrap caused by its extra text changed. Confirmed-failure snapshots did not change.

## Verification

- Focused application attachment tests: 17 passed.
- Focused attachment accessibility UI tests: 17 passed.
- New flicker regressions: 2 passed.
- Full UI Board suite: 329 passed.
- Unicode file-drop PTY test passed.
- Placeholder edit and undo PTY test passed.
- Annotation persistence and restart tests: 8 passed.
- Pointer-selection geometry tests: 5 passed.
- `cargo xtask check`: 1,207 tests and the doctest passed.
- `cargo xtask audit`: advisories, bans, licenses, sources, RustSec, and dependency shear passed.
- `cargo xtask package`: distribution build and installed-product contract passed.
- `cargo xtask test-pty`: 55 passed.

## Review

- Codex pass 1 independently confirmed the proposed root cause against the untouched exact base. It qualified that the internal paste route is terminal-generic and Screenshot Inbox also seeds trusted evidence.
- Codex pass 2 found one low-severity test import contract violation and no behavior defect.
- The import was corrected.
- Codex pass 3 was clean with no actionable findings.

## Live Herdr evidence

The exact topic binary was exercised in owned disposable panes `w16:p2` and `w16:p3` with isolated state at `/private/tmp/proqi-flicker-live.lEznxB`.

A real bracketed paste of `Grüße 第一 image.png` rendered `[Image 1]` without inaccessible text. Complete placeholder deletion and Cmd+Z restored the normal placeholder. Stress covered rapid duplicate and Unicode drops, multiple attachments, repeated delete, undo, and redo, 45-column and 17-row resize, exact session resume after process restart, and focused worker, SQLite, pointer, and PTY tests. Submission before and after verification was asserted through deterministic effect and state oracles so no prompt was sent to the preserved coordinator pane.

Panes `w16:p2` and `w16:p3` and the isolated state directory were removed. `w16:p1` was preserved.

## Risk

`BoardApp::presentation_state` remains health-blind while render and pointer projection are health-aware. This is a pre-existing architecture risk for confirmed-inaccessible geometry and is intentionally out of scope. This change does not worsen it: no layout, render, or pointer implementation changed, and unknown or checking now matches the normal health-blind projection.

## CI

All required CI completed green for head `66c6a20311546db89fc35aff94871a346ebbd125`: change classification, Quality, Dependency security and policy, Coverage, minimum supported Rust, macOS and Ubuntu tests, macOS PTY, macOS and Ubuntu package contracts, registry package contract, Debian package contract, and the aggregate Required CI result. The documentation-only gate correctly skipped because the PR changes Rust.
