### PR TITLE
Fix Markdown invocation discovery for large definitions

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -509,11 +509,21 @@ prevents a Claude-specific rewrite when another documented harness adds an
 equivalent layer, and prevents catalog-only definitions from being fabricated
 into insertable tokens.
 
-Discovery reads only small metadata prefixes and never stores instruction
-bodies. The adapter caps roots, ancestor depth, recursion, entries, file sizes,
-metadata strings, plugin registries, and manifest component paths. It follows
-only explicitly encountered symlink definitions, canonicalizes physical paths
-for deduplication, and never crawls the home directory. Compatibility roots are
+Markdown discovery opens a regular definition and reads at most a 64 KiB
+frontmatter prefix. It stops as soon as the complete closing delimiter is
+known, never reads or stores the instruction body, and fails closed when an
+opened header does not close within that budget. A filename-derived Markdown
+command without frontmatter stops as soon as the absent opening delimiter is
+known. Skills and Markdown agents still require their valid metadata. Invalid
+UTF-8 inside frontmatter is rejected, while bytes after a valid closing
+delimiter are outside discovery and cannot invalidate it.
+
+Formats that require complete parsing retain separate whole-file bounds,
+including TOML agents, plugin manifests, and plugin registries. The adapter also
+caps roots, ancestor depth, recursion, entries, metadata lines and strings,
+manifest component paths, and plugin counts. It follows only explicitly
+encountered symlink definitions, canonicalizes physical paths for
+deduplication, and never crawls the home directory. Compatibility roots are
 checked in; extra roots enter through validated configuration with explicit
 kind, harness, and scope. Project and global vectors remain separate.
 

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -867,7 +867,7 @@ Edit mode behaves like a focused multiline text editor. It supports:
   where their source harness documents an exact authoring token.
 
 Invocation completion is authoring-only. Proqi never executes a discovered
-definition, reads its instruction body into the catalog, inspects a live agent
+definition, reads its instruction body during discovery, inspects a live agent
 conversation, or claims the adjacent harness has enabled it. `$`, `/`, and
 evidence-backed `@` tokens open only in edit mode and only when the token at the
 logical cursor plausibly matches an insertable catalog form. Shell variables,

--- a/docs/INVOCATIONS.md
+++ b/docs/INVOCATIONS.md
@@ -65,6 +65,22 @@ as folded image and large-paste placeholders. The styling is render-only: it
 does not create durable annotations or change editor text, wrapping, cursor
 positions, persistence, or undo.
 
+## Discovery resource boundary
+
+Markdown definitions are discovered from at most 64 KiB of frontmatter. Proqi
+stops at the complete closing `---` line and never reads or retains the
+instruction body. An opened frontmatter header that does not close within the
+budget is rejected. Invalid UTF-8 inside frontmatter is rejected, while invalid
+bytes after a valid closing delimiter are irrelevant to discovery. A Markdown
+command whose name comes from its filename needs no frontmatter and does not
+require its instruction body to be read.
+
+Skills and Markdown agents still require their existing metadata. The metadata
+line limit, field sanitization, visibility flags, root and traversal budgets,
+canonical-path deduplication, scope, precedence, and plugin limits remain
+unchanged. TOML agents, plugin manifests, and plugin registries require complete
+parsing and retain their separate whole-file limits.
+
 The byte-zero rule applies only to the shared `/plan` and `/goal` starters.
 Discovered compatible slash forms, including project and local skills or
 commands, highlight at exact token boundaries after whitespace and on later

--- a/src/adapters/invocation/metadata.rs
+++ b/src/adapters/invocation/metadata.rs
@@ -1,8 +1,14 @@
-use std::{fs, path::Path};
+use std::{
+    fs::{self, File},
+    io::{self, BufRead, BufReader, Read},
+    path::Path,
+};
 
 use crate::ports::invocation::InvocationHarness;
 
-pub(super) const MAX_METADATA_BYTES: u64 = 16 * 1024;
+pub(super) const MAX_MARKDOWN_FRONTMATTER_BYTES: usize = 64 * 1024;
+const MAX_COMPLETE_METADATA_BYTES: u64 = 16 * 1024;
+const MAX_METADATA_LINES: usize = 64;
 const MAX_NAME_CHARS: usize = 80;
 const MAX_DESCRIPTION_CHARS: usize = 180;
 
@@ -14,29 +20,54 @@ pub(super) struct Metadata {
     pub(super) hidden: bool,
 }
 
-pub(super) fn markdown(path: &Path) -> Option<Metadata> {
-    let content = bounded_text(path)?;
-    let frontmatter = content.strip_prefix("---\n")?;
-    let end = frontmatter.find("\n---")?;
-    let mut metadata = Metadata::default();
-    for line in frontmatter[..end].lines().take(64) {
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-        let value = scalar(value);
-        match key.trim() {
-            "name" => metadata.name = clean_name(&value),
-            "description" => metadata.description = clean_description(&value),
-            "mode" => metadata.mode = clean_name(&value).map(|value| value.to_lowercase()),
-            "hidden" | "disable" => metadata.hidden = matches!(value.as_str(), "true" | "yes"),
-            _ => {}
-        }
+pub(super) enum MarkdownMetadata {
+    Absent,
+    Parsed(Metadata),
+    Invalid,
+}
+
+pub(super) fn markdown(path: &Path) -> MarkdownMetadata {
+    let Ok(file_metadata) = fs::metadata(path) else {
+        return MarkdownMetadata::Invalid;
+    };
+    if !file_metadata.is_file() {
+        return MarkdownMetadata::Invalid;
     }
-    Some(metadata)
+    let Ok(mut file) = File::open(path) else {
+        return MarkdownMetadata::Invalid;
+    };
+    markdown_reader(&mut file)
+}
+
+fn markdown_reader(reader: &mut impl Read) -> MarkdownMetadata {
+    let mut reader = BufReader::with_capacity(1, reader);
+    let mut consumed = 0;
+    match opening_delimiter(&mut reader, &mut consumed) {
+        Ok(true) => {}
+        Ok(false) => return MarkdownMetadata::Absent,
+        Err(()) => return MarkdownMetadata::Invalid,
+    }
+    let mut metadata = Metadata::default();
+    let mut line_count = 0;
+    loop {
+        let Ok(Some(line)) = bounded_line(&mut reader, &mut consumed) else {
+            return MarkdownMetadata::Invalid;
+        };
+        if is_closing_delimiter(&line) {
+            return MarkdownMetadata::Parsed(metadata);
+        }
+        let Ok(text) = std::str::from_utf8(without_line_ending(&line)) else {
+            return MarkdownMetadata::Invalid;
+        };
+        if line_count < MAX_METADATA_LINES {
+            parse_line(&mut metadata, text);
+        }
+        line_count = line_count.saturating_add(1);
+    }
 }
 
 pub(super) fn toml_agent(path: &Path) -> Option<Metadata> {
-    let content = bounded_text(path)?;
+    let content = complete_bounded_text(path)?;
     let value = toml::from_str::<toml::Value>(&content).ok()?;
     Some(Metadata {
         name: value
@@ -72,12 +103,90 @@ pub(super) fn command_name(root: &Path, path: &Path, harness: InvocationHarness)
     clean_name(&parts.join(separator))
 }
 
-fn bounded_text(path: &Path) -> Option<String> {
+fn complete_bounded_text(path: &Path) -> Option<String> {
     let metadata = fs::metadata(path).ok()?;
-    if !metadata.is_file() || metadata.len() > MAX_METADATA_BYTES {
+    if !metadata.is_file() || metadata.len() > MAX_COMPLETE_METADATA_BYTES {
         return None;
     }
     fs::read_to_string(path).ok()
+}
+
+fn opening_delimiter(reader: &mut impl BufRead, consumed: &mut usize) -> Result<bool, ()> {
+    for expected in b"---" {
+        match read_byte(reader, consumed)? {
+            Some(byte) if byte == *expected => {}
+            Some(_) | None => return Ok(false),
+        }
+    }
+    match read_byte(reader, consumed)? {
+        Some(b'\n') => Ok(true),
+        Some(b'\r') => Ok(read_byte(reader, consumed)? == Some(b'\n')),
+        Some(_) | None => Ok(false),
+    }
+}
+
+fn read_byte(reader: &mut impl BufRead, consumed: &mut usize) -> Result<Option<u8>, ()> {
+    if *consumed >= MAX_MARKDOWN_FRONTMATTER_BYTES {
+        return Ok(None);
+    }
+    let available = reader.fill_buf().map_err(|_error| ())?;
+    let Some(byte) = available.first().copied() else {
+        return Ok(None);
+    };
+    reader.consume(1);
+    *consumed = consumed.saturating_add(1);
+    Ok(Some(byte))
+}
+
+fn bounded_line(
+    reader: &mut impl BufRead,
+    consumed: &mut usize,
+) -> Result<Option<Vec<u8>>, io::Error> {
+    let mut line = Vec::new();
+    loop {
+        if *consumed >= MAX_MARKDOWN_FRONTMATTER_BYTES {
+            return Ok(None);
+        }
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok((!line.is_empty()).then_some(line));
+        }
+        let remaining = MAX_MARKDOWN_FRONTMATTER_BYTES.saturating_sub(*consumed);
+        let bounded = &available[..available.len().min(remaining)];
+        let length = bounded
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(bounded.len(), |index| index.saturating_add(1));
+        line.extend_from_slice(&bounded[..length]);
+        reader.consume(length);
+        *consumed = consumed.saturating_add(length);
+        if line.ends_with(b"\n") {
+            return Ok(Some(line));
+        }
+    }
+}
+
+fn is_closing_delimiter(line: &[u8]) -> bool {
+    without_line_ending(line) == b"---"
+}
+
+fn without_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+fn parse_line(metadata: &mut Metadata, line: &str) {
+    let Some((key, value)) = line.split_once(':') else {
+        return;
+    };
+    let value = scalar(value);
+    match key.trim() {
+        "name" => metadata.name = clean_name(&value),
+        "description" => metadata.description = clean_description(&value),
+        "mode" => metadata.mode = clean_name(&value).map(|value| value.to_lowercase()),
+        "hidden" | "disable" => metadata.hidden = matches!(value.as_str(), "true" | "yes"),
+        _ => {}
+    }
 }
 
 fn scalar(value: &str) -> String {
@@ -119,3 +228,6 @@ fn clean_description(value: &str) -> Option<String> {
     }
     Some(cleaned.chars().take(MAX_DESCRIPTION_CHARS).collect())
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/adapters/invocation/metadata/tests.rs
+++ b/src/adapters/invocation/metadata/tests.rs
@@ -1,0 +1,124 @@
+use std::io::{self, Cursor, Read};
+
+use super::{MAX_MARKDOWN_FRONTMATTER_BYTES, MarkdownMetadata, markdown_reader};
+
+struct ReadProbe {
+    bytes: Cursor<Vec<u8>>,
+    bytes_read: usize,
+    largest_request: usize,
+}
+
+impl ReadProbe {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes: Cursor::new(bytes),
+            bytes_read: 0,
+            largest_request: 0,
+        }
+    }
+}
+
+impl Read for ReadProbe {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        self.largest_request = self.largest_request.max(buffer.len());
+        let count = self.bytes.read(buffer)?;
+        self.bytes_read = self.bytes_read.saturating_add(count);
+        Ok(count)
+    }
+}
+
+#[test]
+fn production_reader_stops_underlying_reads_at_the_closing_delimiter() {
+    let prefix = b"---\nname: bounded\ndescription: Prefix only\n---\n";
+    let mut definition = prefix.to_vec();
+    definition.extend_from_slice(b"instruction body\n\xff\xfe");
+    let mut reader = ReadProbe::new(definition);
+
+    let MarkdownMetadata::Parsed(metadata) = markdown_reader(&mut reader) else {
+        panic!("valid metadata prefix");
+    };
+
+    assert_eq!(metadata.name.as_deref(), Some("bounded"));
+    assert_eq!(metadata.description.as_deref(), Some("Prefix only"));
+    assert_eq!(reader.bytes_read, prefix.len());
+    assert_eq!(reader.bytes.position(), prefix.len() as u64);
+    assert_eq!(reader.largest_request, 1);
+}
+
+#[test]
+fn filename_derived_command_without_frontmatter_reads_only_the_first_byte() {
+    let mut reader = Cursor::new(b"instruction body that is not metadata".as_slice());
+
+    assert!(matches!(
+        markdown_reader(&mut reader),
+        MarkdownMetadata::Absent
+    ));
+    assert_eq!(reader.position(), 1);
+}
+
+#[test]
+fn invalid_utf8_inside_metadata_fails_closed() {
+    let mut reader = Cursor::new(b"---\ndescription: invalid \xff\n---\nbody".as_slice());
+
+    assert!(matches!(
+        markdown_reader(&mut reader),
+        MarkdownMetadata::Invalid
+    ));
+}
+
+#[test]
+fn crlf_frontmatter_is_bounded_by_its_closing_line() {
+    let prefix = b"---\r\nname: crlf\r\ndescription: Windows lines\r\n---\r\n";
+    let mut definition = prefix.to_vec();
+    definition.extend_from_slice(b"body\r\n");
+    let mut reader = Cursor::new(definition);
+
+    let MarkdownMetadata::Parsed(metadata) = markdown_reader(&mut reader) else {
+        panic!("CRLF metadata");
+    };
+
+    assert_eq!(metadata.name.as_deref(), Some("crlf"));
+    assert_eq!(metadata.description.as_deref(), Some("Windows lines"));
+    assert_eq!(reader.position(), prefix.len() as u64);
+}
+
+#[test]
+fn unterminated_frontmatter_stops_at_the_budget() {
+    let mut definition = b"---\ndescription: never closed\n".to_vec();
+    definition.resize(MAX_MARKDOWN_FRONTMATTER_BYTES + 8_192, b'x');
+    let mut reader = Cursor::new(definition);
+
+    assert!(matches!(
+        markdown_reader(&mut reader),
+        MarkdownMetadata::Invalid
+    ));
+    assert_eq!(reader.position(), MAX_MARKDOWN_FRONTMATTER_BYTES as u64);
+}
+
+#[test]
+fn closing_delimiter_beyond_the_budget_fails_closed() {
+    let mut definition = b"---\nmetadata-padding: ".to_vec();
+    definition.resize(MAX_MARKDOWN_FRONTMATTER_BYTES + 1, b'x');
+    definition.extend_from_slice(b"\n---\nbody");
+    let mut reader = Cursor::new(definition);
+
+    assert!(matches!(
+        markdown_reader(&mut reader),
+        MarkdownMetadata::Invalid
+    ));
+    assert_eq!(reader.position(), MAX_MARKDOWN_FRONTMATTER_BYTES as u64);
+}
+
+#[test]
+fn metadata_fields_after_the_line_bound_are_not_retained() {
+    let mut definition = String::from("---\n");
+    definition.push_str(&"ignored: value\n".repeat(64));
+    definition.push_str("description: too late\n---\nbody");
+    let mut reader = Cursor::new(definition.as_bytes());
+
+    let MarkdownMetadata::Parsed(metadata) = markdown_reader(&mut reader) else {
+        panic!("closed metadata");
+    };
+
+    assert!(metadata.description.is_none());
+}

--- a/src/adapters/invocation/scan.rs
+++ b/src/adapters/invocation/scan.rs
@@ -258,14 +258,16 @@ fn push_markdown(
     let Ok(file_metadata) = fs::metadata(definition) else {
         return;
     };
-    if !file_metadata.is_file() || file_metadata.len() > metadata::MAX_METADATA_BYTES {
+    if !file_metadata.is_file() {
         return;
     }
-    let parsed = metadata::markdown(definition);
-    if matches!(root.shape, RootShape::Skills | RootShape::MarkdownAgents) && parsed.is_none() {
-        return;
-    }
-    let metadata = parsed.unwrap_or_default();
+    let metadata = match metadata::markdown(definition) {
+        metadata::MarkdownMetadata::Parsed(metadata) => metadata,
+        metadata::MarkdownMetadata::Absent if root.shape == RootShape::MarkdownCommands => {
+            metadata::Metadata::default()
+        }
+        metadata::MarkdownMetadata::Absent | metadata::MarkdownMetadata::Invalid => return,
+    };
     if metadata.hidden {
         return;
     }

--- a/src/adapters/invocation/tests.rs
+++ b/src/adapters/invocation/tests.rs
@@ -9,6 +9,7 @@ use crate::ports::invocation::{
 
 use super::FilesystemInvocationCatalog;
 
+mod markdown_prefix;
 #[cfg(unix)]
 mod symlink_layout;
 
@@ -88,7 +89,7 @@ fn kinds_and_documented_harness_forms_stay_distinct() {
 }
 
 #[test]
-fn symlinks_are_canonicalized_and_invalid_or_large_metadata_is_skipped() {
+fn symlinks_are_canonicalized_and_filename_commands_need_no_frontmatter() {
     let fixture = TempDir::new().expect("tempdir");
     let home = fixture.path().join("home");
     let cwd = fixture.path().join("repo");
@@ -136,7 +137,12 @@ fn symlinks_are_canonicalized_and_invalid_or_large_metadata_is_skipped() {
         .expect("linked skill");
     assert_eq!(linked.forms.len(), 1);
     assert_eq!(linked.forms[0].token, "$linked");
-    assert!(result.project.iter().all(|entry| entry.name != "huge"));
+    assert!(
+        result
+            .project
+            .iter()
+            .any(|entry| entry.forms.iter().any(|form| form.token == "/huge"))
+    );
     assert!(
         result
             .project

--- a/src/adapters/invocation/tests/markdown_prefix.rs
+++ b/src/adapters/invocation/tests/markdown_prefix.rs
@@ -1,0 +1,342 @@
+use std::{fs, path::Path};
+
+use super::{discover, write};
+use tempfile::TempDir;
+
+fn large_markdown(frontmatter: &str, total_bytes: usize) -> String {
+    let mut definition = format!("---\n{frontmatter}---\n");
+    assert!(definition.len() < total_bytes);
+    definition.push_str(&"x".repeat(total_bytes.saturating_sub(definition.len())));
+    definition
+}
+
+fn write_bytes(path: &Path, content: &[u8]) {
+    fs::create_dir_all(path.parent().expect("fixture parent")).expect("create fixture directory");
+    fs::write(path, content).expect("write fixture");
+}
+
+fn has_token(result: &crate::ports::invocation::InvocationDiscovery, token: &str) -> bool {
+    result
+        .project
+        .iter()
+        .chain(&result.global)
+        .any(|entry| entry.forms.iter().any(|form| form.token == token))
+}
+
+fn issue_51_command() -> String {
+    const FRONTMATTER_END: usize = 614;
+    const TOTAL_BYTES: usize = 19_702;
+    let mut definition =
+        String::from("---\ndescription: Issue 51 regression command\nmetadata-padding: ");
+    let padding = FRONTMATTER_END
+        .saturating_sub(definition.len())
+        .saturating_sub("\n---\n".len());
+    definition.push_str(&"x".repeat(padding));
+    definition.push_str("\n---\n");
+    assert_eq!(definition.len(), FRONTMATTER_END);
+    definition.push_str(&"x".repeat(TOTAL_BYTES.saturating_sub(definition.len())));
+    assert_eq!(definition.len(), TOTAL_BYTES);
+    definition
+}
+
+#[test]
+fn issue_51_large_plugin_command_uses_its_small_frontmatter() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    let plugin = fixture.path().join("plugins/issue51");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    write(&plugin.join("commands/large.md"), &issue_51_command());
+    write(
+        &home.join(".claude/plugins/installed_plugins.json"),
+        &format!(
+            "{{\"plugins\":{{\"issue51@catalog\":[{{\"installPath\":{:?}}}]}}}}",
+            plugin.to_string_lossy()
+        ),
+    );
+
+    let result = discover(&home, &cwd);
+
+    assert!(result.global.iter().any(|entry| {
+        entry
+            .forms
+            .iter()
+            .any(|form| form.token == "/issue51:large")
+    }));
+}
+
+#[test]
+fn large_markdown_definitions_work_across_scope_and_kind_boundaries() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    let plugin = fixture.path().join("plugins/stress");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+
+    let definitions = [
+        (
+            cwd.join(".agents/skills/project-skill/SKILL.md"),
+            "name: project-skill\ndescription: Project Agent Skill\n",
+            24_799,
+        ),
+        (
+            home.join(".agents/skills/global-skill/SKILL.md"),
+            "name: global-skill\ndescription: Global Agent Skill\n",
+            96 * 1024,
+        ),
+        (
+            plugin.join("skills/plugin-skill/SKILL.md"),
+            "name: plugin-skill\ndescription: Plugin skill\n",
+            128 * 1024,
+        ),
+        (
+            cwd.join(".claude/commands/project-command.md"),
+            "description: Project command\n",
+            32 * 1024,
+        ),
+        (
+            home.join(".claude/commands/global-command.md"),
+            "description: Global command\n",
+            256 * 1024,
+        ),
+        (
+            cwd.join(".claude/agents/project-agent.md"),
+            "name: project-agent\ndescription: Project agent\n",
+            48 * 1024,
+        ),
+        (
+            home.join(".claude/agents/global-agent.md"),
+            "name: global-agent\ndescription: Global agent\n",
+            512 * 1024,
+        ),
+        (
+            plugin.join("agents/plugin-agent.md"),
+            "name: plugin-agent\ndescription: Plugin agent\n",
+            8 * 1024 * 1024,
+        ),
+    ];
+    for (path, frontmatter, size) in definitions {
+        write(&path, &large_markdown(frontmatter, size));
+    }
+    write(
+        &home.join(".claude/plugins/installed_plugins.json"),
+        &format!(
+            "{{\"plugins\":{{\"stress@catalog\":[{{\"installPath\":{:?}}}]}}}}",
+            plugin.to_string_lossy()
+        ),
+    );
+
+    let result = discover(&home, &cwd);
+
+    for token in [
+        "$project-skill",
+        "$global-skill",
+        "/stress:plugin-skill",
+        "/project-command",
+        "/global-command",
+        "@agent-project-agent",
+        "@agent-global-agent",
+        "@agent-stress:plugin-agent",
+    ] {
+        assert!(has_token(&result, token), "missing {token}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn large_symlinked_skill_keeps_agent_and_claude_forms() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    let external = fixture.path().join("external/shared");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    write(
+        &external.join("SKILL.md"),
+        &large_markdown(
+            "name: shared-large\ndescription: Large shared symlink\n",
+            2 * 1024 * 1024,
+        ),
+    );
+    fs::create_dir_all(cwd.join(".agents/skills")).expect("Agent Skills root");
+    fs::create_dir_all(cwd.join(".claude/skills")).expect("Claude skills root");
+    let agent_alias = cwd.join(".agents/skills/shared-large");
+    std::os::unix::fs::symlink(&external, &agent_alias).expect("Agent Skills alias");
+    std::os::unix::fs::symlink(&agent_alias, cwd.join(".claude/skills/shared-large"))
+        .expect("Claude alias");
+
+    let result = discover(&home, &cwd);
+
+    assert!(has_token(&result, "$shared-large"));
+    assert!(has_token(&result, "/shared-large"));
+    assert_eq!(
+        result
+            .project
+            .iter()
+            .filter(|entry| entry.name == "shared-large")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn metadata_validity_and_visibility_are_decided_before_large_bodies() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    write(
+        &cwd.join(".agents/skills/unicode/SKILL.md"),
+        &large_markdown("name: unicode\ndescription: Grüße 界 und 👩‍💻\n", 80 * 1024),
+    );
+    let crlf = large_markdown("name: crlf-agent\ndescription: CRLF agent\n", 72 * 1024)
+        .replace('\n', "\r\n");
+    write(&cwd.join(".claude/agents/crlf-agent.md"), &crlf);
+    write(
+        &cwd.join(".claude/commands/hidden.md"),
+        &large_markdown("description: Hidden\nhidden: true\n", 96 * 1024),
+    );
+    write(
+        &cwd.join(".agents/skills/disabled/SKILL.md"),
+        &large_markdown(
+            "name: disabled\ndescription: Disabled\ndisable: yes\n",
+            96 * 1024,
+        ),
+    );
+
+    let result = discover(&home, &cwd);
+
+    assert!(has_token(&result, "$unicode"));
+    assert!(has_token(&result, "@agent-crlf-agent"));
+    assert!(!has_token(&result, "/hidden"));
+    assert!(!has_token(&result, "$disabled"));
+    let unicode = result
+        .project
+        .iter()
+        .find(|entry| entry.name == "unicode")
+        .expect("Unicode skill");
+    assert_eq!(unicode.description.as_deref(), Some("Grüße 界 und 👩‍💻"));
+}
+
+#[test]
+fn missing_or_invalid_headers_keep_filename_commands_but_reject_required_metadata() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    write_bytes(
+        &cwd.join(".claude/commands/no-header.md"),
+        b"\xff\xfe instruction body without frontmatter",
+    );
+    write(
+        &cwd.join(".agents/skills/no-header/SKILL.md"),
+        "instruction body without frontmatter",
+    );
+    write(
+        &cwd.join(".claude/agents/malformed.md"),
+        "---\nnot valid metadata\n---\nbody",
+    );
+    write_bytes(
+        &cwd.join(".agents/skills/invalid-utf8/SKILL.md"),
+        b"---\nname: invalid-utf8\ndescription: bad \xff\n---\nbody",
+    );
+    write_bytes(
+        &cwd.join(".claude/commands/invalid-utf8-header.md"),
+        b"---\ndescription: bad \xff\n---\nbody",
+    );
+    let mut invalid_body = b"---\nname: valid-body\ndescription: Metadata is valid\n---\n".to_vec();
+    invalid_body.extend_from_slice(b"\xff\xfe body bytes");
+    write_bytes(
+        &cwd.join(".agents/skills/valid-body/SKILL.md"),
+        &invalid_body,
+    );
+
+    let result = discover(&home, &cwd);
+
+    assert!(has_token(&result, "/no-header"));
+    assert!(has_token(&result, "$valid-body"));
+    assert!(!has_token(&result, "$no-header"));
+    assert!(!has_token(&result, "@agent-malformed"));
+    assert!(!has_token(&result, "$invalid-utf8"));
+    assert!(!has_token(&result, "/invalid-utf8-header"));
+}
+
+#[test]
+fn unterminated_and_over_budget_headers_fail_closed() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    let mut unterminated = String::from("---\nname: unterminated\ndescription: Missing close\n");
+    unterminated.push_str(&"x".repeat(80 * 1024));
+    write(
+        &cwd.join(".agents/skills/unterminated/SKILL.md"),
+        &unterminated,
+    );
+    write(&cwd.join(".claude/commands/unterminated.md"), &unterminated);
+    let mut late = String::from("---\nname: late\ndescription: Late close\npadding: ");
+    late.push_str(&"x".repeat(64 * 1024));
+    late.push_str("\n---\nbody");
+    write(&cwd.join(".agents/skills/late/SKILL.md"), &late);
+    let mut hidden_late =
+        String::from("---\ndescription: Hidden late close\nhidden: true\npadding: ");
+    hidden_late.push_str(&"x".repeat(64 * 1024));
+    hidden_late.push_str("\n---\nbody");
+    write(&cwd.join(".claude/commands/hidden-late.md"), &hidden_late);
+
+    let result = discover(&home, &cwd);
+
+    assert!(!has_token(&result, "$unterminated"));
+    assert!(!has_token(&result, "$late"));
+    assert!(!has_token(&result, "/unterminated"));
+    assert!(!has_token(&result, "/hidden-late"));
+}
+
+#[test]
+fn complete_file_bounds_remain_for_toml_registries_and_manifests() {
+    let fixture = TempDir::new().expect("tempdir");
+    let home = fixture.path().join("home");
+    let cwd = fixture.path().join("repo");
+    let plugin = fixture.path().join("plugins/fallback");
+    write(&cwd.join(".git/HEAD"), "ref: refs/heads/main\n");
+    let mut oversized_toml = String::from("name = \"oversized\"\ndescription = \"Agent\"\n");
+    oversized_toml.push_str(&"# padding\n".repeat(2_000));
+    write(&cwd.join(".codex/agents/oversized.toml"), &oversized_toml);
+    write(
+        &plugin.join("commands/default.md"),
+        "---\ndescription: Default root\n---\nbody",
+    );
+    write(
+        &plugin.join("custom/custom.md"),
+        "---\ndescription: Custom root\n---\nbody",
+    );
+    let manifest = format!(
+        "{{\"name\":\"custom-name\",\"commands\":\"custom\",\"padding\":\"{}\"}}",
+        "x".repeat(65 * 1024)
+    );
+    write(&plugin.join(".claude-plugin/plugin.json"), &manifest);
+    write(
+        &home.join(".claude/plugins/installed_plugins.json"),
+        &format!(
+            "{{\"plugins\":{{\"fallback@catalog\":[{{\"installPath\":{:?}}}]}}}}",
+            plugin.to_string_lossy()
+        ),
+    );
+
+    let result = discover(&home, &cwd);
+
+    assert!(result.project.iter().all(|entry| entry.name != "oversized"));
+    assert!(has_token(&result, "/fallback:default"));
+    assert!(!has_token(&result, "/custom-name:custom"));
+
+    let oversized_registry = format!(
+        "{{\"plugins\":{{\"fallback@catalog\":[{{\"installPath\":{:?},\"padding\":\"{}\"}}]}}}}",
+        plugin.to_string_lossy(),
+        "x".repeat(512 * 1024)
+    );
+    write(
+        &home.join(".claude/plugins/installed_plugins.json"),
+        &oversized_registry,
+    );
+    let result = discover(&home, &cwd);
+    assert!(!has_token(&result, "/fallback:default"));
+}

--- a/tests/pty/invocation.rs
+++ b/tests/pty/invocation.rs
@@ -3,17 +3,18 @@
 use super::support::{consume_first_run, expect_command, json_command};
 
 #[test]
-fn discovered_invocation_completes_and_shuts_down_in_a_real_pty() {
+fn large_discovered_invocation_completes_and_shuts_down_in_a_real_pty() {
     let state = tempfile::tempdir().expect("temporary state");
     let home = tempfile::tempdir().expect("isolated home");
     let external = home.path().join("catalog/aos-media-image");
     let skill = external.join("SKILL.md");
     std::fs::create_dir_all(&external).expect("external skill directory");
-    std::fs::write(
-        skill,
-        "---\nname: aos-media-image\ndescription: Erstellt Bilder für Grüße und 界\n---\nfixture body",
-    )
-    .expect("skill fixture");
+    let mut definition =
+        "---\nname: aos-media-image\ndescription: Erstellt Bilder für Grüße und 界\n---\n"
+            .as_bytes()
+            .to_vec();
+    definition.resize(64 * 1024, 0xff);
+    std::fs::write(skill, definition).expect("large skill fixture");
     let agent_root = home.path().join(".agents/skills");
     let claude_root = home.path().join(".claude/skills");
     std::fs::create_dir_all(&agent_root).expect("Agent Skills root");


### PR DESCRIPTION
## Summary

- Discover Markdown invocation metadata through an explicit 64 KiB frontmatter reader that stops underlying reads at the complete closing delimiter and never reads or retains the instruction body.
- Distinguish absent, valid, and invalid frontmatter so filename-derived commands work without frontmatter while malformed opened headers fail closed.
- Preserve metadata sanitization, visibility behavior, traversal budgets, canonical deduplication, precedence, and complete-file limits for TOML agents, plugin manifests, and registries.
- Update the product, architecture, and invocation documentation to reflect the actual discovery boundary.

Closes #51.

By contributing, you agree that your contribution is licensed under the
repository's [MIT License](https://github.com/oborchers/proqi/blob/main/LICENSE).
See [CONTRIBUTING.md](https://github.com/oborchers/proqi/blob/main/CONTRIBUTING.md)
for the repository's contribution rules.
Report vulnerabilities through
[SECURITY.md](https://github.com/oborchers/proqi/blob/main/SECURITY.md), never in
this pull request.

## Regression coverage

- Reproduces the exact 19,702-byte issue fixture whose frontmatter closes at byte 614.
- Covers definitions larger than 24 KiB and an 8 MiB stress definition across project, global, plugin, and supported symlink roots.
- Covers skills, commands, Markdown agents, hidden and disabled metadata, Unicode, CRLF, missing and malformed headers, invalid UTF-8, and over-budget or unterminated frontmatter.
- Instruments the production reader to prove that underlying reads stop exactly at the closing delimiter.
- Preserves complete bounded parsing and rejection for TOML agents, manifests, and registries.
- Exercises the real PTY path with a 64 KiB definition whose body contains invalid UTF-8.

## Verification

- [x] `cargo xtask check`
- [x] `cargo xtask audit`
- [x] `cargo xtask package`
- [x] `cargo xtask test-pty`
- [x] Focused invocation adapter and real PTY tests
- [x] Documentation updated
- [x] No runtime state, secrets, machine-specific paths, or pending snapshots
- [x] Native Codex review pass 2 returned no actionable findings
- [x] Isolated live Herdr stress checkpoint completed
