### PR TITLE
Fix update participant readiness race

### DIFF
--- a/tests/pty/support.rs
+++ b/tests/pty/support.rs
@@ -8,6 +8,15 @@ use std::process::Command;
 
 use serde_json::Value;
 
+use proqi::{
+    adapters::runtime::{FileRuntimeCoordinator, SystemClock, SystemIdGenerator},
+    domain::SessionId,
+    ports::{
+        environment::{Clock as _, IdGenerator as _},
+        runtime::{InstanceInfo, RuntimeCoordinator as _, RuntimeError},
+    },
+};
+
 const OWNER_READINESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 pub(super) fn expect_command() -> Command {
@@ -27,12 +36,23 @@ pub(super) fn wait_for_path(path: &std::path::Path) {
     }
 }
 
-pub(super) fn wait_for_control_owner(state: &std::path::Path, session: &str) {
-    let instances = state.join("runtime/instances");
+pub(super) fn wait_for_control_owner(state: &std::path::Path, session: &str) -> InstanceInfo {
+    let session = session.parse::<SessionId>().expect("session ID");
+    let mut ids = SystemIdGenerator;
+    let coordinator = FileRuntimeCoordinator::new(
+        state.join("runtime"),
+        ids.instance_id(),
+        std::env::current_dir().expect("current directory"),
+        SystemClock.now(),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .expect("runtime coordinator");
     let deadline = std::time::Instant::now() + OWNER_READINESS_TIMEOUT;
     loop {
-        if control_owner_is_ready(&instances, session) {
-            return;
+        if let Some(participant) =
+            ready_control_owner(&coordinator, session).expect("scan runtime owners")
+        {
+            return participant;
         }
         assert!(
             std::time::Instant::now() < deadline,
@@ -42,28 +62,18 @@ pub(super) fn wait_for_control_owner(state: &std::path::Path, session: &str) {
     }
 }
 
-fn control_owner_is_ready(instances: &std::path::Path, session: &str) -> bool {
-    let Ok(entries) = std::fs::read_dir(instances) else {
-        return false;
-    };
-    entries
-        .filter_map(Result::ok)
-        .any(|entry| control_metadata_is_ready(&entry.path(), session))
-}
-
-fn control_metadata_is_ready(path: &std::path::Path, session: &str) -> bool {
-    let Ok(bytes) = std::fs::read(path) else {
-        return false;
-    };
-    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
-        return false;
-    };
-    value["session_id"] == session
-        && value["control_protocol"].as_u64()
-            == Some(u64::from(proqi::ports::control::CONTROL_PROTOCOL_VERSION))
-        && value["control_endpoint"]
-            .as_str()
-            .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
+fn ready_control_owner(
+    coordinator: &FileRuntimeCoordinator,
+    session: SessionId,
+) -> Result<Option<InstanceInfo>, RuntimeError> {
+    Ok(coordinator.active_instances()?.into_iter().find(|info| {
+        info.session_id == session
+            && info.control_protocol == Some(proqi::ports::control::CONTROL_PROTOCOL_VERSION)
+            && info
+                .control_endpoint
+                .as_deref()
+                .is_some_and(|endpoint| std::path::Path::new(endpoint).exists())
+    }))
 }
 
 pub(super) fn raw_input_command(
@@ -147,4 +157,141 @@ pub(super) fn consume_first_run(binary: &str, state: &std::path::Path) {
         .expect("first session ID");
     let _trashed = json_command(binary, state, &["sessions", "trash", session]);
     let _pruned = json_command(binary, state, &["sessions", "prune", session, "--yes"]);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use proqi::{
+        adapters::{
+            memory::FakeIdGenerator,
+            runtime::{FileRuntimeCoordinator, FileSessionLease},
+        },
+        domain::Timestamp,
+        ports::{environment::IdGenerator as _, runtime::RuntimeCoordinator as _},
+    };
+
+    use super::ready_control_owner;
+
+    struct OwnerFixture {
+        lease: FileSessionLease,
+        observer: FileRuntimeCoordinator,
+        endpoint: PathBuf,
+        runtime: PathBuf,
+        _state: tempfile::TempDir,
+    }
+
+    fn owner_fixture(id_seed: u64) -> OwnerFixture {
+        let state = tempfile::tempdir().expect("temporary state");
+        let runtime = state.path().join("runtime");
+        let mut ids = FakeIdGenerator::new(id_seed);
+        let owner = FileRuntimeCoordinator::new(
+            runtime.clone(),
+            ids.instance_id(),
+            state.path().to_path_buf(),
+            Timestamp::from_millis(2),
+            "1.0.0",
+        )
+        .expect("owner coordinator");
+        let observer = FileRuntimeCoordinator::new(
+            runtime.clone(),
+            ids.instance_id(),
+            state.path().to_path_buf(),
+            Timestamp::from_millis(3),
+            "1.0.0",
+        )
+        .expect("observer coordinator");
+        let lease = owner
+            .acquire_session(ids.session_id())
+            .expect("session lease");
+        let endpoint = PathBuf::from(lease.control_endpoint().expect("prepared endpoint"));
+        std::fs::write(&endpoint, []).expect("endpoint fixture");
+        OwnerFixture {
+            lease,
+            observer,
+            endpoint,
+            runtime,
+            _state: state,
+        }
+    }
+
+    #[test]
+    fn readiness_returns_the_exact_canonical_owner_not_atomic_or_stale_neighbors() {
+        let mut fixture = owner_fixture(1_800_100_000_000);
+        let session = fixture.lease.info().session_id;
+        let mut ready_temporary = fixture.lease.info().clone();
+        ready_temporary.control_protocol = Some(proqi::ports::control::CONTROL_PROTOCOL_VERSION);
+        ready_temporary.control_endpoint = Some(fixture.endpoint.to_string_lossy().into_owned());
+        let temporary = fixture
+            .runtime
+            .join("instances")
+            .join(format!("{}.json.tmp", ready_temporary.instance_id));
+        std::fs::write(
+            temporary,
+            serde_json::to_vec(&ready_temporary).expect("temporary metadata"),
+        )
+        .expect("atomic-write neighbor");
+        std::fs::write(fixture.runtime.join("instances/malformed.json"), b"{")
+            .expect("malformed neighbor");
+
+        let mut stale_ids = FakeIdGenerator::new(1_700_000_000_000);
+        let mut stale = ready_temporary;
+        stale.instance_id = stale_ids.instance_id();
+        stale.started_at = Timestamp::from_millis(1);
+        let stale_path = fixture
+            .runtime
+            .join("instances")
+            .join(format!("{}.json", stale.instance_id));
+        std::fs::write(
+            stale_path,
+            serde_json::to_vec(&stale).expect("stale metadata"),
+        )
+        .expect("stale same-session neighbor");
+
+        assert_eq!(
+            ready_control_owner(&fixture.observer, session).expect("initial scan"),
+            None
+        );
+        fixture.lease.publish_control().expect("publish control");
+        assert_eq!(
+            ready_control_owner(&fixture.observer, session).expect("ready scan"),
+            Some(fixture.lease.info().clone())
+        );
+    }
+
+    #[test]
+    fn readiness_requires_the_current_protocol_and_existing_endpoint() {
+        let mut fixture = owner_fixture(1_800_200_000_000);
+        let session = fixture.lease.info().session_id;
+        fixture.lease.publish_control().expect("publish control");
+        let metadata = fixture
+            .runtime
+            .join("instances")
+            .join(format!("{}.json", fixture.lease.info().instance_id));
+        let mut wrong_protocol = fixture.lease.info().clone();
+        wrong_protocol.control_protocol =
+            Some(proqi::ports::control::CONTROL_PROTOCOL_VERSION.saturating_sub(1));
+        std::fs::write(
+            &metadata,
+            serde_json::to_vec(&wrong_protocol).expect("wrong protocol metadata"),
+        )
+        .expect("replace protocol fixture");
+        assert_eq!(
+            ready_control_owner(&fixture.observer, session).expect("protocol scan"),
+            None
+        );
+
+        fixture.lease.publish_control().expect("restore protocol");
+        std::fs::remove_file(&fixture.endpoint).expect("remove endpoint");
+        assert_eq!(
+            ready_control_owner(&fixture.observer, session).expect("endpoint scan"),
+            None
+        );
+        std::fs::write(&fixture.endpoint, []).expect("restore endpoint");
+        assert_eq!(
+            ready_control_owner(&fixture.observer, session).expect("restored scan"),
+            Some(fixture.lease.info().clone())
+        );
+    }
 }

--- a/tests/pty/update_control.rs
+++ b/tests/pty/update_control.rs
@@ -51,9 +51,7 @@ fn real_owner_preflights_and_returns_to_use_after_one_fake_installation() {
     let done = state.path().join("update-owner-done");
     let mut owner = spawn_owner(binary, state.path(), session, &ready, &done);
     wait_for_path(&ready);
-    wait_for_control_owner(state.path(), session);
-
-    let participant = active_participant(state.path(), session);
+    let participant = wait_for_control_owner(state.path(), session);
     let installation = SystemInstallDetector::for_executable(binary.into())
         .detect()
         .expect("installation identity");
@@ -116,9 +114,7 @@ fn homebrew_owner_restores_and_replaces_itself_in_the_same_pty() {
     let mut owner =
         spawn_restarting_owner(&binary, state.path(), session, &ready, &restarted, &done);
     wait_for_path(&ready);
-    wait_for_control_owner(state.path(), session);
-
-    let before = active_participant(state.path(), session);
+    let before = wait_for_control_owner(state.path(), session);
     let installation = SystemInstallDetector::for_executable(binary.clone())
         .detect()
         .expect("Homebrew installation");
@@ -151,8 +147,7 @@ fn homebrew_owner_restores_and_replaces_itself_in_the_same_pty() {
     assert!(restart.accepted);
 
     wait_for_path(&restarted);
-    wait_for_control_owner(state.path(), session);
-    let after = active_participant(state.path(), session);
+    let after = wait_for_control_owner(state.path(), session);
     assert_eq!(
         after.pid, before.pid,
         "Unix exec must preserve the process ID"
@@ -186,15 +181,13 @@ fn in_app_restart_reopens_until_dismissed_then_remains_manual() {
         &peer_done,
     );
     wait_for_path(&peer_ready);
-    wait_for_control_owner(state.path(), peer_session);
+    let mut peer_participant = wait_for_control_owner(state.path(), peer_session);
     let ready = state.path().join("highlight-owner-ready");
     let mut owner = highlight_fixture::spawn_crash_owner(&binary, state.path(), session, &ready);
     wait_for_path(&ready);
-    wait_for_control_owner(state.path(), session);
-    rewrite_participant_version(state.path(), session, "0.3.0");
-    rewrite_participant_version(state.path(), peer_session, "0.3.0");
-
-    let before = active_participant(state.path(), session);
+    let mut before = wait_for_control_owner(state.path(), session);
+    rewrite_participant_version(state.path(), &mut before, "0.3.0");
+    rewrite_participant_version(state.path(), &mut peer_participant, "0.3.0");
     let (update_state, installation, target) =
         coordinate_highlight_restart(&binary, state.path(), &before);
     wait_for_path(&peer_restarted);
@@ -301,38 +294,14 @@ fn coordinate_highlight_restart(
     (update_state, installation.identity, target)
 }
 
-fn active_participant(state: &Path, session: &str) -> InstanceInfo {
-    active_participant_entry(state, session).1
-}
-
-fn active_participant_entry(state: &Path, session: &str) -> (std::path::PathBuf, InstanceInfo) {
-    let directory = state.join("runtime/instances");
-    fs::read_dir(directory)
-        .expect("instance directory")
-        .filter_map(Result::ok)
-        .filter_map(|entry| {
-            let path = entry.path();
-            let bytes = fs::read(&path).ok()?;
-            let info = serde_json::from_slice::<InstanceInfo>(&bytes).ok()?;
-            Some((path, info))
-        })
-        .find(|(_, info)| {
-            info.session_id.to_string() == session
-                && info.control_protocol == Some(proqi::ports::control::CONTROL_PROTOCOL_VERSION)
-                && info
-                    .control_endpoint
-                    .as_deref()
-                    .is_some_and(|endpoint| Path::new(endpoint).exists())
-        })
-        .expect("active participant")
-}
-
-fn rewrite_participant_version(state: &Path, session: &str, version: &str) {
-    let (path, mut info) = active_participant_entry(state, session);
-    version.clone_into(&mut info.version);
+fn rewrite_participant_version(state: &Path, participant: &mut InstanceInfo, version: &str) {
+    version.clone_into(&mut participant.version);
+    let path = state
+        .join("runtime/instances")
+        .join(format!("{}.json", participant.instance_id));
     fs::write(
         path,
-        serde_json::to_vec(&info).expect("serialize participant"),
+        serde_json::to_vec(participant).expect("serialize participant"),
     )
     .expect("rewrite participant version");
 }


### PR DESCRIPTION
## Summary

- Use the canonical runtime coordinator to establish control-owner readiness.
- Return and reuse the exact `InstanceInfo` whose readiness was observed.
- Add deterministic coverage for atomic-write neighbors, malformed metadata, stale same-session records, protocol mismatch, and endpoint removal.

## Root cause

The PTY fixture scanned every entry in the instance directory. During atomic metadata publication, it could accept a fully ready `.json.tmp` file before that file replaced the canonical `.json` record. The fixture then performed a separate participant scan, creating a time-of-check versus time-of-use gap in which the temporary record had moved but the canonical record was not yet observed as ready.

This was a fixture ownership defect, not a production registration gap. Production already enumerates canonical `.json` records through `FileRuntimeCoordinator`, validates the authoritative session lock, and resolves current ownership. The earlier fixes added current-protocol and live-endpoint predicates, but retained the broad directory scan and the split readiness/read sequence.

## Verification

- Reproduced the old failure under CPU and filesystem pressure at repetitions 15 and 28.
- Passed 100 serial repetitions of the exact failing scenario under equivalent pressure after the fix.
- Passed 30 normal parallel runs of both new readiness regressions, 60 test executions total.
- Passed all related `update_control`, `update_migration`, and `active_control` PTY scenarios.
- Passed `cargo xtask check`, including 1,367 tests.
- Passed `cargo xtask audit`.
- Passed `cargo xtask package`.
- Passed `cargo xtask test-pty`, 70 of 70 scenarios.
- Reviewed all snapshot state. No snapshot changed and no pending snapshot exists.
- Completed three native Codex review passes. The final pass was clean.
