### PR TITLE
Add verified global Herdr agent delivery

### DIFF
--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -24,8 +24,8 @@ The architecture optimizes for five properties:
 - Committed content and undo history must survive process and machine failure.
 - Multiple application versions may temporarily run after a package-manager
   update without corrupting shared state.
-- Clipboard use works everywhere, while adjacent-agent submission remains an
-  optional, capability-gated enhancement.
+- Clipboard use works everywhere, while adjacent and Commands-only global agent
+  submission remain optional, capability-gated enhancements.
 - The core remains testable without a real terminal, clipboard, database, or
   Herdr process.
 
@@ -467,6 +467,7 @@ is the safety boundary.
 trait AgentGateway {
     fn capabilities(&mut self) -> Result<AgentCapabilities>;
     fn adjacent_targets(&mut self, context: PaneContext) -> Result<Vec<AgentTarget>>;
+    fn global_targets(&mut self) -> Result<Vec<AgentTarget>>;
     fn submit(&mut self, request: SubmissionRequest) -> Result<SubmissionReceipt>;
 }
 ```
@@ -690,7 +691,8 @@ event-sourced system.
   pristine schema starts eligible for version 1, while migration from every
   prior schema initializes version 1 as completed.
 - `submission_attempts`: one content-redacted semantic delivery and its
-  aggregate payload digest, target fingerprint, disposition, and state.
+  aggregate payload digest, target fingerprint, disposition, versioned route
+  kind, optional adjacent direction, and state.
 - `submission_attempt_items`: ordered source thought identities and per-source
   digests for one delivery. A partial unique index permits at most one active
   submission per thought.
@@ -771,6 +773,13 @@ is a compatibility boundary: a protocol 10 process must never be admitted as a
 compatible owner after protocol 11 payloads may exist. The separate schema 11
 onboarding migration remains protocol 10, and migration 12 preserves its
 completed or eligible marker exactly.
+
+Schema version 13 and storage protocol version 12 register the closed submission
+route journal. Migration preserves every legacy target fingerprint and decodes
+its required direction as route version 0 `adjacent_pane`. New route version 1
+rows store `adjacent_pane` with a direction or `herdr_agent` without one. Neither
+form stores workspace, tab, pane, session, labels, prompt content, or raw Herdr
+responses.
 
 ## Multiple running versions during an update
 
@@ -1304,6 +1313,8 @@ The adapter:
 
 - Detects Herdr and negotiates its client and server protocol.
 - Resolves neighboring panes in all four directions.
+- Discovers compatible coding agents across the current Herdr server from one
+  fresh, bounded, schema-validated snapshot.
 - Independently verifies pane identity, workspace, tab, geometry, agent type,
   optional session identity, and interactive state.
 - Invokes the semantic prompt command directly without a shell.
@@ -1314,6 +1325,21 @@ The adapter:
 - Projects recognized coding agents from one bounded snapshot for inert
   invocation-picker references, without exposing raw topology or terminal
   metadata above the adapter.
+
+`SubmissionRoute` is a closed discriminated address. `AdjacentPane` retains the
+verified direction, source context, target geometry, and target address.
+`HerdrAgent` retains only the verified current-server workspace, tab, pane,
+harness, and established or explicitly qualified provisional session address.
+It never fabricates geometry or a sentinel direction. Global discovery labels
+are presentation metadata and do not participate in receipt identity.
+
+The Commands-only global chooser is generation tagged. Its loading, filtering,
+selection, rendering, paging, and hit geometry derive from one semantic row
+owner. Discovery and prompt work run on the existing cancellable external lane.
+The reducer and render path perform no Herdr process or filesystem work. The
+chooser shows blocked, unknown, launching, and noninteractive targets but marks
+them ineligible. Submission obtains another fresh snapshot and requires one
+exact matching address before invoking `agent prompt`.
 
 The receiving harness decides whether a prompt sent to a working agent is
 queued, treated as steering, or rejected. The gateway reports that state and
@@ -1371,6 +1397,13 @@ identities, their SHA-256 digests, one aggregate payload digest, and a target
 identity fingerprint, never prompt content or raw pane and agent session
 identifiers.
 
+Schema version 13 and storage protocol version 12 replace the direction-only
+journal address with route encoding version 1, a closed route kind, and an
+optional adjacent direction. Current adjacent rows require a direction and
+global Herdr rows require none. Migration decodes every prior row as legacy
+route version 0 `adjacent_pane`, preserves its direction and exact existing
+fingerprint bytes, and retains conservative prepared and sending recovery.
+
 Attachment preflight precedes creation of this journal attempt. Successful
 preflight preserves the same direct Herdr request and journal transitions.
 External files remain caller-owned paths, so a file can disappear after the
@@ -1404,6 +1437,12 @@ provisional target immediately. When the receipt precedes the session hook,
 Proqi accepts the
 matching receipt and immediately rediscovers adjacent targets without retrying
 the prompt.
+
+For a global route, revalidation rejects disappearance, workspace or tab
+movement, session replacement, protocol disagreement, ambiguous duplicate
+identity, stale or incomplete snapshots, and receipt mismatch. Label renames
+are accepted because labels are not address fields. Invocation references use a
+separate presentation projection and never become submission routes.
 
 Accepted Herdr protocols 19 through 21 acknowledge accepted text entry but do not
 guarantee a distinct prompt boundary when another sender submits concurrently.

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -29,8 +29,9 @@ while adding only the structure that materially improves agent work:
 - Continuous reflow when its terminal pane is resized.
 
 Native copy and paste remain the universal transfer mechanism. In supported
-Herdr environments, direct submission to a verified adjacent agent is an
-optional progressive enhancement.
+Herdr environments, direct submission to a verified adjacent agent and
+Commands-only submission to a verified current-server agent are optional
+progressive enhancements.
 
 ## Product principles
 
@@ -692,7 +693,7 @@ either transformation returns board focus to the retained source identity when
 the generated neighbor had focus and was removed. An immediate redo from the
 retained source editor addresses the same transformation as one unit.
 
-### Submit to an adjacent agent
+### Submit to an agent
 
 When Proqi runs beside one or more agent panes in a supported terminal
 environment, it can submit the focused thought directly to a verified adjacent
@@ -701,6 +702,14 @@ agent above, below, left, or right.
 This is a progressive enhancement. Copy and cut remain available in every
 terminal. Submission controls appear only when an installed integration can
 identify an eligible adjacent agent with confidence.
+
+The searchable Commands overlay also exposes `Submit to agent...`. It discovers
+compatible coding agents in other tabs and workspaces on the current Herdr
+server. This global path has no dedicated shortcut, footer control, or
+always-visible action. After choosing a target, the user explicitly chooses
+`Submit`, which removes only after an accepted receipt, or `Submit and keep`.
+The existing adjacent `s`, `S`, Primary aliases, directional chooser, footer
+controls, and mouse behavior remain unchanged.
 
 Herdr is the first supported integration. It provides directional pane lookup,
 agent detection, optional session identity, readiness state, and an agent-aware
@@ -716,6 +725,13 @@ A submission target is eligible only when all of the following are true:
 - The target is recognized as a supported interactive agent.
 - The target exposes enough identity to show the user where the thought will
   go.
+
+For a global route, verified workspace, tab, pane, harness, and stable or
+qualified provisional session identity replace adjacency geometry. Discovery
+is limited to the current Herdr server. Idle, done, and working targets are
+eligible. Blocked and unknown targets, plus targets still launching or not yet
+interactive, remain visible in the chooser with delivery disabled and truthful
+feedback. Duplicate display names are harmless because labels are not identity.
 
 Directional lookup is never trusted without these independent checks. The
 product never guesses a target and never falls back to raw input injection.
@@ -780,6 +796,14 @@ Submission does not wait for the agent's response and does not import or inspect
 the agent conversation. The receiving harness decides whether a prompt sent
 while it is working is queued, treated as steering, or rejected. Proqi shows
 the agent state but does not reinterpret the harness's behavior.
+
+Global delivery captures the focused thought or current multi-thought selection
+in board order. It revalidates the exact target immediately before the Herdr
+prompt operation and fails closed if the target disappears, moves to another
+workspace or tab, changes session, becomes ambiguous, becomes ineligible, or
+returns a mismatched receipt. Workspace, tab, and agent label renames do not
+change identity. Live invocation references remain inert authoring annotations
+and are never interpreted as delivery targets.
 
 ### Reordering
 
@@ -1468,8 +1492,8 @@ model.
 
 ### Integration boundary
 
-The core defines a narrow adjacent-agent interface for capability discovery,
-verified target resolution, prompt submission, and structured errors. The TUI
+The core defines a narrow agent interface for capability discovery, adjacent
+and current-server target resolution, prompt submission, and structured errors. The TUI
 does not contain Herdr-specific process or protocol logic.
 
 The first adapter invokes the installed Herdr CLI directly without a shell. It
@@ -1477,10 +1501,13 @@ uses structured JSON responses, verifies the client and server protocol, applies
 bounded timeouts, and treats integration failures as non-destructive. Thought
 content is never interpolated into a shell command.
 
-The adapter resolves candidates in all four directions and then validates their
+For adjacent delivery, the adapter resolves candidates in all four directions and validates their
 pane identity, tab and workspace membership, geometry, detected agent, session,
 and interactive state. A direction with no verified candidate is unavailable.
-The adapter does not search unrelated tabs or workspaces for a convenient agent.
+For the explicit Commands action, it obtains one fresh bounded current-server
+snapshot and validates compatible agents across tabs and workspaces. It does not
+imply named remote servers, SSH hosts, historical sessions, arbitrary panes, or
+unrecognized shells.
 
 Other multiplexers may implement the same interface later. Unsupported
 terminals expose no submission capability and retain the complete clipboard-first
@@ -1684,6 +1711,8 @@ Specifically:
   action for a single target or one action plus a direction for several targets.
 - Submission can target verified agents above, below, left, or right without
   confusing their sessions.
+- Commands can submit the focused thought or current selection to a verified
+  compatible agent in another tab or workspace on the current Herdr server.
 - Failed or ambiguous submissions never remove or modify the thought.
 - Notes remain readable through continuous pane resizing.
 - Thoughts can be reordered by keyboard or direct mouse drag, and the new order

--- a/src/adapters/diagnostics.rs
+++ b/src/adapters/diagnostics.rs
@@ -10,7 +10,10 @@ use thiserror::Error;
 use tracing::Level;
 use tracing_subscriber::util::SubscriberInitExt as _;
 
-use crate::domain::{Direction, InstanceId, SubmissionId};
+use crate::{
+    domain::{Direction, InstanceId, SubmissionId},
+    ports::agent::SubmissionRouteKind,
+};
 
 pub use collect::{DiagnosticBundle, collect_bundle};
 use writer::RotatingMakeWriter;
@@ -112,8 +115,10 @@ pub enum SafeEvent<'a> {
         submission_id: SubmissionId,
         /// Durable submission state.
         state: &'a str,
-        /// Target direction without pane or workspace details.
-        direction: Direction,
+        /// Closed content-redacted route classification.
+        route_kind: SubmissionRouteKind,
+        /// Adjacent direction, absent for global delivery.
+        direction: Option<Direction>,
         /// Integration provider name.
         provider: &'a str,
         /// Optional stable result code.
@@ -264,6 +269,7 @@ pub fn record(event: SafeEvent<'_>) {
         SafeEvent::Submission {
             submission_id,
             state,
+            route_kind,
             direction,
             provider,
             outcome,
@@ -271,7 +277,8 @@ pub fn record(event: SafeEvent<'_>) {
             event = "submission_transition",
             submission_id = %submission_id,
             state,
-            direction = direction.as_str(),
+            route_kind = route_kind.as_str(),
+            direction = direction.map(Direction::as_str),
             provider,
             outcome
         ),

--- a/src/adapters/herdr/discovery.rs
+++ b/src/adapters/herdr/discovery.rs
@@ -2,6 +2,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+#[path = "discovery/global.rs"]
+mod global;
 #[path = "discovery/topology.rs"]
 mod topology;
 
@@ -99,6 +101,12 @@ pub(super) fn adjacent_targets<R: ProcessRunner>(
         }
     }
     Ok(targets)
+}
+
+pub(super) fn global_targets<R: ProcessRunner>(
+    gateway: &mut HerdrGateway<R>,
+) -> Result<Vec<AgentTarget>, AgentError> {
+    global::targets(gateway)
 }
 
 pub(super) fn live_references<R: ProcessRunner>(
@@ -323,21 +331,25 @@ fn eligible_target(
         .name
         .clone()
         .unwrap_or_else(|| format!("{kind} {}", agent.pane_id));
-    Ok(AgentTarget {
-        provider: "herdr".to_owned(),
+    let address = crate::ports::agent::HerdrAgentAddress::new(
+        agent.workspace_id.clone(),
+        agent.tab_id.clone(),
+        agent.pane_id.clone(),
+        kind,
+        agent_session,
+    )
+    .ok_or_else(|| AgentError::Malformed("invalid adjacent agent address".to_owned()))?;
+    Ok(AgentTarget::adjacent(
+        "herdr".to_owned(),
         protocol,
         direction,
-        pane_id: agent.pane_id.clone(),
-        workspace_id: agent.workspace_id.clone(),
-        tab_id: agent.tab_id.clone(),
-        agent_kind: kind,
-        agent_name: name,
-        agent_session,
+        address,
+        name,
         readiness,
-        delivery: AgentDeliveryCapabilities::SUBMIT_ONLY,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
         rect,
-        source: source.clone(),
-    })
+        source.clone(),
+    ))
 }
 
 fn readiness(value: Option<RawReadiness>) -> Result<AgentState, AgentError> {

--- a/src/adapters/herdr/discovery/global.rs
+++ b/src/adapters/herdr/discovery/global.rs
@@ -1,0 +1,168 @@
+//! Fresh current-server compatible-agent discovery.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ports::{
+    agent::{
+        AgentAvailability, AgentDeliveryCapabilities, AgentError, AgentState, AgentTarget,
+        HerdrAgentAddress,
+    },
+    environment::ProcessRunner,
+};
+
+use super::{
+    super::{
+        DISCOVERY_TIMEOUT, HerdrGateway,
+        compatibility::HerdrCompatibilityPolicy,
+        contract::{CurrentBody, Envelope, PaneInfo, SchemaDocument, SnapshotBody},
+    },
+    MAX_AGENT_ROWS, observed_state,
+    topology::{
+        correlated_tab_label, correlated_workspace_label, sanitize_agent_name, tab_labels,
+        workspace_labels,
+    },
+};
+
+pub(super) fn targets<R: ProcessRunner>(
+    gateway: &mut HerdrGateway<R>,
+) -> Result<Vec<AgentTarget>, AgentError> {
+    if !gateway.managed {
+        return Err(AgentError::Unavailable(
+            "HERDR_ENV is not set for this pane".to_owned(),
+        ));
+    }
+    let schema: SchemaDocument = gateway.json(&["api", "schema", "--json"], DISCOVERY_TIMEOUT)?;
+    let body: Envelope<SnapshotBody> = gateway.json(&["api", "snapshot"], DISCOVERY_TIMEOUT)?;
+    let snapshot = body.result.snapshot;
+    let protocol = HerdrCompatibilityPolicy::negotiate(&schema, &snapshot)?.value();
+    let current: Envelope<CurrentBody> =
+        gateway.json(&["pane", "current", "--current"], DISCOVERY_TIMEOUT)?;
+    if current.result.pane.pane_id.trim().is_empty() {
+        return Err(AgentError::Malformed(
+            "current Herdr pane has an incomplete identity".to_owned(),
+        ));
+    }
+    if snapshot.agents.len() > MAX_AGENT_ROWS
+        || snapshot.workspaces.len() > MAX_AGENT_ROWS
+        || snapshot.tabs.len() > MAX_AGENT_ROWS
+    {
+        return Err(AgentError::Unsupported(
+            "current-server agent discovery exceeds the verified row budget".to_owned(),
+        ));
+    }
+    let workspaces = workspace_labels(snapshot.workspaces, MAX_AGENT_ROWS)?;
+    let tabs = tab_labels(snapshot.tabs, MAX_AGENT_ROWS)?;
+    unique_targets(
+        snapshot.agents,
+        protocol,
+        &current.result.pane.pane_id,
+        &workspaces,
+        &tabs,
+    )
+}
+
+fn unique_targets(
+    agents: Vec<PaneInfo>,
+    protocol: u32,
+    current_pane_id: &str,
+    workspaces: &BTreeMap<String, Option<String>>,
+    tabs: &BTreeMap<String, (String, Option<String>)>,
+) -> Result<Vec<AgentTarget>, AgentError> {
+    let mut identities = BTreeSet::new();
+    let mut pane_ids = BTreeSet::new();
+    let mut targets = Vec::new();
+    for pane in agents {
+        if pane.pane_id == current_pane_id {
+            continue;
+        }
+        let Some(target) = target(&pane, protocol, workspaces, tabs)? else {
+            continue;
+        };
+        let identity = (
+            target.workspace_id().to_owned(),
+            target.tab_id().to_owned(),
+            target.pane_id().to_owned(),
+            target.agent_kind().as_str().to_owned(),
+            target.agent_session().as_id().map(str::to_owned),
+        );
+        if !pane_ids.insert(target.pane_id().to_owned()) || !identities.insert(identity) {
+            return Err(AgentError::Ambiguous(
+                "multiple compatible agents claim one delivery identity".to_owned(),
+            ));
+        }
+        targets.push(target);
+    }
+    Ok(targets)
+}
+
+fn target(
+    pane: &PaneInfo,
+    protocol: u32,
+    workspaces: &BTreeMap<String, Option<String>>,
+    tabs: &BTreeMap<String, (String, Option<String>)>,
+) -> Result<Option<AgentTarget>, AgentError> {
+    let Some(kind) = pane
+        .agent
+        .clone()
+        .and_then(|value| super::super::harness::kind(value).ok())
+    else {
+        return Ok(None);
+    };
+    let agent_session =
+        match super::super::harness::discovered_session(&kind, pane.agent_session.as_ref()) {
+            Ok(session) => session,
+            Err(AgentError::Unsupported(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+    if pane.workspace_id.trim().is_empty()
+        || pane.tab_id.trim().is_empty()
+        || pane.pane_id.trim().is_empty()
+    {
+        return Err(AgentError::Malformed(
+            "compatible agent has an incomplete delivery identity".to_owned(),
+        ));
+    }
+    let workspace_label = correlated_workspace_label(workspaces, &pane.workspace_id, false)?;
+    let tab_label = correlated_tab_label(tabs, &pane.workspace_id, &pane.tab_id, false)?;
+    let readiness = observed_state(pane.agent_status);
+    let availability = availability(pane, readiness);
+    let agent_name = pane
+        .name
+        .as_deref()
+        .map(sanitize_agent_name)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| format!("{kind} agent"));
+    Ok(Some(AgentTarget::herdr_agent(
+        protocol,
+        HerdrAgentAddress::new(
+            pane.workspace_id.clone(),
+            pane.tab_id.clone(),
+            pane.pane_id.clone(),
+            kind,
+            agent_session,
+        )
+        .ok_or_else(|| AgentError::Malformed("invalid current-server agent address".to_owned()))?,
+        agent_name,
+        workspace_label,
+        tab_label,
+        readiness,
+        availability,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
+    )))
+}
+
+fn availability(pane: &PaneInfo, state: AgentState) -> AgentAvailability {
+    if pane.launch_pending == Some(true) {
+        AgentAvailability::Launching
+    } else if pane.interactive_ready == Some(false) {
+        AgentAvailability::NotInteractive
+    } else {
+        match state {
+            AgentState::Idle | AgentState::Working | AgentState::Done => {
+                AgentAvailability::Available
+            }
+            AgentState::Blocked => AgentAvailability::Blocked,
+            AgentState::Unknown => AgentAvailability::Unknown,
+        }
+    }
+}

--- a/src/adapters/herdr/harness.rs
+++ b/src/adapters/herdr/harness.rs
@@ -38,7 +38,7 @@ pub(super) fn receipt_session(
     session: Option<&AgentSession>,
 ) -> Result<AgentSessionBinding, AgentError> {
     let Some(session) = session else {
-        return if target.agent_session.is_provisional() {
+        return if target.agent_session().is_provisional() {
             Ok(AgentSessionBinding::provisional())
         } else {
             Err(AgentError::Malformed(
@@ -46,8 +46,8 @@ pub(super) fn receipt_session(
             ))
         };
     };
-    let binding = established_session(&target.agent_kind, session)?;
-    if target.agent_session.accepts_receipt(&binding) {
+    let binding = established_session(target.agent_kind(), session)?;
+    if target.agent_session().accepts_receipt(&binding) {
         Ok(binding)
     } else {
         Err(AgentError::Malformed(

--- a/src/adapters/herdr/mod.rs
+++ b/src/adapters/herdr/mod.rs
@@ -110,6 +110,10 @@ impl<R: ProcessRunner> AgentGateway for HerdrGateway<R> {
         discovery::adjacent_targets(self, context)
     }
 
+    fn global_targets(&mut self) -> Result<Vec<AgentTarget>, AgentError> {
+        discovery::global_targets(self)
+    }
+
     fn submit(&mut self, request: SubmissionRequest) -> Result<SubmissionReceipt, AgentError> {
         submission::submit(self, &request)
     }

--- a/src/adapters/herdr/submission.rs
+++ b/src/adapters/herdr/submission.rs
@@ -1,7 +1,10 @@
 //! Target revalidation and atomic semantic prompt submission.
 
 use crate::ports::{
-    agent::{AgentError, AgentGateway as _, AgentState, SubmissionReceipt, SubmissionRequest},
+    agent::{
+        AgentError, AgentGateway as _, AgentState, SubmissionReceipt, SubmissionRequest,
+        SubmissionRoute,
+    },
     environment::ProcessRunner,
 };
 
@@ -14,10 +17,17 @@ pub(super) fn submit<R: ProcessRunner>(
     gateway: &mut HerdrGateway<R>,
     request: &SubmissionRequest,
 ) -> Result<SubmissionReceipt, AgentError> {
-    let verified = gateway
-        .adjacent_targets(&request.target.source)?
+    let require_protocol_match = matches!(request.target.route, SubmissionRoute::HerdrAgent(_));
+    let refreshed = match &request.target.route {
+        SubmissionRoute::AdjacentPane { source, .. } => gateway.adjacent_targets(source)?,
+        SubmissionRoute::HerdrAgent(_) => gateway.global_targets()?,
+    };
+    let verified = refreshed
         .into_iter()
-        .filter(|target| target.identity() == request.target.identity())
+        .filter(|target| {
+            target.identity() == request.target.identity()
+                && (!require_protocol_match || target.protocol == request.target.protocol)
+        })
         .collect::<Vec<_>>();
     let [target] = verified.as_slice() else {
         return Err(if verified.is_empty() {
@@ -26,12 +36,18 @@ pub(super) fn submit<R: ProcessRunner>(
             AgentError::Ambiguous("target identity is no longer unique".to_owned())
         });
     };
+    if !target.can_submit() {
+        return Err(AgentError::Unsupported(format!(
+            "target is {} before submission",
+            target.availability.as_str()
+        )));
+    }
     let response: Envelope<PromptBody> = gateway.json(
-        &["agent", "prompt", &target.pane_id, &request.content],
+        &["agent", "prompt", target.pane_id(), &request.content],
         SUBMISSION_TIMEOUT,
     )?;
     let mut accepted_target = target.clone();
-    accepted_target.agent_session = verify_prompted(target, &response.result)?;
+    accepted_target.bind_agent_session(verify_prompted(target, &response.result)?);
     Ok(SubmissionReceipt {
         submission_id: request.submission_id,
         target: accepted_target,
@@ -44,10 +60,10 @@ fn verify_prompted(
     response: &PromptBody,
 ) -> Result<crate::ports::agent::AgentSessionBinding, AgentError> {
     if response.kind != "agent_prompted"
-        || response.agent.pane_id != target.pane_id
-        || response.agent.workspace_id != target.workspace_id
-        || response.agent.tab_id != target.tab_id
-        || response.agent.agent.as_deref() != Some(target.agent_kind.as_str())
+        || response.agent.pane_id != target.pane_id()
+        || response.agent.workspace_id != target.workspace_id()
+        || response.agent.tab_id != target.tab_id()
+        || response.agent.agent.as_deref() != Some(target.agent_kind().as_str())
     {
         return Err(AgentError::Malformed(
             "prompt receipt does not match the verified target".to_owned(),

--- a/src/adapters/herdr/tests.rs
+++ b/src/adapters/herdr/tests.rs
@@ -19,6 +19,8 @@ use super::HerdrGateway;
 
 #[path = "tests/compatibility.rs"]
 mod compatibility;
+#[path = "tests/global.rs"]
+mod global;
 #[path = "tests/hermes.rs"]
 mod hermes;
 #[path = "tests/kilo.rs"]
@@ -252,7 +254,7 @@ fn all_directions_are_queried_and_only_independently_verified_agents_return() {
     ));
     let targets = gateway.adjacent_targets(&context).expect("targets");
     assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0].direction, Direction::Right);
+    assert_eq!(targets[0].adjacent_direction(), Some(Direction::Right));
     assert_eq!(targets[0].readiness, AgentState::Idle);
     let requests = runner.requests.borrow();
     let directional = requests
@@ -286,7 +288,7 @@ fn ordinary_neighbor_without_agent_identity_does_not_hide_a_valid_target() {
         .adjacent_targets(&context)
         .expect("ordinary shell is ignored");
     assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0].direction, Direction::Right);
+    assert_eq!(targets[0].adjacent_direction(), Some(Direction::Right));
 }
 
 #[test]
@@ -364,22 +366,24 @@ fn explicit_interactive_readiness_metadata_fails_closed() {
 }
 
 fn target(context: &PaneContext) -> AgentTarget {
-    AgentTarget {
-        provider: "herdr".to_owned(),
-        protocol: 19,
-        direction: Direction::Right,
-        pane_id: "w1:p2".to_owned(),
-        workspace_id: "w1".to_owned(),
-        tab_id: "w1:t1".to_owned(),
-        agent_kind: HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
-        agent_name: "reviewer".to_owned(),
-        agent_session: AgentSessionBinding::established("agent-session-1")
-            .expect("fixture session"),
-        readiness: AgentState::Idle,
-        delivery: crate::ports::agent::AgentDeliveryCapabilities::SUBMIT_ONLY,
-        rect: right_rect(),
-        source: context.clone(),
-    }
+    AgentTarget::adjacent(
+        "herdr".to_owned(),
+        19,
+        Direction::Right,
+        crate::ports::agent::HerdrAgentAddress::new(
+            "w1".to_owned(),
+            "w1:t1".to_owned(),
+            "w1:p2".to_owned(),
+            HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
+            AgentSessionBinding::established("agent-session-1").expect("fixture session"),
+        )
+        .expect("fixture address"),
+        "reviewer".to_owned(),
+        AgentState::Idle,
+        crate::ports::agent::AgentDeliveryCapabilities::SUBMIT_ONLY,
+        right_rect(),
+        context.clone(),
+    )
 }
 
 #[test]

--- a/src/adapters/herdr/tests/global.rs
+++ b/src/adapters/herdr/tests/global.rs
@@ -1,0 +1,292 @@
+use super::*;
+
+use crate::ports::agent::{AgentAvailability, SubmissionRoute};
+
+fn live_agent(
+    workspace: &str,
+    tab: &str,
+    pane: &str,
+    name: &str,
+    state: &str,
+    session: Option<&str>,
+) -> Value {
+    let mut value = json!({
+        "workspace_id": workspace,
+        "tab_id": tab,
+        "pane_id": pane,
+        "agent": CODEX_AGENT_KIND,
+        "name": name,
+        "agent_status": state,
+        "interactive_ready": true,
+        "launch_pending": false
+    });
+    if let Some(session) = session {
+        value["agent_session"] = json!({
+            "agent": CODEX_AGENT_KIND,
+            "kind": "id",
+            "source": "herdr:codex",
+            "value": session
+        });
+    }
+    value
+}
+
+fn global_snapshot(protocol: u32, agents: &[Value]) -> Value {
+    json!({"result":{"snapshot":{
+        "protocol": protocol,
+        "version": fixture_version(protocol),
+        "workspaces":[
+            {"workspace_id":"w1","label":"Main 世界"},
+            {"workspace_id":"w2","label":"Other"}
+        ],
+        "tabs":[
+            {"workspace_id":"w1","tab_id":"w1:t1","label":"Board"},
+            {"workspace_id":"w1","tab_id":"w1:t2","label":"Review"},
+            {"workspace_id":"w2","tab_id":"w2:t1","label":"Remote local"}
+        ],
+        "agents": agents
+    }}})
+}
+
+fn global_responses(protocol: u32, agents: &[Value]) -> Vec<FakeResponse> {
+    vec![
+        success(schema(protocol)),
+        success(global_snapshot(protocol, agents)),
+        success(current(&source())),
+    ]
+}
+
+#[test]
+fn current_server_discovery_keeps_cross_tab_workspace_and_disabled_states_truthful() {
+    let agents = vec![
+        live_agent("w1", "w1:t1", "w1:p1", "self", "idle", Some("self")),
+        live_agent("w1", "w1:t2", "w1:p2", "同名", "idle", Some("s1")),
+        live_agent("w2", "w2:t1", "w2:p8", "同名", "done", Some("s2")),
+        live_agent("w1", "w1:t2", "w1:p3", "busy", "working", Some("s3")),
+        live_agent("w1", "w1:t2", "w1:p4", "blocked", "blocked", Some("s4")),
+        live_agent("w1", "w1:t2", "w1:p5", "unknown", "unknown", Some("s5")),
+        {
+            let mut agent = live_agent("w1", "w1:t2", "w1:p6", "launching", "idle", Some("s6"));
+            agent["launch_pending"] = json!(true);
+            agent
+        },
+        {
+            let mut agent = live_agent(
+                "w1",
+                "w1:t2",
+                "w1:p7",
+                "not interactive",
+                "idle",
+                Some("s7"),
+            );
+            agent["interactive_ready"] = json!(false);
+            agent
+        },
+    ];
+    let (mut gateway, runner) = gateway(global_responses(20, &agents));
+    let targets = gateway.global_targets().expect("global targets");
+
+    assert_eq!(targets.len(), 7);
+    assert!(
+        targets
+            .iter()
+            .all(|target| matches!(target.route, SubmissionRoute::HerdrAgent(_)))
+    );
+    assert_eq!(
+        targets.iter().filter(|target| target.can_submit()).count(),
+        3
+    );
+    assert!(targets.iter().any(|target| {
+        target.workspace_id() == "w2"
+            && target.tab_id() == "w2:t1"
+            && target.readiness == AgentState::Done
+            && target.workspace_label.as_deref() == Some("Other")
+    }));
+    assert_eq!(
+        targets
+            .iter()
+            .find(|target| target.agent_name == "blocked")
+            .map(|target| target.availability),
+        Some(AgentAvailability::Blocked)
+    );
+    assert_eq!(
+        targets
+            .iter()
+            .find(|target| target.agent_name == "unknown")
+            .map(|target| target.availability),
+        Some(AgentAvailability::Unknown)
+    );
+    assert_eq!(
+        targets
+            .iter()
+            .find(|target| target.agent_name == "launching")
+            .map(|target| target.availability),
+        Some(AgentAvailability::Launching)
+    );
+    assert_eq!(
+        targets
+            .iter()
+            .find(|target| target.agent_name == "not interactive")
+            .map(|target| target.availability),
+        Some(AgentAvailability::NotInteractive)
+    );
+    let requests = runner.requests.borrow();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(requests[0].args, ["api", "schema", "--json"]);
+    assert_eq!(requests[1].args, ["api", "snapshot"]);
+    assert_eq!(requests[2].args, ["pane", "current", "--current"]);
+    assert!(targets.iter().all(|target| target.pane_id() != "w1:p1"));
+}
+
+#[test]
+fn duplicate_pane_identity_and_incomplete_topology_fail_closed() {
+    let duplicate = live_agent("w1", "w1:t2", "w1:p2", "one", "idle", Some("s1"));
+    let (mut duplicate_gateway, _) = gateway(global_responses(20, &[duplicate.clone(), duplicate]));
+    assert!(matches!(
+        duplicate_gateway.global_targets(),
+        Err(AgentError::Ambiguous(_))
+    ));
+
+    let incomplete = live_agent(
+        "missing",
+        "missing:t1",
+        "missing:p1",
+        "one",
+        "idle",
+        Some("s1"),
+    );
+    let (mut gateway, _) = gateway(global_responses(20, &[incomplete]));
+    assert!(matches!(
+        gateway.global_targets(),
+        Err(AgentError::Malformed(_))
+    ));
+}
+
+#[test]
+fn global_submission_revalidates_exact_address_and_accepts_label_renames() {
+    let initial = live_agent("w2", "w2:t1", "w2:p8", "before", "idle", Some("s1"));
+    let renamed = live_agent("w2", "w2:t1", "w2:p8", "after", "working", Some("s1"));
+    let mut responses = global_responses(20, &[initial]);
+    let mut renamed_snapshot = global_snapshot(20, std::slice::from_ref(&renamed));
+    renamed_snapshot["result"]["snapshot"]["workspaces"][1]["label"] = json!("Renamed workspace");
+    renamed_snapshot["result"]["snapshot"]["tabs"][2]["label"] = json!("Renamed tab");
+    responses.push(success(schema(20)));
+    responses.push(success(renamed_snapshot));
+    responses.push(success(current(&source())));
+    responses.push(success(json!({"result":{
+        "type":"agent_prompted",
+        "agent":renamed
+    }})));
+    let (mut gateway, runner) = gateway(responses);
+    let target = gateway.global_targets().expect("initial target").remove(0);
+    let mut ids = FakeIdGenerator::new(1_900);
+    let request = SubmissionRequest {
+        submission_id: ids.submission_id(),
+        target,
+        content: "control\u{1b}[31m\nGrüße".to_owned(),
+    };
+    let receipt = gateway.submit(request.clone()).expect("accepted prompt");
+
+    assert_eq!(receipt.target.agent_name, "after");
+    assert_eq!(
+        receipt.target.workspace_label.as_deref(),
+        Some("Renamed workspace")
+    );
+    assert_eq!(receipt.post_state, Some(AgentState::Working));
+    let requests = runner.requests.borrow();
+    assert_eq!(requests[6].args[0..3], ["agent", "prompt", "w2:p8"]);
+    assert_eq!(requests[6].args[3], request.content.as_str());
+}
+
+#[test]
+fn movement_disappearance_replacement_and_disabled_refresh_send_no_prompt() {
+    for refreshed in [
+        Vec::new(),
+        vec![live_agent(
+            "w1",
+            "w1:t2",
+            "w1:p2",
+            "moved",
+            "idle",
+            Some("s1"),
+        )],
+        vec![live_agent(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "replaced",
+            "idle",
+            Some("s2"),
+        )],
+        vec![live_agent(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "blocked",
+            "blocked",
+            Some("s1"),
+        )],
+    ] {
+        let initial = live_agent("w2", "w2:t1", "w2:p8", "initial", "idle", Some("s1"));
+        let mut responses = global_responses(20, &[initial]);
+        responses.extend(global_responses(20, &refreshed));
+        let (mut gateway, runner) = gateway(responses);
+        let target = gateway.global_targets().expect("initial target").remove(0);
+        let mut ids = FakeIdGenerator::new(2_000);
+        let request = SubmissionRequest {
+            submission_id: ids.submission_id(),
+            target,
+            content: "exact".to_owned(),
+        };
+        assert!(matches!(
+            gateway.submit(request),
+            Err(AgentError::Unsupported(_))
+        ));
+        assert_eq!(runner.requests.borrow().len(), 6);
+    }
+}
+
+#[test]
+fn receipt_mismatch_after_structured_prompt_is_never_accepted() {
+    let initial = live_agent("w2", "w2:t1", "w2:p8", "initial", "idle", Some("s1"));
+    let mismatched = live_agent("w2", "w2:t1", "w2:p9", "other", "working", Some("s1"));
+    let mut responses = global_responses(20, std::slice::from_ref(&initial));
+    responses.extend(global_responses(20, &[initial]));
+    responses.push(success(json!({"result":{
+        "type":"agent_prompted",
+        "agent":mismatched
+    }})));
+    let (mut gateway, _) = gateway(responses);
+    let target = gateway.global_targets().expect("initial target").remove(0);
+    let mut ids = FakeIdGenerator::new(2_100);
+    let request = SubmissionRequest {
+        submission_id: ids.submission_id(),
+        target,
+        content: "exact".to_owned(),
+    };
+    assert!(matches!(
+        gateway.submit(request),
+        Err(AgentError::Malformed(_))
+    ));
+}
+
+#[test]
+fn protocol_change_during_revalidation_sends_no_prompt() {
+    let initial = live_agent("w2", "w2:t1", "w2:p8", "initial", "idle", Some("s1"));
+    let mut responses = global_responses(20, std::slice::from_ref(&initial));
+    responses.extend(global_responses(21, &[initial]));
+    let (mut gateway, runner) = gateway(responses);
+    let target = gateway.global_targets().expect("initial target").remove(0);
+    let mut ids = FakeIdGenerator::new(2_200);
+    let request = SubmissionRequest {
+        submission_id: ids.submission_id(),
+        target,
+        content: "exact".to_owned(),
+    };
+
+    assert!(matches!(
+        gateway.submit(request),
+        Err(AgentError::Unsupported(_))
+    ));
+    assert_eq!(runner.requests.borrow().len(), 6);
+}

--- a/src/adapters/herdr/tests/hermes.rs
+++ b/src/adapters/herdr/tests/hermes.rs
@@ -60,10 +60,10 @@ fn recorded_hermes_identity_uses_the_open_established_session_path() {
         let [target] = targets.as_slice() else {
             panic!("expected one recorded Hermes target");
         };
-        assert_eq!(target.agent_kind.as_str(), "hermes");
+        assert_eq!(target.agent_kind().as_str(), "hermes");
         assert_eq!(target.agent_name, "hermes-qualifier");
         assert_eq!(
-            target.agent_session.as_id(),
+            target.agent_session().as_id(),
             Some("hermes-session-fixture-a")
         );
         assert_eq!(target.readiness, readiness);
@@ -121,7 +121,7 @@ fn recorded_hermes_target_survives_unrelated_adjacent_shells() {
         .adjacent_targets(&context)
         .expect("ordinary shell neighbors are ignored");
     assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0].agent_kind.as_str(), "hermes");
+    assert_eq!(targets[0].agent_kind().as_str(), "hermes");
 }
 
 #[test]
@@ -186,9 +186,9 @@ fn recorded_hermes_receipt_preserves_identity_and_exact_prompt_data() {
         })
         .expect("accepted established Hermes prompt");
 
-    assert_eq!(receipt.target.agent_kind.as_str(), "hermes");
+    assert_eq!(receipt.target.agent_kind().as_str(), "hermes");
     assert_eq!(
-        receipt.target.agent_session.as_id(),
+        receipt.target.agent_session().as_id(),
         Some("hermes-session-fixture-a")
     );
     assert_eq!(receipt.post_state, Some(AgentState::Working));

--- a/src/adapters/herdr/tests/kilo.rs
+++ b/src/adapters/herdr/tests/kilo.rs
@@ -63,16 +63,18 @@ fn recorded_agents(document: &str) -> Value {
 fn kilo_target() -> crate::ports::agent::AgentTarget {
     let context = source();
     let mut target = target(&context);
-    target.agent_kind = HarnessKind::new(KILO_AGENT_KIND).expect("Kilo harness kind");
+    target.set_test_agent_kind(HarnessKind::new(KILO_AGENT_KIND).expect("Kilo harness kind"));
     target.agent_name = "kilo-reviewer".to_owned();
-    target.agent_session = AgentSessionBinding::established("ses_fixture_kilo_established")
-        .expect("Kilo fixture session");
+    target.set_test_agent_session(
+        AgentSessionBinding::established("ses_fixture_kilo_established")
+            .expect("Kilo fixture session"),
+    );
     target
 }
 
 fn provisional_kilo_target() -> crate::ports::agent::AgentTarget {
     let mut target = kilo_target();
-    target.agent_session = AgentSessionBinding::provisional();
+    target.set_test_agent_session(AgentSessionBinding::provisional());
     target
 }
 
@@ -88,9 +90,9 @@ fn recorded_kilo_detection_uses_the_generic_established_session_path() {
 
     let targets = gateway.adjacent_targets(&context).expect("Kilo target");
     assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0].agent_kind.as_str(), KILO_AGENT_KIND);
+    assert_eq!(targets[0].agent_kind().as_str(), KILO_AGENT_KIND);
     assert_eq!(
-        targets[0].agent_session.as_id(),
+        targets[0].agent_session().as_id(),
         Some("ses_fixture_kilo_established")
     );
     assert_eq!(targets[0].readiness, AgentState::Idle);
@@ -109,8 +111,8 @@ fn recorded_kilo_sessionless_is_provisional_while_unready_and_exit_stay_hidden()
         .adjacent_targets(&context)
         .expect("provisional Kilo target");
     assert_eq!(targets.len(), 1);
-    assert_eq!(targets[0].agent_kind.as_str(), KILO_AGENT_KIND);
-    assert!(targets[0].agent_session.is_provisional());
+    assert_eq!(targets[0].agent_kind().as_str(), KILO_AGENT_KIND);
+    assert!(targets[0].agent_session().is_provisional());
 
     let context = source();
     let responses = discovery_responses(
@@ -162,7 +164,7 @@ fn recorded_kilo_first_receipt_may_establish_the_session() {
         .expect("session-establishing Kilo receipt");
 
     assert_eq!(
-        receipt.target.agent_session.as_id(),
+        receipt.target.agent_session().as_id(),
         Some("ses_fixture_kilo_established")
     );
     assert_eq!(semantic_prompt_count(&runner.requests.borrow()), 1);
@@ -188,7 +190,7 @@ fn recorded_kilo_first_receipt_may_precede_the_session_hook() {
         })
         .expect("matching provisional Kilo receipt");
 
-    assert!(receipt.target.agent_session.is_provisional());
+    assert!(receipt.target.agent_session().is_provisional());
     assert_eq!(semantic_prompt_count(&runner.requests.borrow()), 1);
 }
 
@@ -215,7 +217,7 @@ fn recorded_kilo_receipt_accepts_one_exact_semantic_prompt() {
         .expect("matching Kilo receipt");
 
     assert_eq!(receipt.submission_id, submission_id);
-    assert_eq!(receipt.target.agent_kind.as_str(), KILO_AGENT_KIND);
+    assert_eq!(receipt.target.agent_kind().as_str(), KILO_AGENT_KIND);
     assert_eq!(receipt.post_state, Some(AgentState::Working));
     let requests = runner.requests.borrow();
     let request = requests.last().expect("semantic prompt request");

--- a/src/adapters/herdr/tests/opencode.rs
+++ b/src/adapters/herdr/tests/opencode.rs
@@ -40,10 +40,11 @@ fn agents(name: &str) -> Value {
 
 fn opencode_target(context: &crate::ports::agent::PaneContext) -> crate::ports::agent::AgentTarget {
     let mut result = target(context);
-    result.agent_kind = HarnessKind::new(OPENCODE_AGENT_KIND).expect("fixture harness");
+    result.set_test_agent_kind(HarnessKind::new(OPENCODE_AGENT_KIND).expect("fixture harness"));
     result.agent_name = "opencode-fixture".to_owned();
-    result.agent_session =
-        AgentSessionBinding::established("opencode-session-alpha").expect("fixture session");
+    result.set_test_agent_session(
+        AgentSessionBinding::established("opencode-session-alpha").expect("fixture session"),
+    );
     result
 }
 
@@ -75,10 +76,13 @@ fn recorded_detection_requires_established_opencode_identity_and_readiness() {
             "{name}"
         );
         if let Some(target) = targets.first() {
-            assert_eq!(target.agent_kind.as_str(), OPENCODE_AGENT_KIND);
-            assert_eq!(target.agent_session.is_provisional(), provisional);
+            assert_eq!(target.agent_kind().as_str(), OPENCODE_AGENT_KIND);
+            assert_eq!(target.agent_session().is_provisional(), provisional);
             if !provisional {
-                assert_eq!(target.agent_session.as_id(), Some("opencode-session-alpha"));
+                assert_eq!(
+                    target.agent_session().as_id(),
+                    Some("opencode-session-alpha")
+                );
             }
         }
     }
@@ -118,9 +122,9 @@ fn recorded_receipt_accepts_exact_opencode_submission_as_one_argument() {
         })
         .expect("matching OpenCode receipt");
 
-    assert_eq!(receipt.target.agent_kind.as_str(), OPENCODE_AGENT_KIND);
+    assert_eq!(receipt.target.agent_kind().as_str(), OPENCODE_AGENT_KIND);
     assert_eq!(
-        receipt.target.agent_session.as_id(),
+        receipt.target.agent_session().as_id(),
         Some("opencode-session-alpha")
     );
     assert_eq!(receipt.post_state, Some(AgentState::Working));
@@ -141,7 +145,7 @@ fn first_opencode_prompt_is_exactly_once_and_establishes_the_recorded_session() 
     responses.push(success(recorded("accepted")));
     let (mut gateway, runner) = gateway(responses);
     let mut provisional = opencode_target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
     let payload = "first OpenCode prompt\nwith Unicode e\u{301} 👩‍💻".to_owned();
     let receipt = gateway
@@ -153,7 +157,7 @@ fn first_opencode_prompt_is_exactly_once_and_establishes_the_recorded_session() 
         .expect("session-establishing OpenCode receipt");
 
     assert_eq!(
-        receipt.target.agent_session.as_id(),
+        receipt.target.agent_session().as_id(),
         Some("opencode-session-alpha")
     );
     let prompts = runner
@@ -178,7 +182,7 @@ fn first_opencode_receipt_may_precede_the_session_hook_without_resending() {
     responses.push(success(recorded("before_hook")));
     let (mut gateway, runner) = gateway(responses);
     let mut provisional = opencode_target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
     let receipt = gateway
         .submit(SubmissionRequest {
@@ -188,7 +192,7 @@ fn first_opencode_receipt_may_precede_the_session_hook_without_resending() {
         })
         .expect("matching provisional OpenCode receipt");
 
-    assert!(receipt.target.agent_session.is_provisional());
+    assert!(receipt.target.agent_session().is_provisional());
     assert_eq!(
         runner
             .requests

--- a/src/adapters/herdr/tests/pi.rs
+++ b/src/adapters/herdr/tests/pi.rs
@@ -28,10 +28,11 @@ fn agents(name: &str) -> Value {
 
 fn pi_target() -> crate::ports::agent::AgentTarget {
     let mut target = target(&source());
-    target.agent_kind = HarnessKind::new("pi").expect("fixture harness");
+    target.set_test_agent_kind(HarnessKind::new("pi").expect("fixture harness"));
     target.agent_name = "pi-review".to_owned();
-    target.agent_session =
-        AgentSessionBinding::established("fixture/pi/session-a.jsonl").expect("fixture session");
+    target.set_test_agent_session(
+        AgentSessionBinding::established("fixture/pi/session-a.jsonl").expect("fixture session"),
+    );
     target
 }
 
@@ -49,9 +50,9 @@ fn recorded_pi_identity_readiness_and_exit_follow_the_established_session_path()
         ));
         let targets = gateway.adjacent_targets(&context).expect("recorded Pi");
         assert_eq!(targets.len(), 1);
-        assert_eq!(targets[0].agent_kind.as_str(), "pi");
+        assert_eq!(targets[0].agent_kind().as_str(), "pi");
         assert_eq!(
-            targets[0].agent_session.as_id(),
+            targets[0].agent_session().as_id(),
             Some("fixture/pi/session-a.jsonl")
         );
         assert_eq!(targets[0].readiness, expected);

--- a/src/adapters/herdr/tests/sessionless.rs
+++ b/src/adapters/herdr/tests/sessionless.rs
@@ -44,8 +44,8 @@ fn discovery_accepts_established_sessions_for_open_ended_harness_kinds() {
 
         let targets = gateway.adjacent_targets(&context).expect("valid discovery");
         assert_eq!(targets.len(), 1, "{harness}");
-        assert_eq!(targets[0].agent_kind.as_str(), harness);
-        assert_eq!(targets[0].agent_session.as_id(), Some("agent-session-1"));
+        assert_eq!(targets[0].agent_kind().as_str(), harness);
+        assert_eq!(targets[0].agent_session().as_id(), Some("agent-session-1"));
     }
 }
 
@@ -66,7 +66,7 @@ fn discovery_exposes_only_explicitly_supported_sessionless_targets() {
             .adjacent_targets(&context)
             .expect("supported empty harness");
         assert_eq!(targets.len(), 1, "{harness}");
-        assert!(targets[0].agent_session.is_provisional(), "{harness}");
+        assert!(targets[0].agent_session().is_provisional(), "{harness}");
     }
 
     for harness in [CLAUDE_AGENT_KIND, "future-harness"] {
@@ -102,7 +102,7 @@ fn first_prompt_establishes_the_session_identity() {
     }})));
     let (mut gateway, runner) = gateway(responses);
     let mut provisional = target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
     let receipt = gateway
         .submit(SubmissionRequest {
@@ -113,7 +113,7 @@ fn first_prompt_establishes_the_session_identity() {
         .expect("session-establishing prompt");
 
     assert_eq!(
-        receipt.target.agent_session.as_id(),
+        receipt.target.agent_session().as_id(),
         Some("agent-session-1")
     );
     assert_eq!(
@@ -129,7 +129,7 @@ fn a_session_appearing_before_submission_is_a_target_change() {
     let responses = discovery_responses(&context, json!(agents), Some(("w1:p2", right_rect())));
     let (mut gateway, runner) = gateway(responses);
     let mut provisional = target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
 
     assert!(matches!(
@@ -166,7 +166,7 @@ fn first_prompt_receipt_may_precede_the_session_hook() {
     }})));
     let (mut gateway, _) = gateway(responses);
     let mut provisional = target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
 
     let receipt = gateway
@@ -176,7 +176,7 @@ fn first_prompt_receipt_may_precede_the_session_hook() {
             content: "accepted before the session hook".to_owned(),
         })
         .expect("matching provisional receipt");
-    assert!(receipt.target.agent_session.is_provisional());
+    assert!(receipt.target.agent_session().is_provisional());
 }
 
 #[test]
@@ -192,7 +192,7 @@ fn inconsistent_first_session_identity_fails_closed() {
     }})));
     let (mut gateway, _) = gateway(responses);
     let mut provisional = target(&context);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    provisional.set_test_agent_session(AgentSessionBinding::provisional());
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
 
     assert!(matches!(

--- a/src/adapters/herdr/tests/submission_receipts.rs
+++ b/src/adapters/herdr/tests/submission_receipts.rs
@@ -8,7 +8,43 @@ use crate::{
     },
 };
 
-use super::{agent, discovery_responses, gateway, right_rect, source, success, target};
+use super::{
+    agent, discovery_responses, discovery_responses_for_protocol, gateway, right_rect, source,
+    success, target,
+};
+
+#[test]
+fn adjacent_submission_accepts_a_fresh_supported_protocol_change() {
+    let context = source();
+    let agents = vec![agent("w1:p2", "w1", "w1:t1", "idle")];
+    let mut responses = discovery_responses_for_protocol(
+        &context,
+        20,
+        json!(agents),
+        Some(("w1:p2", right_rect())),
+    );
+    responses.push(success(json!({"result":{
+        "type":"agent_prompted",
+        "agent":agent("w1:p2", "w1", "w1:t1", "working")
+    }})));
+    let (mut gateway, runner) = gateway(responses);
+    let mut ids = FakeIdGenerator::new(1_725_200_100_000);
+
+    gateway
+        .submit(SubmissionRequest {
+            submission_id: ids.submission_id(),
+            target: target(&context),
+            content: "compatible protocol change".to_owned(),
+        })
+        .expect("supported adjacent protocol change");
+
+    let requests = runner.requests.borrow();
+    let prompt = requests.last().expect("prompt request");
+    assert_eq!(
+        prompt.args,
+        ["agent", "prompt", "w1:p2", "compatible protocol change"]
+    );
+}
 
 #[test]
 fn matching_prompt_receipt_accepts_every_advisory_post_state() {

--- a/src/adapters/sqlite/migration.rs
+++ b/src/adapters/sqlite/migration.rs
@@ -17,7 +17,7 @@ use super::{
     StoreConfig,
     schema::{
         MIGRATION_1, MIGRATION_2, MIGRATION_3, MIGRATION_4, MIGRATION_5, MIGRATION_6, MIGRATION_7,
-        MIGRATION_8, MIGRATION_9, MIGRATION_10, MIGRATION_11, MIGRATION_12,
+        MIGRATION_8, MIGRATION_9, MIGRATION_10, MIGRATION_11, MIGRATION_12, MIGRATION_13,
     },
     support::{
         create_private_dir, map_sql_error, set_private_file_permissions, set_private_open_mode,
@@ -110,6 +110,7 @@ fn apply_migrations(connection: &Connection, found: u32) -> Result<(), StoreErro
         MIGRATION_10,
         MIGRATION_11,
         MIGRATION_12,
+        MIGRATION_13,
     ];
     let first = usize::try_from(found - 1)
         .map_err(|_| StoreError::Corrupt("invalid schema version".to_owned()))?;

--- a/src/adapters/sqlite/schema.rs
+++ b/src/adapters/sqlite/schema.rs
@@ -96,7 +96,15 @@ CREATE TABLE submission_attempts (
     source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
     source_sequence INTEGER NOT NULL CHECK (source_sequence >= 0),
     disposition TEXT NOT NULL CHECK (disposition IN ('keep', 'remove_after_success')),
-    direction TEXT NOT NULL CHECK (direction IN ('up', 'right', 'down', 'left')),
+    route_version INTEGER NOT NULL CHECK (route_version IN (0, 1)),
+    route_kind TEXT NOT NULL CHECK (
+        route_kind IN ('adjacent_pane', 'herdr_agent')
+        AND (route_version = 1 OR route_kind = 'adjacent_pane')
+    ),
+    direction TEXT CHECK (
+        (route_kind = 'adjacent_pane' AND direction IN ('up', 'right', 'down', 'left'))
+        OR (route_kind = 'herdr_agent' AND direction IS NULL)
+    ),
     provider TEXT NOT NULL,
     protocol INTEGER NOT NULL CHECK (protocol >= 0),
     target_fingerprint BLOB NOT NULL CHECK (length(target_fingerprint) = 32),
@@ -141,7 +149,7 @@ CREATE VIRTUAL TABLE session_search USING fts5(
 );
 
 INSERT INTO schema_meta(singleton, schema_version, storage_protocol, migrated_at)
-VALUES (1, 12, 11, 0);
+VALUES (1, 13, 12, 0);
 INSERT INTO onboarding_state(singleton, completed_version) VALUES (1, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (1, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (2, 0);
@@ -155,6 +163,7 @@ INSERT INTO migration_history(version, applied_at) VALUES (9, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (10, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (11, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (12, 0);
+INSERT INTO migration_history(version, applied_at) VALUES (13, 0);
 ";
 
 pub(super) const MIGRATION_2: &str = r"
@@ -281,4 +290,69 @@ INSERT INTO migration_history(version, applied_at) VALUES (11, 0);
 pub(super) const MIGRATION_12: &str = r"
 UPDATE schema_meta SET schema_version = 12, storage_protocol = 11;
 INSERT INTO migration_history(version, applied_at) VALUES (12, 0);
+";
+
+pub(super) const MIGRATION_13: &str = r"
+DROP INDEX submission_attempt_items_active_thought;
+ALTER TABLE submission_attempt_items RENAME TO submission_attempt_items_v12;
+ALTER TABLE submission_attempts RENAME TO submission_attempts_v12;
+CREATE TABLE submission_attempts (
+    id BLOB PRIMARY KEY CHECK (length(id) = 16),
+    session_id BLOB NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    thought_id BLOB NOT NULL REFERENCES thoughts(id) ON DELETE CASCADE,
+    source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
+    source_sequence INTEGER NOT NULL CHECK (source_sequence >= 0),
+    disposition TEXT NOT NULL CHECK (disposition IN ('keep', 'remove_after_success')),
+    route_version INTEGER NOT NULL CHECK (route_version IN (0, 1)),
+    route_kind TEXT NOT NULL CHECK (
+        route_kind IN ('adjacent_pane', 'herdr_agent')
+        AND (route_version = 1 OR route_kind = 'adjacent_pane')
+    ),
+    direction TEXT CHECK (
+        (route_kind = 'adjacent_pane' AND direction IN ('up', 'right', 'down', 'left'))
+        OR (route_kind = 'herdr_agent' AND direction IS NULL)
+    ),
+    provider TEXT NOT NULL,
+    protocol INTEGER NOT NULL CHECK (protocol >= 0),
+    target_fingerprint BLOB NOT NULL CHECK (length(target_fingerprint) = 32),
+    pre_state TEXT NOT NULL,
+    post_state TEXT,
+    error_code TEXT,
+    deletion_operation_id BLOB CHECK (
+        deletion_operation_id IS NULL OR length(deletion_operation_id) = 16
+    ),
+    state TEXT NOT NULL CHECK (
+        state IN ('prepared', 'sending', 'accepted', 'failed', 'cancelled', 'outcome_unknown')
+    ),
+    prepared_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+) STRICT;
+INSERT INTO submission_attempts(
+    id, session_id, thought_id, source_digest, source_sequence, disposition,
+    route_version, route_kind, direction, provider, protocol, target_fingerprint,
+    pre_state, post_state, error_code, deletion_operation_id, state, prepared_at, updated_at
+)
+SELECT id, session_id, thought_id, source_digest, source_sequence, disposition,
+       0, 'adjacent_pane', direction, provider, protocol, target_fingerprint,
+       pre_state, post_state, error_code, deletion_operation_id, state, prepared_at, updated_at
+FROM submission_attempts_v12;
+CREATE TABLE submission_attempt_items (
+    submission_id BLOB NOT NULL REFERENCES submission_attempts(id) ON DELETE CASCADE,
+    thought_id BLOB NOT NULL REFERENCES thoughts(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
+    active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+    PRIMARY KEY(submission_id, ordinal),
+    UNIQUE(submission_id, thought_id)
+) STRICT;
+INSERT INTO submission_attempt_items(submission_id, thought_id, ordinal, source_digest, active)
+SELECT submission_id, thought_id, ordinal, source_digest, active
+FROM submission_attempt_items_v12;
+DROP TABLE submission_attempt_items_v12;
+DROP TABLE submission_attempts_v12;
+CREATE UNIQUE INDEX submission_attempt_items_active_thought
+ON submission_attempt_items(thought_id)
+WHERE active = 1;
+UPDATE schema_meta SET schema_version = 13, storage_protocol = 12;
+INSERT INTO migration_history(version, applied_at) VALUES (13, 0);
 ";

--- a/src/adapters/sqlite/submission.rs
+++ b/src/adapters/sqlite/submission.rs
@@ -26,9 +26,10 @@ pub(super) fn prepare(
         .execute(
             "INSERT INTO submission_attempts(
                 id, session_id, thought_id, source_digest, source_sequence,
-                disposition, direction, provider, protocol, target_fingerprint,
-                pre_state, state, prepared_at, updated_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'prepared', ?12, ?12)",
+                disposition, route_version, route_kind, direction, provider, protocol,
+                target_fingerprint, pre_state, state, prepared_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+                       'prepared', ?14, ?14)",
             params![
                 attempt.id.database_bytes().as_slice(),
                 attempt.session_id.database_bytes().as_slice(),
@@ -36,7 +37,12 @@ pub(super) fn prepare(
                 attempt.payload_digest.as_slice(),
                 i64::try_from(attempt.source_sequence.get()).unwrap_or(i64::MAX),
                 attempt.disposition.as_str(),
-                attempt.direction.as_str(),
+                i64::from(attempt.route.version()),
+                attempt.route.kind().as_str(),
+                attempt
+                    .route
+                    .adjacent_direction()
+                    .map(crate::domain::Direction::as_str),
                 attempt.provider,
                 i64::from(attempt.protocol),
                 attempt.target_fingerprint.as_slice(),

--- a/src/adapters/terminal/external.rs
+++ b/src/adapters/terminal/external.rs
@@ -43,6 +43,9 @@ use super::{
 
 enum ExternalRequest {
     DiscoverAgents,
+    DiscoverGlobalAgents {
+        generation: u64,
+    },
     DiscoverInvocations(InvocationDiscoveryRequest),
     DiscoverInvocationReferences(InvocationReferenceDiscoveryRequest),
     SubmitAgent(Box<SubmissionRequest>),
@@ -73,6 +76,10 @@ enum ExternalRequest {
 pub(super) enum ExternalResult {
     AgentsDiscovered {
         pane_id: Option<String>,
+        result: Result<Vec<AgentTarget>, AgentError>,
+    },
+    GlobalAgentsDiscovered {
+        generation: u64,
         result: Result<Vec<AgentTarget>, AgentError>,
     },
     InvocationsDiscovered(InvocationDiscovery),
@@ -160,6 +167,9 @@ impl ExternalLane {
     pub(super) fn send(&self, effect: &Effect) -> Result<bool, TerminalError> {
         let request = match effect {
             Effect::DiscoverAgents => ExternalRequest::DiscoverAgents,
+            Effect::DiscoverGlobalAgents { generation } => ExternalRequest::DiscoverGlobalAgents {
+                generation: *generation,
+            },
             Effect::DiscoverInvocations(request) => {
                 ExternalRequest::DiscoverInvocations(request.clone())
             }
@@ -304,6 +314,12 @@ fn external_loop(
     while let Ok(request) = requests.recv() {
         let outcome = match request {
             ExternalRequest::DiscoverAgents => discover_agents(&mut agents),
+            ExternalRequest::DiscoverGlobalAgents { generation } => {
+                ExternalResult::GlobalAgentsDiscovered {
+                    generation,
+                    result: agents.global_targets(),
+                }
+            }
             ExternalRequest::DiscoverInvocations(request) => {
                 discover_invocations(&mut invocations, request)
             }

--- a/src/adapters/terminal/integration.rs
+++ b/src/adapters/terminal/integration.rs
@@ -3,15 +3,16 @@
 pub(super) fn integration_context(
     target: &crate::ports::agent::AgentTarget,
     verified_at: crate::domain::Timestamp,
-) -> crate::domain::IntegrationContext {
-    crate::domain::IntegrationContext {
+) -> Option<crate::domain::IntegrationContext> {
+    let direction = target.adjacent_direction()?;
+    Some(crate::domain::IntegrationContext {
         provider: "herdr".to_owned(),
-        direction: target.direction,
-        agent_kind: target.agent_kind.as_str().to_owned(),
+        direction,
+        agent_kind: target.agent_kind().as_str().to_owned(),
         agent_name: target.agent_name.clone(),
-        workspace_hint: Some(target.workspace_id.clone()),
-        tab_hint: Some(target.tab_id.clone()),
-        pane_hint: Some(target.pane_id.clone()),
+        workspace_hint: Some(target.workspace_id().to_owned()),
+        tab_hint: Some(target.tab_id().to_owned()),
+        pane_hint: Some(target.pane_id().to_owned()),
         verified_at,
-    }
+    })
 }

--- a/src/adapters/terminal/persistence/tests.rs
+++ b/src/adapters/terminal/persistence/tests.rs
@@ -298,7 +298,7 @@ fn staged_submission_removal(
         payload_digest: [17; 32],
         source_sequence,
         disposition: SubmissionDisposition::RemoveAfterSuccess,
-        direction: Direction::Right,
+        route: crate::ports::store::SubmissionJournalRoute::legacy_adjacent(Direction::Right),
         provider: "herdr".to_owned(),
         protocol: 19,
         target_fingerprint: [18; 32],

--- a/src/adapters/terminal/runner/diagnostics.rs
+++ b/src/adapters/terminal/runner/diagnostics.rs
@@ -21,3 +21,37 @@ pub(super) fn shutdown_finished(cleanup_failures: usize, elapsed: std::time::Dur
 pub(super) fn provider_name(value: &str) -> &'static str {
     if value == "herdr" { "herdr" } else { "unknown" }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        adapters::{diagnostics::SafeEvent, memory::FakeIdGenerator},
+        ports::{
+            agent::SubmissionRouteKind, environment::IdGenerator as _,
+            store::SubmissionJournalRoute,
+        },
+    };
+
+    #[test]
+    fn global_submission_diagnostic_projection_has_no_content_or_topology_fields() {
+        let route = SubmissionJournalRoute::herdr_agent();
+        let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+        let event = SafeEvent::Submission {
+            submission_id: ids.submission_id(),
+            state: "preparing",
+            route_kind: route.kind(),
+            direction: route.adjacent_direction(),
+            provider: super::provider_name("/secret/provider/w2:p9"),
+            outcome: None,
+        };
+        let diagnostic = format!("{event:?}");
+
+        assert!(diagnostic.contains("HerdrAgent"));
+        assert!(diagnostic.contains("provider: \"unknown\""));
+        assert!(!diagnostic.contains("secret"));
+        assert!(!diagnostic.contains("w2:p9"));
+        assert!(!diagnostic.contains("prompt body"));
+        assert_eq!(route.kind(), SubmissionRouteKind::HerdrAgent);
+        assert_eq!(route.adjacent_direction(), None);
+    }
+}

--- a/src/adapters/terminal/runner/durability.rs
+++ b/src/adapters/terminal/runner/durability.rs
@@ -64,6 +64,7 @@ pub(super) fn enqueue_effects(
                 pending.update = pending.update.saturating_add(1);
             }
             Effect::DiscoverAgents
+            | Effect::DiscoverGlobalAgents { .. }
             | Effect::DiscoverInvocations(_)
             | Effect::DiscoverInvocationReferences(_)
             | Effect::SubmitAgent(_)
@@ -127,7 +128,7 @@ fn enqueue_persistence_effect(
             lanes.persistence.metadata(
                 crate::ports::store::OperationBatch::IntegrationContext {
                     session_id,
-                    context: Some(integration_context(&target, verified_at)),
+                    context: integration_context(&target, verified_at),
                 },
             )?;
         }
@@ -147,7 +148,8 @@ fn enqueue_persistence_effect(
                 crate::adapters::diagnostics::SafeEvent::Submission {
                     submission_id: attempt.id,
                     state: "preparing",
-                    direction: attempt.direction,
+                    route_kind: attempt.route.kind(),
+                    direction: attempt.route.adjacent_direction(),
                     provider: super::diagnostics::provider_name(&attempt.provider),
                     outcome: None,
                 },

--- a/src/adapters/terminal/runner/external_results.rs
+++ b/src/adapters/terminal/runner/external_results.rs
@@ -92,6 +92,10 @@ fn complete(
             app.complete_agent_discovery(result);
             Vec::new()
         }
+        ExternalResult::GlobalAgentsDiscovered { generation, result } => {
+            app.complete_global_agent_discovery(generation, result);
+            Vec::new()
+        }
         ExternalResult::InvocationsDiscovered(result) => {
             let completeness = result.completeness.clone();
             if app.complete_invocation_discovery(result) {

--- a/src/application/model/effect.rs
+++ b/src/application/model/effect.rs
@@ -45,6 +45,11 @@ pub enum Effect {
     },
     /// Discover verified adjacent agents without blocking the reducer lane.
     DiscoverAgents,
+    /// Discover compatible coding agents across the current Herdr server.
+    DiscoverGlobalAgents {
+        /// Picker generation used to discard stale completion.
+        generation: u64,
+    },
     /// Refresh bounded authoring definitions without blocking the reducer lane.
     DiscoverInvocations(InvocationDiscoveryRequest),
     /// Refresh one bounded picker-open collaborator snapshot.

--- a/src/application/prompt.rs
+++ b/src/application/prompt.rs
@@ -21,7 +21,7 @@ pub(crate) fn join_prompt_for_target(
     target: &AgentTarget,
     sources: &[(ThoughtId, String)],
 ) -> String {
-    let normalize_starters = supports_shared_starters(target.agent_kind.as_str());
+    let normalize_starters = supports_shared_starters(target.agent_kind().as_str());
     sources
         .iter()
         .enumerate()

--- a/src/ports/agent.rs
+++ b/src/ports/agent.rs
@@ -4,7 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, time::Duration};
 use thiserror::Error;
 
-use crate::domain::{Direction, SubmissionId};
+use crate::domain::SubmissionId;
+
+mod route;
+mod target;
+pub use route::{HerdrAgentAddress, SubmissionRoute, SubmissionRouteKind};
+pub use target::{AgentAvailability, AgentTarget, AgentTargetIdentity};
 
 /// Canonical adjacent-agent kind label for the Codex harness.
 pub const CODEX_AGENT_KIND: &str = "codex";
@@ -247,95 +252,6 @@ impl AgentFailureCode {
     }
 }
 
-/// One independently verified adjacent agent.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AgentTarget {
-    /// Integration provider that verified this target.
-    pub provider: String,
-    /// Negotiated provider protocol.
-    pub protocol: u32,
-    /// Direction from the Proqi pane.
-    pub direction: Direction,
-    /// Opaque target pane identifier.
-    pub pane_id: String,
-    /// Opaque workspace identifier matching the source.
-    pub workspace_id: String,
-    /// Opaque tab identifier matching the source.
-    pub tab_id: String,
-    /// Recognized harness kind.
-    pub agent_kind: HarnessKind,
-    /// User-facing identity.
-    pub agent_name: String,
-    /// Stable or provisional harness session binding.
-    pub agent_session: AgentSessionBinding,
-    /// Verified readiness.
-    pub readiness: AgentState,
-    /// Delivery behaviors verified for this target.
-    pub delivery: AgentDeliveryCapabilities,
-    /// Target pane geometry.
-    pub rect: PaneRect,
-    /// Source context against which adjacency was verified.
-    pub source: PaneContext,
-}
-
-/// Stable identity used to match discovery and submission receipts.
-///
-/// Geometry, readiness, display names, and negotiated delivery metadata may
-/// legitimately change while one semantic prompt request is in flight.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AgentTargetIdentity {
-    /// Integration provider.
-    pub provider: String,
-    /// Integration workspace containing both panes.
-    pub workspace_id: String,
-    /// Integration tab containing both panes.
-    pub tab_id: String,
-    /// Source Proqi pane.
-    pub source_pane_id: String,
-    /// Target agent pane.
-    pub target_pane_id: String,
-    /// Verified direction from source to target.
-    pub direction: Direction,
-    /// Recognized agent harness.
-    pub agent_kind: HarnessKind,
-    /// Stable or provisional harness session binding.
-    pub agent_session: AgentSessionBinding,
-}
-
-impl AgentTarget {
-    /// Return the stable receipt identity, excluding volatile presentation and state.
-    #[must_use]
-    pub fn identity(&self) -> AgentTargetIdentity {
-        AgentTargetIdentity {
-            provider: self.provider.clone(),
-            workspace_id: self.workspace_id.clone(),
-            tab_id: self.tab_id.clone(),
-            source_pane_id: self.source.pane_id.clone(),
-            target_pane_id: self.pane_id.clone(),
-            direction: self.direction,
-            agent_kind: self.agent_kind.clone(),
-            agent_session: self.agent_session.clone(),
-        }
-    }
-
-    /// Whether a receipt preserves an established or provisional target identity.
-    #[must_use]
-    pub fn accepts_receipt(&self, receipt: &Self) -> bool {
-        let expected = self.identity();
-        let actual = receipt.identity();
-        expected.provider == actual.provider
-            && expected.workspace_id == actual.workspace_id
-            && expected.tab_id == actual.tab_id
-            && expected.source_pane_id == actual.source_pane_id
-            && expected.target_pane_id == actual.target_pane_id
-            && expected.direction == actual.direction
-            && expected.agent_kind == actual.agent_kind
-            && expected
-                .agent_session
-                .accepts_receipt(&actual.agent_session)
-    }
-}
-
 /// One semantic prompt submission.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SubmissionRequest {
@@ -424,6 +340,13 @@ pub trait AgentGateway {
     ///
     /// Fails closed on stale context, ambiguous identity, or malformed topology.
     fn adjacent_targets(&mut self, context: &PaneContext) -> Result<Vec<AgentTarget>, AgentError>;
+
+    /// Discover compatible coding agents across the current Herdr server.
+    ///
+    /// # Errors
+    ///
+    /// Fails closed on incomplete, stale, ambiguous, or malformed identity data.
+    fn global_targets(&mut self) -> Result<Vec<AgentTarget>, AgentError>;
 
     /// Revalidate one target and submit exact text through a semantic provider command.
     ///

--- a/src/ports/agent/route.rs
+++ b/src/ports/agent/route.rs
@@ -1,0 +1,174 @@
+//! Closed verified addresses for semantic agent delivery.
+
+use serde::{Deserialize, Serialize};
+
+use crate::domain::Direction;
+
+use super::{AgentSessionBinding, HarnessKind, PaneContext, PaneRect};
+
+/// Current-server identity of one Herdr coding agent.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HerdrAgentAddress {
+    /// Opaque workspace identity from the current server snapshot.
+    workspace_id: String,
+    /// Opaque tab identity from the same snapshot.
+    tab_id: String,
+    /// Opaque pane identity currently hosting the agent.
+    pane_id: String,
+    /// Recognized coding-agent harness.
+    agent_kind: HarnessKind,
+    /// Stable harness session, or one explicitly qualified provisional binding.
+    agent_session: AgentSessionBinding,
+}
+
+impl HerdrAgentAddress {
+    /// Construct one complete current-server delivery address.
+    #[must_use]
+    pub fn new(
+        workspace_id: String,
+        tab_id: String,
+        pane_id: String,
+        agent_kind: HarnessKind,
+        agent_session: AgentSessionBinding,
+    ) -> Option<Self> {
+        if workspace_id.trim().is_empty() || tab_id.trim().is_empty() || pane_id.trim().is_empty() {
+            return None;
+        }
+        Some(Self {
+            workspace_id,
+            tab_id,
+            pane_id,
+            agent_kind,
+            agent_session,
+        })
+    }
+
+    /// Return the current-server workspace identity.
+    #[must_use]
+    pub fn workspace_id(&self) -> &str {
+        &self.workspace_id
+    }
+
+    /// Return the current-server tab identity.
+    #[must_use]
+    pub fn tab_id(&self) -> &str {
+        &self.tab_id
+    }
+
+    /// Return the target pane identity.
+    #[must_use]
+    pub fn pane_id(&self) -> &str {
+        &self.pane_id
+    }
+
+    /// Return the recognized harness kind.
+    #[must_use]
+    pub const fn agent_kind(&self) -> &HarnessKind {
+        &self.agent_kind
+    }
+
+    /// Return the established or qualified provisional harness session.
+    #[must_use]
+    pub const fn agent_session(&self) -> &AgentSessionBinding {
+        &self.agent_session
+    }
+
+    pub(super) fn replace_agent_kind(&mut self, kind: HarnessKind) {
+        self.agent_kind = kind;
+    }
+
+    pub(super) fn replace_agent_session(&mut self, session: AgentSessionBinding) {
+        self.agent_session = session;
+    }
+}
+
+/// Stable closed route classification shared by persistence and diagnostics.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubmissionRouteKind {
+    /// Same-tab directional delivery with verified geometry.
+    AdjacentPane,
+    /// Current-server global Herdr agent delivery.
+    HerdrAgent,
+}
+
+impl SubmissionRouteKind {
+    /// Stable internal storage and diagnostics spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AdjacentPane => "adjacent_pane",
+            Self::HerdrAgent => "herdr_agent",
+        }
+    }
+}
+
+/// One closed verified route for semantic prompt delivery.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SubmissionRoute {
+    /// Existing same-tab directional delivery with independently verified geometry.
+    AdjacentPane {
+        /// Direction from the Proqi pane.
+        direction: Direction,
+        /// Current-server identity of the adjacent agent.
+        target: HerdrAgentAddress,
+        /// Source context against which adjacency was verified.
+        source: PaneContext,
+        /// Verified adjacent target geometry.
+        target_rect: PaneRect,
+    },
+    /// Globally addressed coding agent on the current Herdr server.
+    HerdrAgent(HerdrAgentAddress),
+}
+
+impl SubmissionRoute {
+    /// Return the exact current-server target address.
+    #[must_use]
+    pub const fn target(&self) -> &HerdrAgentAddress {
+        match self {
+            Self::AdjacentPane { target, .. } | Self::HerdrAgent(target) => target,
+        }
+    }
+
+    /// Return the verified adjacent direction, when this is an adjacent route.
+    #[must_use]
+    pub const fn adjacent_direction(&self) -> Option<Direction> {
+        match self {
+            Self::AdjacentPane { direction, .. } => Some(*direction),
+            Self::HerdrAgent(_) => None,
+        }
+    }
+
+    /// Return the adjacent source context, when geometry is part of this route.
+    #[must_use]
+    pub const fn adjacent_source(&self) -> Option<&PaneContext> {
+        match self {
+            Self::AdjacentPane { source, .. } => Some(source),
+            Self::HerdrAgent(_) => None,
+        }
+    }
+
+    /// Return the verified adjacent target rectangle, when present.
+    #[must_use]
+    pub const fn adjacent_target_rect(&self) -> Option<PaneRect> {
+        match self {
+            Self::AdjacentPane { target_rect, .. } => Some(*target_rect),
+            Self::HerdrAgent(_) => None,
+        }
+    }
+
+    /// Stable route-kind spelling used by persistence and diagnostics.
+    #[must_use]
+    pub const fn kind_str(&self) -> &'static str {
+        self.kind().as_str()
+    }
+
+    /// Return the closed route classification.
+    #[must_use]
+    pub const fn kind(&self) -> SubmissionRouteKind {
+        match self {
+            Self::AdjacentPane { .. } => SubmissionRouteKind::AdjacentPane,
+            Self::HerdrAgent(_) => SubmissionRouteKind::HerdrAgent,
+        }
+    }
+}

--- a/src/ports/agent/target.rs
+++ b/src/ports/agent/target.rs
@@ -1,0 +1,289 @@
+//! Verified delivery target and receipt identity.
+
+use crate::domain::Direction;
+
+use super::{
+    AgentDeliveryCapabilities, AgentSessionBinding, AgentState, HarnessKind, HerdrAgentAddress,
+    PaneContext, PaneRect, SubmissionRoute, SubmissionRouteKind,
+};
+
+/// Truthful live eligibility for semantic prompt delivery.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AgentAvailability {
+    /// The provider supports prompt delivery in the observed live state.
+    Available,
+    /// The harness explicitly reports that it is blocked.
+    Blocked,
+    /// The harness state cannot currently be determined.
+    Unknown,
+    /// The harness is still launching.
+    Launching,
+    /// The pane is not ready for interactive input.
+    NotInteractive,
+}
+
+impl AgentAvailability {
+    /// Stable content-redacted state spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::Blocked => "blocked",
+            Self::Unknown => "unknown",
+            Self::Launching => "launching",
+            Self::NotInteractive => "not_interactive",
+        }
+    }
+}
+
+/// One independently verified adjacent or current-server global agent.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentTarget {
+    /// Integration provider that verified this target.
+    pub provider: String,
+    /// Negotiated provider protocol.
+    pub protocol: u32,
+    /// Closed verified adjacent or current-server global route.
+    pub route: SubmissionRoute,
+    /// User-facing identity.
+    pub agent_name: String,
+    /// Optional bounded workspace label from the verified discovery snapshot.
+    pub workspace_label: Option<String>,
+    /// Optional bounded tab label from the verified discovery snapshot.
+    pub tab_label: Option<String>,
+    /// Verified readiness.
+    pub readiness: AgentState,
+    /// Current live eligibility, including launch and interactive readiness.
+    pub availability: AgentAvailability,
+    /// Delivery behaviors verified for this target.
+    pub delivery: AgentDeliveryCapabilities,
+}
+
+/// Stable identity used to match discovery and submission receipts.
+///
+/// Geometry, readiness, display names, and negotiated delivery metadata may
+/// legitimately change while one semantic prompt request is in flight.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentTargetIdentity {
+    /// Integration provider.
+    pub provider: String,
+    /// Closed delivery route classification.
+    pub route_kind: SubmissionRouteKind,
+    /// Integration workspace containing the target.
+    pub workspace_id: String,
+    /// Integration tab containing the target.
+    pub tab_id: String,
+    /// Source Proqi pane for adjacent delivery only.
+    pub source_pane_id: Option<String>,
+    /// Target agent pane.
+    pub target_pane_id: String,
+    /// Verified direction from source to target for adjacent delivery only.
+    pub direction: Option<Direction>,
+    /// Recognized agent harness.
+    pub agent_kind: HarnessKind,
+    /// Stable or provisional harness session binding.
+    pub agent_session: AgentSessionBinding,
+}
+
+impl AgentTarget {
+    /// Construct one verified adjacent target.
+    #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "closed adjacent route has nine independent facts"
+    )]
+    pub fn adjacent(
+        provider: String,
+        protocol: u32,
+        direction: Direction,
+        address: HerdrAgentAddress,
+        agent_name: String,
+        readiness: AgentState,
+        delivery: AgentDeliveryCapabilities,
+        target_rect: PaneRect,
+        source: PaneContext,
+    ) -> Self {
+        Self {
+            provider,
+            protocol,
+            route: SubmissionRoute::AdjacentPane {
+                direction,
+                target: address,
+                source,
+                target_rect,
+            },
+            agent_name,
+            workspace_label: None,
+            tab_label: None,
+            readiness,
+            availability: AgentAvailability::Available,
+            delivery,
+        }
+    }
+
+    /// Construct one current-server global target.
+    #[must_use]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "closed global route has eight independent facts"
+    )]
+    pub fn herdr_agent(
+        protocol: u32,
+        address: HerdrAgentAddress,
+        agent_name: String,
+        workspace_label: Option<String>,
+        tab_label: Option<String>,
+        readiness: AgentState,
+        availability: AgentAvailability,
+        delivery: AgentDeliveryCapabilities,
+    ) -> Self {
+        Self {
+            provider: "herdr".to_owned(),
+            protocol,
+            route: SubmissionRoute::HerdrAgent(address),
+            agent_name,
+            workspace_label,
+            tab_label,
+            readiness,
+            availability,
+            delivery,
+        }
+    }
+
+    /// Return the exact verified current-server target address.
+    #[must_use]
+    pub const fn address(&self) -> &HerdrAgentAddress {
+        self.route.target()
+    }
+
+    /// Return the target pane identity.
+    #[must_use]
+    pub fn pane_id(&self) -> &str {
+        self.address().pane_id()
+    }
+
+    /// Return the target workspace identity.
+    #[must_use]
+    pub fn workspace_id(&self) -> &str {
+        self.address().workspace_id()
+    }
+
+    /// Return the target tab identity.
+    #[must_use]
+    pub fn tab_id(&self) -> &str {
+        self.address().tab_id()
+    }
+
+    /// Return the recognized harness kind.
+    #[must_use]
+    pub const fn agent_kind(&self) -> &HarnessKind {
+        self.address().agent_kind()
+    }
+
+    /// Return the stable or explicitly provisional session binding.
+    #[must_use]
+    pub const fn agent_session(&self) -> &AgentSessionBinding {
+        self.address().agent_session()
+    }
+
+    /// Return the adjacent direction, when this is an adjacent route.
+    #[must_use]
+    pub const fn adjacent_direction(&self) -> Option<Direction> {
+        self.route.adjacent_direction()
+    }
+
+    /// Whether this exact observed target is eligible for semantic delivery.
+    #[must_use]
+    pub const fn can_submit(&self) -> bool {
+        self.delivery.supports() && matches!(self.availability, AgentAvailability::Available)
+    }
+
+    /// Return this target with a replacement recognized harness identity.
+    #[must_use]
+    pub fn with_agent_kind(mut self, kind: HarnessKind) -> Self {
+        self.address_mut().replace_agent_kind(kind);
+        self
+    }
+
+    /// Return this target with a replacement stable or qualified provisional session.
+    #[must_use]
+    pub fn with_agent_session(mut self, session: AgentSessionBinding) -> Self {
+        self.bind_agent_session(session);
+        self
+    }
+
+    /// Replace volatile adjacent geometry while preserving the delivery identity.
+    #[must_use]
+    pub fn with_adjacent_geometry(mut self, target_rect: PaneRect, source: PaneContext) -> Self {
+        if let SubmissionRoute::AdjacentPane {
+            target_rect: current_rect,
+            source: current_source,
+            ..
+        } = &mut self.route
+        {
+            *current_rect = target_rect;
+            *current_source = source;
+        }
+        self
+    }
+
+    /// Replace a provisional session with the exact accepted receipt binding.
+    pub(crate) fn bind_agent_session(&mut self, binding: AgentSessionBinding) {
+        self.address_mut().replace_agent_session(binding);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_test_agent_kind(&mut self, kind: HarnessKind) {
+        self.address_mut().replace_agent_kind(kind);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_test_agent_session(&mut self, session: AgentSessionBinding) {
+        self.address_mut().replace_agent_session(session);
+    }
+
+    /// Return the stable receipt identity, excluding volatile presentation and state.
+    #[must_use]
+    pub fn identity(&self) -> AgentTargetIdentity {
+        AgentTargetIdentity {
+            provider: self.provider.clone(),
+            route_kind: self.route.kind(),
+            workspace_id: self.workspace_id().to_owned(),
+            tab_id: self.tab_id().to_owned(),
+            source_pane_id: self
+                .route
+                .adjacent_source()
+                .map(|source| source.pane_id.clone()),
+            target_pane_id: self.pane_id().to_owned(),
+            direction: self.adjacent_direction(),
+            agent_kind: self.agent_kind().clone(),
+            agent_session: self.agent_session().clone(),
+        }
+    }
+
+    /// Whether a receipt preserves an established or provisional target identity.
+    #[must_use]
+    pub fn accepts_receipt(&self, receipt: &Self) -> bool {
+        let expected = self.identity();
+        let actual = receipt.identity();
+        expected.provider == actual.provider
+            && expected.route_kind == actual.route_kind
+            && expected.workspace_id == actual.workspace_id
+            && expected.tab_id == actual.tab_id
+            && expected.source_pane_id == actual.source_pane_id
+            && expected.target_pane_id == actual.target_pane_id
+            && expected.direction == actual.direction
+            && expected.agent_kind == actual.agent_kind
+            && expected
+                .agent_session
+                .accepts_receipt(&actual.agent_session)
+    }
+
+    fn address_mut(&mut self) -> &mut HerdrAgentAddress {
+        match &mut self.route {
+            SubmissionRoute::AdjacentPane { target, .. } | SubmissionRoute::HerdrAgent(target) => {
+                target
+            }
+        }
+    }
+}

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -4,13 +4,13 @@ mod capture;
 mod compaction;
 mod error;
 mod onboarding;
+mod submission_route;
 
 use serde::{Deserialize, Serialize};
 
 use crate::domain::{
-    BoardOperation, Direction, IntegrationContext, OperationId, OperationSequence, RevisionId,
-    Session, SessionBoard, SessionId, SubmissionId, ThoughtId, ThoughtRevision, Timestamp,
-    UndoScope,
+    BoardOperation, IntegrationContext, OperationId, OperationSequence, RevisionId, Session,
+    SessionBoard, SessionId, SubmissionId, ThoughtId, ThoughtRevision, Timestamp, UndoScope,
 };
 use crate::ports::agent::{AgentState, SubmissionDisposition};
 
@@ -18,11 +18,12 @@ pub use capture::{CaptureCommit, CaptureCommitOutcome, CaptureReceipt};
 pub use compaction::{CompactedOperationRequest, thought_payload_digest};
 pub use error::{StoreError, StoreFailureCode};
 pub use onboarding::{FirstRunBoard, FirstRunOutcome, OnboardingVersion};
+pub use submission_route::{SUBMISSION_ROUTE_VERSION, SubmissionJournalRoute};
 
 /// Current storage schema understood by this binary.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 12;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 13;
 /// Current local storage protocol understood by this binary.
-pub const STORAGE_PROTOCOL_VERSION: u32 = 11;
+pub const STORAGE_PROTOCOL_VERSION: u32 = 12;
 
 /// One ordered, content-redacted source included in a submission.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -81,8 +82,8 @@ pub struct SubmissionAttempt {
     pub source_sequence: OperationSequence,
     /// Keep or remove after durable acceptance.
     pub disposition: SubmissionDisposition,
-    /// Adjacent target direction.
-    pub direction: Direction,
+    /// Versioned content-redacted delivery route.
+    pub route: SubmissionJournalRoute,
     /// Integration provider name.
     pub provider: String,
     /// Negotiated provider protocol.

--- a/src/ports/store/submission_route.rs
+++ b/src/ports/store/submission_route.rs
@@ -1,0 +1,76 @@
+//! Content-redacted durable route encoding for submission recovery.
+
+use crate::{
+    domain::Direction,
+    ports::agent::{SubmissionRoute, SubmissionRouteKind},
+};
+
+/// Current content-redacted journal encoding for submission routes.
+pub const SUBMISSION_ROUTE_VERSION: u32 = 1;
+
+/// Versioned content-redacted delivery route retained by the submission journal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SubmissionJournalRoute {
+    version: u32,
+    kind: SubmissionRouteKind,
+    adjacent_direction: Option<Direction>,
+}
+
+impl SubmissionJournalRoute {
+    /// Construct the current adjacent-route journal encoding.
+    #[must_use]
+    pub const fn adjacent(direction: Direction) -> Self {
+        Self {
+            version: SUBMISSION_ROUTE_VERSION,
+            kind: SubmissionRouteKind::AdjacentPane,
+            adjacent_direction: Some(direction),
+        }
+    }
+
+    /// Construct the current global Herdr-route journal encoding.
+    #[must_use]
+    pub const fn herdr_agent() -> Self {
+        Self {
+            version: SUBMISSION_ROUTE_VERSION,
+            kind: SubmissionRouteKind::HerdrAgent,
+            adjacent_direction: None,
+        }
+    }
+
+    /// Project a verified route without persisting topology identity.
+    #[must_use]
+    pub const fn from_route(route: &SubmissionRoute) -> Self {
+        match route {
+            SubmissionRoute::AdjacentPane { direction, .. } => Self::adjacent(*direction),
+            SubmissionRoute::HerdrAgent(_) => Self::herdr_agent(),
+        }
+    }
+
+    /// Decode one exact legacy direction as the original adjacent route.
+    #[must_use]
+    pub const fn legacy_adjacent(direction: Direction) -> Self {
+        Self {
+            version: 0,
+            kind: SubmissionRouteKind::AdjacentPane,
+            adjacent_direction: Some(direction),
+        }
+    }
+
+    /// Return the durable route encoding version.
+    #[must_use]
+    pub const fn version(self) -> u32 {
+        self.version
+    }
+
+    /// Return the closed durable route kind.
+    #[must_use]
+    pub const fn kind(self) -> SubmissionRouteKind {
+        self.kind
+    }
+
+    /// Return direction only for an adjacent route.
+    #[must_use]
+    pub const fn adjacent_direction(self) -> Option<Direction> {
+        self.adjacent_direction
+    }
+}

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -13,6 +13,7 @@ mod control;
 mod duplicate;
 mod editing;
 mod folds;
+pub(in crate::ui) mod global_delivery;
 mod help;
 pub(in crate::ui) mod highlights;
 mod input_dispatch;
@@ -145,6 +146,8 @@ pub struct BoardApp {
     recovery_exported_for: Option<OperationSequence>,
     agent_targets: Vec<AgentTarget>,
     agent_refresh_in_flight: bool,
+    global_delivery: Option<global_delivery::GlobalDeliveryState>,
+    global_delivery_generation: u64,
     submission_mode: Option<SubmissionMode>,
     deferred_submissions: BTreeMap<SubmissionId, DeferredSubmissionIntent>,
     preflight_submissions: BTreeMap<SubmissionId, DeferredSubmissionIntent>,
@@ -240,6 +243,8 @@ impl BoardApp {
             recovery_exported_for: None,
             agent_targets: Vec::new(),
             agent_refresh_in_flight: false,
+            global_delivery: None,
+            global_delivery_generation: 0,
             submission_mode: None,
             deferred_submissions: BTreeMap::new(),
             preflight_submissions: BTreeMap::new(),
@@ -325,6 +330,9 @@ impl BoardApp {
         if self.palette.is_some() {
             return self.handle_palette_input(&input, ids, clock);
         }
+        if self.global_delivery.is_some() {
+            return self.handle_global_delivery_input(&input, ids, clock);
+        }
         if self.invocation_popup.is_some() {
             return self.handle_invocation_input(&input, ids, clock);
         }
@@ -354,6 +362,7 @@ impl BoardApp {
             || self.update_prompt.is_some()
             || self.release_highlights.is_some()
             || self.palette.is_some()
+            || self.global_delivery.is_some()
             || self.invocation_popup.is_some()
             || self.transfer.is_some()
             || self.rename.is_some()

--- a/src/ui/app/agent.rs
+++ b/src/ui/app/agent.rs
@@ -240,11 +240,16 @@ impl BoardApp {
         {
             *target = receipt.target.clone();
         }
-        let mut effects = vec![Effect::StoreIntegrationContext {
-            session_id: self.state.board.session.id,
-            target: receipt.target.clone(),
-            verified_at: pending.at,
-        }];
+        let mut effects = receipt
+            .target
+            .adjacent_direction()
+            .map(|_| Effect::StoreIntegrationContext {
+                session_id: self.state.board.session.id,
+                target: receipt.target.clone(),
+                verified_at: pending.at,
+            })
+            .into_iter()
+            .collect::<Vec<_>>();
         let removed = pending.removal_sequence.is_some();
         if removed {
             self.state.reconcile_empty_board(
@@ -272,12 +277,14 @@ impl BoardApp {
                 "thoughts changed during submission and were kept"
             }
         };
-        self.set_success(format!(
-            "submitted {} to {}, {outcome}",
-            receipt.target.direction.as_str(),
-            receipt.target.agent_name
-        ));
-        if receipt.target.agent_session.is_provisional() {
+        let destination = receipt.target.adjacent_direction().map_or_else(
+            || format!("to {}", receipt.target.agent_name),
+            |direction| format!("{} to {}", direction.as_str(), receipt.target.agent_name),
+        );
+        self.set_success(format!("submitted {destination}, {outcome}"));
+        if receipt.target.adjacent_direction().is_some()
+            && receipt.target.agent_session().is_provisional()
+        {
             effects.push(Effect::DiscoverAgents);
         }
         effects

--- a/src/ui/app/agent_delivery.rs
+++ b/src/ui/app/agent_delivery.rs
@@ -4,7 +4,7 @@ use crate::{
     application::{Effect, InteractionMode},
     domain::{Direction, ThoughtId},
     ports::{
-        agent::SubmissionDisposition,
+        agent::{AgentTarget, SubmissionDisposition},
         environment::{Clock, IdGenerator},
     },
 };
@@ -93,7 +93,7 @@ impl BoardApp {
             .agent_targets
             .iter()
             .filter(|target| target.delivery.supports())
-            .map(|target| target.direction)
+            .filter_map(AgentTarget::adjacent_direction)
             .collect::<Vec<_>>();
         match eligible.as_slice() {
             [] => {
@@ -166,7 +166,7 @@ impl BoardApp {
         let Some(target) = self
             .agent_targets
             .iter()
-            .find(|target| target.direction == direction)
+            .find(|target| target.adjacent_direction() == Some(direction))
             .cloned()
         else {
             self.set_warning(format!("no verified agent {}", direction.as_str()));

--- a/src/ui/app/agent_identity.rs
+++ b/src/ui/app/agent_identity.rs
@@ -7,18 +7,26 @@ use crate::ports::agent::AgentTarget;
 pub(super) fn target_fingerprint(target: &AgentTarget) -> [u8; 32] {
     let mut hasher = Sha256::new();
     let identity = target.identity();
+    hasher.update(crate::ports::store::SUBMISSION_ROUTE_VERSION.to_be_bytes());
     for field in [
         identity.provider.as_str(),
+        identity.route_kind.as_str(),
         identity.workspace_id.as_str(),
         identity.tab_id.as_str(),
-        identity.source_pane_id.as_str(),
         identity.target_pane_id.as_str(),
-        identity.direction.as_str(),
         identity.agent_kind.as_str(),
     ] {
         hasher.update(field.as_bytes());
         hasher.update([0]);
     }
+    if let Some(source_pane_id) = identity.source_pane_id.as_deref() {
+        hasher.update(source_pane_id.as_bytes());
+    }
+    hasher.update([0]);
+    if let Some(direction) = identity.direction {
+        hasher.update(direction.as_str().as_bytes());
+    }
+    hasher.update([0]);
     match identity.agent_session.as_id() {
         Some(session_id) => {
             hasher.update([1]);

--- a/src/ui/app/agent_preparation.rs
+++ b/src/ui/app/agent_preparation.rs
@@ -110,7 +110,7 @@ impl BoardApp {
             payload_digest,
             source_sequence: self.state.board.session.last_durable_sequence,
             disposition,
-            direction: target.direction,
+            route: crate::ports::store::SubmissionJournalRoute::from_route(&target.route),
             provider: target.provider.clone(),
             protocol: target.protocol,
             target_fingerprint: target_fingerprint(target),

--- a/src/ui/app/control/tests.rs
+++ b/src/ui/app/control/tests.rs
@@ -407,26 +407,30 @@ fn thought_mutations_are_locked_from_submission_intent_until_completion() {
             height: 10,
         },
     };
-    app.complete_agent_discovery(Ok(vec![AgentTarget {
-        provider: "herdr".to_owned(),
-        protocol: 1,
-        direction: Direction::Left,
-        pane_id: "target".to_owned(),
-        workspace_id: source.workspace_id.clone(),
-        tab_id: source.tab_id.clone(),
-        agent_kind: HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
-        agent_name: "Codex".to_owned(),
-        agent_session: AgentSessionBinding::established("agent-session").expect("fixture session"),
-        readiness: AgentState::Working,
-        delivery: AgentDeliveryCapabilities::SUBMIT_ONLY,
-        rect: PaneRect {
+    let address = crate::ports::agent::HerdrAgentAddress::new(
+        source.workspace_id.clone(),
+        source.tab_id.clone(),
+        "target".to_owned(),
+        HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
+        AgentSessionBinding::established("agent-session").expect("fixture session"),
+    )
+    .expect("fixture address");
+    app.complete_agent_discovery(Ok(vec![AgentTarget::adjacent(
+        "herdr".to_owned(),
+        1,
+        Direction::Left,
+        address,
+        "Codex".to_owned(),
+        AgentState::Working,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
+        PaneRect {
             x: 10,
             y: 0,
             width: 10,
             height: 10,
         },
         source,
-    }]));
+    )]));
     let clock = FakeClock::new(Timestamp::from_millis(2));
     let effects = app.handle(UiInput::Key(UiKey::Character('s')), &mut ids, &clock);
     assert!(matches!(

--- a/src/ui/app/editing/navigation.rs
+++ b/src/ui/app/editing/navigation.rs
@@ -56,6 +56,7 @@ impl BoardApp {
             || self.update_prompt.is_some()
             || self.release_highlights.is_some()
             || self.palette.is_some()
+            || self.global_delivery.is_some()
             || self.invocation_popup.is_some()
             || self.transfer.is_some()
             || self.rename.is_some()

--- a/src/ui/app/global_delivery.rs
+++ b/src/ui/app/global_delivery.rs
@@ -1,0 +1,372 @@
+//! Searchable current-server target and explicit disposition chooser.
+
+use crate::{
+    application::Effect,
+    domain::ThoughtId,
+    ports::{
+        agent::{
+            AgentAvailability, AgentError, AgentFailureCode, AgentTarget, SubmissionDisposition,
+        },
+        editor::CursorMovement,
+        environment::{Clock, IdGenerator},
+    },
+};
+
+use super::{BoardApp, UiInput, UiKey, pending_types::EditFlush, query::QueryEditor};
+
+mod view;
+
+pub(super) struct GlobalDeliveryState {
+    generation: u64,
+    query: QueryEditor,
+    selected: usize,
+    scroll: usize,
+    thought_ids: Vec<ThoughtId>,
+    source_digests: Vec<[u8; 32]>,
+    stage: GlobalDeliveryStage,
+}
+
+enum GlobalDeliveryStage {
+    Targets {
+        loading: bool,
+        targets: Vec<AgentTarget>,
+        failure: Option<AgentFailureCode>,
+    },
+    Disposition {
+        target: Box<AgentTarget>,
+    },
+}
+
+pub(in crate::ui) struct GlobalDeliveryChoiceView {
+    pub(in crate::ui) primary: String,
+    pub(in crate::ui) secondary: String,
+    pub(in crate::ui) enabled: bool,
+}
+
+pub(in crate::ui) struct GlobalDeliveryView {
+    pub(in crate::ui) title: &'static str,
+    pub(in crate::ui) query: String,
+    pub(in crate::ui) choices: Vec<GlobalDeliveryChoiceView>,
+    pub(in crate::ui) selected: usize,
+}
+
+impl BoardApp {
+    pub(super) fn begin_global_delivery(
+        &mut self,
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        let thought_ids = self.action_thought_ids();
+        if thought_ids.is_empty() {
+            self.set_warning("select a thought before submitting to an agent");
+            return Vec::new();
+        }
+        let mut effects = match self.flush_edit_boundary(ids, clock) {
+            EditFlush::Complete(effects) => effects,
+            EditFlush::Blocked(effects) => return effects,
+        };
+        let source_digests = thought_ids
+            .iter()
+            .filter_map(|thought_id| self.current_thought_digest(*thought_id))
+            .collect::<Vec<_>>();
+        if source_digests.len() != thought_ids.len() {
+            self.set_warning("board changed before agent discovery; thoughts kept");
+            return effects;
+        }
+        self.global_delivery_generation = self.global_delivery_generation.wrapping_add(1);
+        let generation = self.global_delivery_generation;
+        self.global_delivery = Some(GlobalDeliveryState {
+            generation,
+            query: QueryEditor::default(),
+            selected: 0,
+            scroll: 0,
+            thought_ids,
+            source_digests,
+            stage: GlobalDeliveryStage::Targets {
+                loading: true,
+                targets: Vec::new(),
+                failure: None,
+            },
+        });
+        effects.push(Effect::DiscoverGlobalAgents { generation });
+        effects
+    }
+
+    /// Apply one generation-matched current-server discovery completion.
+    pub fn complete_global_agent_discovery(
+        &mut self,
+        generation: u64,
+        result: Result<Vec<AgentTarget>, AgentError>,
+    ) {
+        let Some(state) = &mut self.global_delivery else {
+            return;
+        };
+        if state.generation != generation {
+            return;
+        }
+        let GlobalDeliveryStage::Targets {
+            loading,
+            targets,
+            failure,
+        } = &mut state.stage
+        else {
+            return;
+        };
+        *loading = false;
+        match result {
+            Ok(mut discovered) => {
+                discovered.sort_by(|left, right| {
+                    left.workspace_label
+                        .cmp(&right.workspace_label)
+                        .then_with(|| left.tab_label.cmp(&right.tab_label))
+                        .then_with(|| left.agent_name.cmp(&right.agent_name))
+                        .then_with(|| left.workspace_id().cmp(right.workspace_id()))
+                        .then_with(|| left.tab_id().cmp(right.tab_id()))
+                        .then_with(|| left.pane_id().cmp(right.pane_id()))
+                });
+                *targets = discovered;
+                *failure = None;
+            }
+            Err(error) => {
+                targets.clear();
+                *failure = Some(error.stable_code());
+            }
+        }
+        state.clamp();
+    }
+
+    pub(super) fn handle_global_delivery_input(
+        &mut self,
+        input: &UiInput,
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        let UiInput::Key(key) = input else {
+            return match input {
+                UiInput::Pointer(pointer) => match pointer.kind {
+                    crate::ui::PointerKind::ScrollUp => {
+                        self.move_global_delivery(-1);
+                        Vec::new()
+                    }
+                    crate::ui::PointerKind::ScrollDown => {
+                        self.move_global_delivery(1);
+                        Vec::new()
+                    }
+                    _ => self.handle_pointer(*pointer, ids, clock),
+                },
+                UiInput::Paste(value) => {
+                    self.update_global_query(|query| query.paste(value));
+                    Vec::new()
+                }
+                UiInput::PasteAnnotated(payload) => {
+                    self.update_global_query(|query| query.paste(&payload.content));
+                    Vec::new()
+                }
+                _ => Vec::new(),
+            };
+        };
+        match *key {
+            UiKey::Escape => {
+                self.global_delivery = None;
+                self.set_info("agent submission cancelled");
+            }
+            UiKey::Enter => return self.choose_global_delivery(ids, clock),
+            UiKey::Backspace => self.update_global_query(QueryEditor::backspace),
+            UiKey::Delete | UiKey::ModifiedDelete => {
+                self.update_global_query(QueryEditor::delete);
+            }
+            UiKey::FastNavigation { direction, .. } => {
+                self.move_global_delivery(direction.delta());
+            }
+            UiKey::Move {
+                movement: CursorMovement::VisualUp,
+                ..
+            } => self.move_global_delivery(-1),
+            UiKey::Move {
+                movement: CursorMovement::VisualDown,
+                ..
+            } => self.move_global_delivery(1),
+            UiKey::Move { movement, .. } => {
+                self.update_global_query(|query| query.move_cursor(movement));
+            }
+            UiKey::Character(character) if !character.is_control() => {
+                self.update_global_query(|query| query.insert_char(character));
+            }
+            UiKey::UnmodifiedSpace => {
+                self.update_global_query(|query| query.insert_char(' '));
+            }
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    pub(super) fn choose_global_delivery_visible(
+        &mut self,
+        index: usize,
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        if let Some(state) = &mut self.global_delivery {
+            state.selected = state.scroll.saturating_add(index);
+        }
+        self.choose_global_delivery(ids, clock)
+    }
+
+    fn choose_global_delivery(
+        &mut self,
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        let no_choice_message = self
+            .global_delivery
+            .as_ref()
+            .map_or("no compatible agent matches this search", |state| {
+                state.no_choice_message()
+            });
+        let choice = self
+            .global_delivery
+            .as_ref()
+            .and_then(GlobalDeliveryState::choice);
+        match choice {
+            Some(GlobalChoice::Target(target)) if target.can_submit() => {
+                if let Some(state) = &mut self.global_delivery {
+                    state.query = QueryEditor::default();
+                    state.selected = 0;
+                    state.scroll = 0;
+                    state.stage = GlobalDeliveryStage::Disposition {
+                        target: Box::new(target),
+                    };
+                }
+                Vec::new()
+            }
+            Some(GlobalChoice::Target(target)) => {
+                self.set_warning(unavailable_message(target.availability));
+                Vec::new()
+            }
+            Some(GlobalChoice::Disposition(disposition, target, thought_ids, source_digests)) => {
+                self.global_delivery = None;
+                self.deliver_global_target(
+                    &target,
+                    disposition,
+                    &thought_ids,
+                    &source_digests,
+                    ids,
+                    clock,
+                )
+            }
+            None => {
+                self.set_warning(no_choice_message);
+                Vec::new()
+            }
+        }
+    }
+
+    fn deliver_global_target(
+        &mut self,
+        target: &AgentTarget,
+        disposition: SubmissionDisposition,
+        thought_ids: &[ThoughtId],
+        source_digests: &[[u8; 32]],
+        ids: &mut impl IdGenerator,
+        clock: &impl Clock,
+    ) -> Vec<Effect> {
+        let sources_unchanged = thought_ids
+            .iter()
+            .zip(source_digests)
+            .all(|(thought_id, digest)| self.current_thought_digest(*thought_id) == Some(*digest));
+        if thought_ids.len() != source_digests.len() || !sources_unchanged {
+            self.set_warning("source changed during agent selection; thoughts kept");
+            return Vec::new();
+        }
+        if thought_ids.iter().any(|id| self.submission_locked(*id)) {
+            self.set_warning("a selected thought already has a submission in progress");
+            return Vec::new();
+        }
+        self.queue_submission(target, disposition, thought_ids, ids, clock)
+    }
+
+    fn update_global_query(&mut self, update: impl FnOnce(&mut QueryEditor)) {
+        let Some(state) = &mut self.global_delivery else {
+            return;
+        };
+        if !matches!(state.stage, GlobalDeliveryStage::Targets { .. }) {
+            return;
+        }
+        update(&mut state.query);
+        state.selected = 0;
+        state.scroll = 0;
+        state.clamp();
+    }
+
+    fn move_global_delivery(&mut self, delta: isize) {
+        let visible = self
+            .layout
+            .as_ref()
+            .and_then(|layout| layout.overlay.as_ref())
+            .map_or(1, |overlay| overlay.items.len().max(1));
+        let Some(state) = &mut self.global_delivery else {
+            return;
+        };
+        state.selected = state
+            .selected
+            .saturating_add_signed(delta)
+            .min(state.match_count().saturating_sub(1));
+        state.scroll = crate::ui::paging::first_visible(state.selected, state.scroll, visible);
+        self.layout = None;
+    }
+
+    pub(super) fn ensure_global_delivery_visible(&mut self, visible: usize) {
+        let Some(state) = &mut self.global_delivery else {
+            return;
+        };
+        state.clamp();
+        state.scroll = crate::ui::paging::first_visible(state.selected, state.scroll, visible);
+    }
+
+    pub(in crate::ui) fn global_delivery_view(&self) -> Option<GlobalDeliveryView> {
+        self.global_delivery.as_ref().map(GlobalDeliveryState::view)
+    }
+
+    pub(super) fn global_delivery_match_count(&self) -> usize {
+        self.global_delivery
+            .as_ref()
+            .map_or(0, GlobalDeliveryState::match_count)
+    }
+
+    pub(super) fn global_delivery_query_cursor(&self) -> Option<usize> {
+        self.global_delivery
+            .as_ref()
+            .map(|state| state.query.cursor())
+    }
+
+    pub(super) fn global_delivery_overflow(&self, visible: usize) -> (bool, bool) {
+        self.global_delivery
+            .as_ref()
+            .map_or((false, false), |state| {
+                (
+                    state.scroll > 0,
+                    state.scroll.saturating_add(visible) < state.match_count(),
+                )
+            })
+    }
+}
+
+pub(super) enum GlobalChoice {
+    Target(AgentTarget),
+    Disposition(
+        SubmissionDisposition,
+        AgentTarget,
+        Vec<ThoughtId>,
+        Vec<[u8; 32]>,
+    ),
+}
+
+const fn unavailable_message(availability: AgentAvailability) -> &'static str {
+    match availability {
+        AgentAvailability::Blocked => "agent is blocked; choose an available target",
+        AgentAvailability::Unknown => "agent state is unknown; delivery is disabled",
+        AgentAvailability::Launching => "agent is still launching; delivery is disabled",
+        AgentAvailability::NotInteractive => "agent is not interactive yet; delivery is disabled",
+        AgentAvailability::Available => "agent delivery is unavailable",
+    }
+}

--- a/src/ui/app/global_delivery.rs
+++ b/src/ui/app/global_delivery.rs
@@ -40,6 +40,8 @@ enum GlobalDeliveryStage {
 pub(in crate::ui) struct GlobalDeliveryChoiceView {
     pub(in crate::ui) primary: String,
     pub(in crate::ui) secondary: String,
+    pub(in crate::ui) secondary_fallbacks: Vec<String>,
+    pub(in crate::ui) protected_secondaries: Vec<String>,
     pub(in crate::ui) enabled: bool,
 }
 

--- a/src/ui/app/global_delivery/view.rs
+++ b/src/ui/app/global_delivery/view.rs
@@ -92,11 +92,15 @@ impl GlobalDeliveryState {
                     GlobalDeliveryChoiceView {
                         primary: "Submit".to_owned(),
                         secondary: "remove after accepted receipt".to_owned(),
+                        secondary_fallbacks: Vec::new(),
+                        protected_secondaries: Vec::new(),
                         enabled: true,
                     },
                     GlobalDeliveryChoiceView {
                         primary: "Submit and keep".to_owned(),
                         secondary: "keep after accepted receipt".to_owned(),
+                        secondary_fallbacks: Vec::new(),
+                        protected_secondaries: Vec::new(),
                         enabled: true,
                     },
                 ],
@@ -146,15 +150,29 @@ fn target_view(target: &AgentTarget) -> GlobalDeliveryChoiceView {
         .tab_label
         .as_deref()
         .unwrap_or_else(|| target.tab_id());
+    let pane = compact_child(target.workspace_id(), target.pane_id());
+    let state = target_live_state(target);
+    let location_and_pane = format!("{workspace} / {tab} · {pane}");
+    let location_without_harness = format!("{location_and_pane} · {state}");
+    let workspace_and_pane = format!("{workspace} · {pane} · {state}");
+    let pane_and_state = format!("{pane} · {state}");
     GlobalDeliveryChoiceView {
         primary: target.agent_name.clone(),
         secondary: format!(
-            "{workspace} / {tab} · {} · {}",
+            "{location_and_pane} · {} · {state}",
             target.agent_kind().as_str(),
-            target_live_state(target)
         ),
+        secondary_fallbacks: vec![location_without_harness, workspace_and_pane],
+        protected_secondaries: vec![pane_and_state, state.to_owned()],
         enabled: target.can_submit(),
     }
+}
+
+fn compact_child<'a>(workspace: &str, identity: &'a str) -> &'a str {
+    identity
+        .strip_prefix(workspace)
+        .and_then(|suffix| suffix.strip_prefix(':'))
+        .unwrap_or(identity)
 }
 
 const fn target_live_state(target: &AgentTarget) -> &'static str {
@@ -168,6 +186,8 @@ fn placeholder(value: &str) -> GlobalDeliveryChoiceView {
     GlobalDeliveryChoiceView {
         primary: value.to_owned(),
         secondary: String::new(),
+        secondary_fallbacks: Vec::new(),
+        protected_secondaries: Vec::new(),
         enabled: false,
     }
 }

--- a/src/ui/app/global_delivery/view.rs
+++ b/src/ui/app/global_delivery/view.rs
@@ -1,0 +1,173 @@
+//! Semantic rows shared by global delivery rendering, selection, and hit geometry.
+
+use crate::ports::agent::{AgentAvailability, AgentTarget, SubmissionDisposition};
+
+use super::{
+    GlobalChoice, GlobalDeliveryChoiceView, GlobalDeliveryStage, GlobalDeliveryState,
+    GlobalDeliveryView,
+};
+
+impl GlobalDeliveryState {
+    pub(super) const fn no_choice_message(&self) -> &'static str {
+        match &self.stage {
+            GlobalDeliveryStage::Targets { loading: true, .. } => {
+                "agent discovery is still in progress"
+            }
+            GlobalDeliveryStage::Targets {
+                failure: Some(_), ..
+            } => "agent discovery failed; refresh and try again",
+            GlobalDeliveryStage::Targets { .. } => "no compatible agent matches this search",
+            GlobalDeliveryStage::Disposition { .. } => "choose a submission behavior",
+        }
+    }
+
+    pub(super) fn match_count(&self) -> usize {
+        match &self.stage {
+            GlobalDeliveryStage::Targets { loading: true, .. } => 1,
+            GlobalDeliveryStage::Targets { .. } => self.matching_targets().len().max(1),
+            GlobalDeliveryStage::Disposition { .. } => 2,
+        }
+    }
+
+    pub(super) fn clamp(&mut self) {
+        self.selected = self.selected.min(self.match_count().saturating_sub(1));
+        self.scroll = self.scroll.min(self.selected);
+    }
+
+    pub(super) fn choice(&self) -> Option<GlobalChoice> {
+        match &self.stage {
+            GlobalDeliveryStage::Targets { loading: true, .. } => None,
+            GlobalDeliveryStage::Targets { .. } => self
+                .matching_targets()
+                .get(self.selected)
+                .map(|target| GlobalChoice::Target((*target).clone())),
+            GlobalDeliveryStage::Disposition { target } => {
+                let disposition = match self.selected {
+                    0 => SubmissionDisposition::RemoveAfterSuccess,
+                    1 => SubmissionDisposition::Keep,
+                    _ => return None,
+                };
+                Some(GlobalChoice::Disposition(
+                    disposition,
+                    target.as_ref().clone(),
+                    self.thought_ids.clone(),
+                    self.source_digests.clone(),
+                ))
+            }
+        }
+    }
+
+    pub(super) fn view(&self) -> GlobalDeliveryView {
+        let (title, choices) = match &self.stage {
+            GlobalDeliveryStage::Targets { loading: true, .. } => (
+                " submit to agent ",
+                vec![placeholder("Discovering current-server agents...")],
+            ),
+            GlobalDeliveryStage::Targets {
+                failure: Some(code),
+                ..
+            } => (
+                " submit to agent ",
+                vec![placeholder(&format!(
+                    "Discovery unavailable ({})",
+                    code.as_str()
+                ))],
+            ),
+            GlobalDeliveryStage::Targets { .. } => {
+                let matches = self.matching_targets();
+                let rows = if matches.is_empty() {
+                    vec![placeholder("No compatible agents match")]
+                } else {
+                    matches
+                        .into_iter()
+                        .skip(self.scroll)
+                        .map(target_view)
+                        .collect()
+                };
+                (" submit to agent ", rows)
+            }
+            GlobalDeliveryStage::Disposition { .. } => (
+                " submission behavior ",
+                vec![
+                    GlobalDeliveryChoiceView {
+                        primary: "Submit".to_owned(),
+                        secondary: "remove after accepted receipt".to_owned(),
+                        enabled: true,
+                    },
+                    GlobalDeliveryChoiceView {
+                        primary: "Submit and keep".to_owned(),
+                        secondary: "keep after accepted receipt".to_owned(),
+                        enabled: true,
+                    },
+                ],
+            ),
+        };
+        GlobalDeliveryView {
+            title,
+            query: self.query.text().to_owned(),
+            choices,
+            selected: self.selected.saturating_sub(self.scroll),
+        }
+    }
+
+    fn matching_targets(&self) -> Vec<&AgentTarget> {
+        let GlobalDeliveryStage::Targets { targets, .. } = &self.stage else {
+            return Vec::new();
+        };
+        let query = self.query.text().to_lowercase();
+        targets
+            .iter()
+            .filter(|target| query.is_empty() || searchable_target(target).contains(&query))
+            .collect()
+    }
+}
+
+fn searchable_target(target: &AgentTarget) -> String {
+    format!(
+        "{} {} {} {} {} {} {} {}",
+        target.agent_name,
+        target.workspace_label.as_deref().unwrap_or_default(),
+        target.tab_label.as_deref().unwrap_or_default(),
+        target.workspace_id(),
+        target.tab_id(),
+        target.pane_id(),
+        target.agent_kind().as_str(),
+        target.readiness.as_str(),
+    )
+    .to_lowercase()
+}
+
+fn target_view(target: &AgentTarget) -> GlobalDeliveryChoiceView {
+    let workspace = target
+        .workspace_label
+        .as_deref()
+        .unwrap_or_else(|| target.workspace_id());
+    let tab = target
+        .tab_label
+        .as_deref()
+        .unwrap_or_else(|| target.tab_id());
+    GlobalDeliveryChoiceView {
+        primary: target.agent_name.clone(),
+        secondary: format!(
+            "{workspace} / {tab} · {} · {}",
+            target.agent_kind().as_str(),
+            target_live_state(target)
+        ),
+        enabled: target.can_submit(),
+    }
+}
+
+const fn target_live_state(target: &AgentTarget) -> &'static str {
+    match target.availability {
+        AgentAvailability::Available => target.readiness.as_str(),
+        availability => availability.as_str(),
+    }
+}
+
+fn placeholder(value: &str) -> GlobalDeliveryChoiceView {
+    GlobalDeliveryChoiceView {
+        primary: value.to_owned(),
+        secondary: String::new(),
+        enabled: false,
+    }
+}

--- a/src/ui/app/invocation/builtins.rs
+++ b/src/ui/app/invocation/builtins.rs
@@ -63,5 +63,5 @@ fn app_supports_shared_starters(app: &BoardApp) -> bool {
     app.agent_targets()
         .iter()
         .filter(|target| target.delivery.supports())
-        .any(|target| agent_supports_shared_starters(target.agent_kind.as_str()))
+        .any(|target| agent_supports_shared_starters(target.agent_kind().as_str()))
 }

--- a/src/ui/app/invocation/compatibility.rs
+++ b/src/ui/app/invocation/compatibility.rs
@@ -18,7 +18,7 @@ fn target_harnesses(app: &BoardApp) -> BTreeSet<InvocationHarness> {
     app.agent_targets()
         .iter()
         .filter(|target| target.delivery.supports())
-        .filter_map(|target| match target.agent_kind.as_str() {
+        .filter_map(|target| match target.agent_kind().as_str() {
             CODEX_AGENT_KIND => Some(InvocationHarness::Codex),
             CLAUDE_AGENT_KIND => Some(InvocationHarness::ClaudeCode),
             OPENCODE_AGENT_KIND => Some(InvocationHarness::OpenCode),

--- a/src/ui/app/invocation/tests.rs
+++ b/src/ui/app/invocation/tests.rs
@@ -1,9 +1,5 @@
 #[cfg(test)]
 pub(super) mod contract {
-    use std::path::{Path, PathBuf};
-
-    use ratatui_core::{backend::TestBackend, terminal::Terminal};
-
     use crate::{
         adapters::{
             editor::RopeEditorFactory,
@@ -29,6 +25,8 @@ pub(super) mod contract {
             render,
         },
     };
+    use ratatui_core::{backend::TestBackend, terminal::Terminal};
+    use std::path::{Path, PathBuf};
 
     use crate::ui::BoardApp;
 
@@ -107,26 +105,30 @@ pub(super) mod contract {
                 height: 20,
             },
         };
-        AgentTarget {
-            provider: "herdr".to_owned(),
-            protocol: 19,
-            direction: Direction::Right,
-            pane_id: "w1:p2".to_owned(),
-            workspace_id: source.workspace_id.clone(),
-            tab_id: source.tab_id.clone(),
-            agent_kind: HarnessKind::new(harness).expect("harness"),
-            agent_name: harness.to_owned(),
-            agent_session: AgentSessionBinding::established("session").expect("session"),
-            readiness: AgentState::Idle,
-            delivery: AgentDeliveryCapabilities::SUBMIT_ONLY,
-            rect: PaneRect {
+        let address = crate::ports::agent::HerdrAgentAddress::new(
+            source.workspace_id.clone(),
+            source.tab_id.clone(),
+            "w1:p2".to_owned(),
+            HarnessKind::new(harness).expect("harness"),
+            AgentSessionBinding::established("session").expect("session"),
+        )
+        .expect("address");
+        AgentTarget::adjacent(
+            "herdr".to_owned(),
+            19,
+            Direction::Right,
+            address,
+            harness.to_owned(),
+            AgentState::Idle,
+            AgentDeliveryCapabilities::SUBMIT_ONLY,
+            PaneRect {
                 x: 20,
                 y: 0,
                 width: 20,
                 height: 20,
             },
             source,
-        }
+        )
     }
 
     #[test]
@@ -492,7 +494,6 @@ pub(super) mod contract {
         insta::assert_snapshot!("invocation_completion_shallow", completion_snapshot(28, 6));
     }
 }
-
 #[path = "alias_tests.rs"]
 mod alias_tests;
 #[path = "reference_tests.rs"]

--- a/src/ui/app/palette.rs
+++ b/src/ui/app/palette.rs
@@ -168,6 +168,7 @@ impl BoardApp {
     pub(super) fn close_overlay(&mut self) {
         self.cancel_screenshot_takeover();
         self.palette = None;
+        self.global_delivery = None;
         self.search = None;
         self.transfer = None;
         self.close_invocation_picker();
@@ -389,6 +390,7 @@ impl BoardApp {
             Command::Duplicate => self.duplicate(ids, clock),
             Command::SubmitRemove
             | Command::SubmitKeep
+            | Command::SubmitToAgent
             | Command::SubmitAllRemove
             | Command::SubmitAllKeep
             | Command::PlainNewline

--- a/src/ui/app/palette/command.rs
+++ b/src/ui/app/palette/command.rs
@@ -32,6 +32,7 @@ pub(in crate::ui::app) enum Command {
     SelectAll,
     SubmitRemove,
     SubmitKeep,
+    SubmitToAgent,
     SubmitAllRemove,
     SubmitAllKeep,
     RefreshAgents,
@@ -56,7 +57,7 @@ pub(in crate::ui::app) enum Command {
 }
 
 impl Command {
-    pub(super) const ALL: [(Self, &'static str); 51] = [
+    pub(super) const ALL: [(Self, &'static str); 52] = [
         (Self::New, "New thought"),
         (Self::RenameSession, "Rename session"),
         (Self::CopySessionId, "Copy session ID"),
@@ -97,6 +98,7 @@ impl Command {
         (Self::SelectAll, "Select all thoughts"),
         (Self::SubmitRemove, "Submit"),
         (Self::SubmitKeep, "Submit and keep"),
+        (Self::SubmitToAgent, "Submit to agent..."),
         (Self::SubmitAllRemove, "Submit all"),
         (Self::SubmitAllKeep, "Submit all and keep"),
         (Self::SendSession, "Send to another Proqi session"),

--- a/src/ui/app/palette/dispatch.rs
+++ b/src/ui/app/palette/dispatch.rs
@@ -95,6 +95,7 @@ impl BoardApp {
     ) -> Option<Vec<Effect>> {
         use crate::ports::agent::SubmissionDisposition::{Keep, RemoveAfterSuccess};
         match command {
+            Command::SubmitToAgent => Some(self.begin_global_delivery(ids, clock)),
             Command::SubmitRemove => Some(self.begin_delivery(RemoveAfterSuccess, ids, clock)),
             Command::SubmitKeep => Some(self.begin_delivery(Keep, ids, clock)),
             Command::SubmitAllRemove => {

--- a/src/ui/app/pointer.rs
+++ b/src/ui/app/pointer.rs
@@ -219,6 +219,8 @@ impl BoardApp {
             self.execute_search_visible_index(index)
         } else if self.transfer.is_some() {
             self.choose_transfer_visible(index, ids)
+        } else if self.global_delivery.is_some() {
+            self.choose_global_delivery_visible(index, ids, clock)
         } else if self.execute_invocation_visible_index(index) {
             Vec::new()
         } else {

--- a/src/ui/app/screenshot/tests/admission.rs
+++ b/src/ui/app/screenshot/tests/admission.rs
@@ -217,26 +217,30 @@ fn agent_target() -> AgentTarget {
             height: 20,
         },
     };
-    AgentTarget {
-        provider: "herdr".to_owned(),
-        protocol: 19,
-        direction: Direction::Right,
-        pane_id: "w1:p2".to_owned(),
-        workspace_id: source.workspace_id.clone(),
-        tab_id: source.tab_id.clone(),
-        agent_kind: HarnessKind::new(CODEX_AGENT_KIND).expect("agent kind"),
-        agent_name: "codex".to_owned(),
-        agent_session: AgentSessionBinding::established("session").expect("agent session"),
-        readiness: AgentState::Idle,
-        delivery: AgentDeliveryCapabilities::SUBMIT_ONLY,
-        rect: PaneRect {
+    let address = crate::ports::agent::HerdrAgentAddress::new(
+        source.workspace_id.clone(),
+        source.tab_id.clone(),
+        "w1:p2".to_owned(),
+        HarnessKind::new(CODEX_AGENT_KIND).expect("agent kind"),
+        AgentSessionBinding::established("session").expect("agent session"),
+    )
+    .expect("agent address");
+    AgentTarget::adjacent(
+        "herdr".to_owned(),
+        19,
+        Direction::Right,
+        address,
+        "codex".to_owned(),
+        AgentState::Idle,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
+        PaneRect {
             x: 20,
             y: 0,
             width: 20,
             height: 20,
         },
         source,
-    }
+    )
 }
 
 fn session_hit(id: crate::domain::SessionId) -> SessionHit {

--- a/src/ui/app/view.rs
+++ b/src/ui/app/view.rs
@@ -320,6 +320,7 @@ impl BoardApp {
                     .map(transfer::TransferState::query_cursor)
             })
             .or_else(|| self.invocation_query_cursor())
+            .or_else(|| self.global_delivery_query_cursor())
             .or_else(|| {
                 self.palette
                     .as_ref()
@@ -336,6 +337,9 @@ impl BoardApp {
         }
         if self.invocation_popup.is_some() {
             return self.invocation_overflow(visible);
+        }
+        if self.global_delivery.is_some() {
+            return self.global_delivery_overflow(visible);
         }
         self.palette
             .as_ref()

--- a/src/ui/app/view_frame.rs
+++ b/src/ui/app/view_frame.rs
@@ -105,6 +105,7 @@ impl BoardApp {
             .palette
             .as_ref()
             .map_or(0, palette::PaletteState::match_count);
+        let global_delivery_items = self.global_delivery_match_count();
         let invocation_items = self.invocation_match_count();
         let invocation_groups = self
             .invocation_view()
@@ -135,6 +136,8 @@ impl BoardApp {
                 .max(2)
         } else if self.palette.is_some() {
             palette_items.max(2)
+        } else if self.global_delivery.is_some() {
+            global_delivery_items.max(2)
         } else if self.transfer.is_some() {
             transfer_items.max(2)
         } else if self.search.is_some() {
@@ -148,6 +151,7 @@ impl BoardApp {
             layout.configure_overlay(
                 screenshot_items
                     .max(palette_items)
+                    .max(global_delivery_items)
                     .max(search_items)
                     .max(transfer_items)
                     .max(invocation_items)
@@ -164,6 +168,8 @@ impl BoardApp {
         let visible = overlay.items.len().max(1);
         if self.palette.is_some() {
             self.ensure_palette_visible(visible);
+        } else if self.global_delivery.is_some() {
+            self.ensure_global_delivery_visible(visible);
         } else if self.invocation_popup.is_some() {
             self.ensure_invocation_visible(usize::from(overlay.area.height.saturating_sub(3)));
         } else if self.transfer.is_some() {

--- a/src/ui/control_labels.rs
+++ b/src/ui/control_labels.rs
@@ -146,8 +146,12 @@ pub(crate) fn action_width(
 
 pub(crate) fn agent(target: &AgentTarget) -> ControlLabel {
     ControlLabel {
-        key: direction_symbol(target.direction).to_owned(),
-        text: format!(" {}", compact_agent_name(target.agent_kind.as_str())),
+        key: target
+            .adjacent_direction()
+            .map(direction_symbol)
+            .unwrap_or_default()
+            .to_owned(),
+        text: format!(" {}", compact_agent_name(target.agent_kind().as_str())),
     }
 }
 

--- a/src/ui/layout/controls.rs
+++ b/src/ui/layout/controls.rs
@@ -167,13 +167,19 @@ pub(super) fn configure_agent_controls(
     }
     let mut x = area.x;
     if let Some(disposition) = selection {
-        for target in targets.iter().filter(|target| target.delivery.supports()) {
+        for target in targets
+            .iter()
+            .filter(|target| target.delivery.supports() && target.adjacent_direction().is_some())
+        {
+            let Some(direction) = target.adjacent_direction() else {
+                continue;
+            };
             let label_width = crate::ui::control_labels::agent(target).width();
             push(
                 layout,
                 &mut x,
                 area,
-                HitTarget::Deliver(target.direction, disposition),
+                HitTarget::Deliver(direction, disposition),
                 label_width,
             );
         }
@@ -183,12 +189,15 @@ pub(super) fn configure_agent_controls(
         return;
     }
     for target in targets {
+        let Some(direction) = target.adjacent_direction() else {
+            continue;
+        };
         let label_width = crate::ui::control_labels::agent(target).width();
         push(
             layout,
             &mut x,
             area,
-            HitTarget::Agent(target.direction),
+            HitTarget::Agent(direction),
             label_width,
         );
     }
@@ -198,11 +207,16 @@ pub(super) fn configure_agent_controls(
     ] {
         let eligible = targets
             .iter()
-            .filter(|target| target.delivery.supports())
+            .filter(|target| target.delivery.supports() && target.adjacent_direction().is_some())
             .collect::<Vec<_>>();
         let target = match eligible.as_slice() {
             [] => continue,
-            [only] => HitTarget::Deliver(only.direction, disposition),
+            [only] => {
+                let Some(direction) = only.adjacent_direction() else {
+                    continue;
+                };
+                HitTarget::Deliver(direction, disposition)
+            }
             _ => HitTarget::BeginDelivery(disposition),
         };
         let label_width =

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,6 +1,7 @@
 //! Deterministic one-column board renderer.
 
 mod chrome;
+mod global_delivery;
 mod overlay_composition;
 mod overlays;
 mod release_highlights;

--- a/src/ui/render/chrome.rs
+++ b/src/ui/render/chrome.rs
@@ -40,7 +40,7 @@ fn render_control(
         HitTarget::Agent(direction) => app
             .agent_targets()
             .iter()
-            .find(|target| target.direction == direction)
+            .find(|target| target.adjacent_direction() == Some(direction))
             .map(crate::ui::control_labels::agent),
         _ => crate::ui::control_labels::action(target, false, app.interaction_mode(), keys)
             .filter(|label| label.width() <= area.width)

--- a/src/ui/render/global_delivery.rs
+++ b/src/ui/render/global_delivery.rs
@@ -1,0 +1,37 @@
+//! Typed global delivery picker projection.
+
+use ratatui_core::terminal::Frame;
+
+use crate::ui::{BoardApp, Theme, layout::OverlayLayout};
+
+use super::overlays;
+
+pub(super) fn render(
+    frame: &mut Frame<'_>,
+    overlay: &OverlayLayout,
+    app: &BoardApp,
+    picker: &crate::ui::app::global_delivery::GlobalDeliveryView,
+    theme: &Theme,
+) {
+    let rows = picker
+        .choices
+        .iter()
+        .map(|choice| {
+            overlays::PickerRow::choice(&choice.primary, &choice.secondary, choice.enabled)
+        })
+        .collect::<Vec<_>>();
+    overlays::render_picker(
+        frame,
+        overlay,
+        overlays::PickerView {
+            title: picker.title,
+            prompt: '›',
+            query: &picker.query,
+            cursor: app.overlay_query_cursor().unwrap_or(picker.query.len()),
+            entries: &rows,
+            selected: picker.selected,
+        },
+        app.picker_overflow(overlay.items.len()),
+        theme,
+    );
+}

--- a/src/ui/render/global_delivery.rs
+++ b/src/ui/render/global_delivery.rs
@@ -17,7 +17,17 @@ pub(super) fn render(
         .choices
         .iter()
         .map(|choice| {
-            overlays::PickerRow::choice(&choice.primary, &choice.secondary, choice.enabled)
+            if choice.protected_secondaries.is_empty() {
+                overlays::PickerRow::choice(&choice.primary, &choice.secondary, choice.enabled)
+            } else {
+                overlays::PickerRow::responsive_choice(
+                    &choice.primary,
+                    &choice.secondary,
+                    &choice.secondary_fallbacks,
+                    &choice.protected_secondaries,
+                    choice.enabled,
+                )
+            }
         })
         .collect::<Vec<_>>();
     overlays::render_picker(

--- a/src/ui/render/overlay_composition.rs
+++ b/src/ui/render/overlay_composition.rs
@@ -5,8 +5,8 @@ use ratatui_core::terminal::Frame;
 use crate::ui::{BoardApp, LayoutSnapshot, Theme};
 
 use super::{
-    InvocationPickerView, PlainPickerView, overlays, release_highlights, render_invocation_picker,
-    render_plain_picker,
+    InvocationPickerView, PlainPickerView, global_delivery, overlays, release_highlights,
+    render_invocation_picker, render_plain_picker,
 };
 
 pub(super) fn render(
@@ -64,6 +64,10 @@ pub(super) fn render(
                 },
                 theme,
             );
+        }
+    } else if let Some(picker) = app.global_delivery_view() {
+        if let Some(overlay) = &layout.overlay {
+            global_delivery::render(frame, overlay, app, &picker, theme);
         }
     } else if let Some((query, entries, selected)) = app.palette_view() {
         if let Some(overlay) = &layout.overlay {

--- a/src/ui/render/overlays.rs
+++ b/src/ui/render/overlays.rs
@@ -211,6 +211,7 @@ pub(super) struct PickerRow<'a> {
     primary: &'a str,
     secondary: Option<&'a str>,
     secondary_fallbacks: &'a [String],
+    protected_secondaries: &'a [String],
     group: Option<&'a str>,
     enabled: bool,
 }
@@ -221,6 +222,7 @@ impl<'a> PickerRow<'a> {
             primary,
             secondary: None,
             secondary_fallbacks: &[],
+            protected_secondaries: &[],
             group: None,
             enabled: true,
         }
@@ -232,6 +234,7 @@ impl<'a> PickerRow<'a> {
             primary,
             secondary: Some(secondary),
             secondary_fallbacks: &[],
+            protected_secondaries: &[],
             group: None,
             enabled: true,
         }
@@ -247,6 +250,7 @@ impl<'a> PickerRow<'a> {
             primary,
             secondary: Some(secondary),
             secondary_fallbacks,
+            protected_secondaries: &[],
             group,
             enabled: true,
         }
@@ -257,6 +261,24 @@ impl<'a> PickerRow<'a> {
             primary,
             secondary: Some(secondary),
             secondary_fallbacks: &[],
+            protected_secondaries: &[],
+            group: None,
+            enabled,
+        }
+    }
+
+    pub(super) const fn responsive_choice(
+        primary: &'a str,
+        secondary: &'a str,
+        secondary_fallbacks: &'a [String],
+        protected_secondaries: &'a [String],
+        enabled: bool,
+    ) -> Self {
+        Self {
+            primary,
+            secondary: Some(secondary),
+            secondary_fallbacks,
+            protected_secondaries,
             group: None,
             enabled,
         }
@@ -265,15 +287,12 @@ impl<'a> PickerRow<'a> {
 
 #[cfg(test)]
 fn picker_row(entry: PickerRow<'_>, width: u16) -> String {
-    let width = usize::from(width);
-    let primary = display(entry.primary);
-    let primary_width = cell_width(&primary);
-    if let Some(secondary) = fitting_secondary(entry, width) {
-        let secondary = display(secondary);
-        let gap = width.saturating_sub(primary_width + cell_width(&secondary));
-        return format!("{primary}{}{secondary}", " ".repeat(gap));
-    }
-    ellipsize(entry.primary, width)
+    let (primary, secondary) = picker_content(entry, usize::from(width));
+    let Some(secondary) = secondary else {
+        return primary;
+    };
+    let gap = usize::from(width).saturating_sub(cell_width(&primary) + cell_width(&secondary));
+    format!("{primary}{}{secondary}", " ".repeat(gap))
 }
 
 fn picker_line(entry: PickerRow<'_>, width: u16, selected: bool, theme: &Theme) -> Line<'static> {
@@ -295,7 +314,7 @@ fn picker_line(entry: PickerRow<'_>, width: u16, selected: bool, theme: &Theme) 
         return Line::from(Span::styled(content, style));
     }
     let width = usize::from(width);
-    let primary = ellipsize(entry.primary, width);
+    let (primary, secondary) = picker_content(entry, width);
     let base = if selected {
         theme.focused_style()
     } else {
@@ -308,7 +327,7 @@ fn picker_line(entry: PickerRow<'_>, width: u16, selected: bool, theme: &Theme) 
     } else {
         base.fg(theme.foreground)
     };
-    let Some(secondary) = fitting_secondary(entry, width).map(display) else {
+    let Some(secondary) = secondary else {
         let padding = " ".repeat(width.saturating_sub(cell_width(&primary)));
         return Line::from(vec![
             Span::styled(primary, primary_style),
@@ -329,12 +348,42 @@ fn fitting_secondary(entry: PickerRow<'_>, width: usize) -> Option<&str> {
         .secondary
         .into_iter()
         .chain(entry.secondary_fallbacks.iter().map(String::as_str))
+        .chain(entry.protected_secondaries.iter().map(String::as_str))
         .find(|secondary| {
             cell_width(entry.primary)
                 .saturating_add(minimum_gap)
                 .saturating_add(cell_width(secondary))
                 <= width
         })
+}
+
+fn picker_content(entry: PickerRow<'_>, width: usize) -> (String, Option<String>) {
+    let primary = display(entry.primary);
+    if let Some(secondary) = fitting_secondary(entry, width) {
+        return (primary, Some(display(secondary)));
+    }
+    let minimum_gap = usize::from(entry.group.is_none()) + 1;
+    for secondary in entry.protected_secondaries {
+        let secondary_width = cell_width(secondary);
+        if minimum_gap
+            .saturating_add(1)
+            .saturating_add(secondary_width)
+            <= width
+        {
+            let primary_width = width.saturating_sub(minimum_gap + secondary_width);
+            return (
+                ellipsize(entry.primary, primary_width),
+                Some(display(secondary)),
+            );
+        }
+        if secondary_width <= width {
+            return (String::new(), Some(display(secondary)));
+        }
+    }
+    if let Some(secondary) = entry.protected_secondaries.last() {
+        return (String::new(), Some(ellipsize(secondary, width)));
+    }
+    (ellipsize(entry.primary, width), None)
 }
 
 pub(super) fn ellipsize(value: &str, width: usize) -> String {

--- a/src/ui/render/overlays.rs
+++ b/src/ui/render/overlays.rs
@@ -212,6 +212,7 @@ pub(super) struct PickerRow<'a> {
     secondary: Option<&'a str>,
     secondary_fallbacks: &'a [String],
     group: Option<&'a str>,
+    enabled: bool,
 }
 
 impl<'a> PickerRow<'a> {
@@ -221,6 +222,7 @@ impl<'a> PickerRow<'a> {
             secondary: None,
             secondary_fallbacks: &[],
             group: None,
+            enabled: true,
         }
     }
 
@@ -231,6 +233,7 @@ impl<'a> PickerRow<'a> {
             secondary: Some(secondary),
             secondary_fallbacks: &[],
             group: None,
+            enabled: true,
         }
     }
 
@@ -245,6 +248,17 @@ impl<'a> PickerRow<'a> {
             secondary: Some(secondary),
             secondary_fallbacks,
             group,
+            enabled: true,
+        }
+    }
+
+    pub(super) const fn choice(primary: &'a str, secondary: &'a str, enabled: bool) -> Self {
+        Self {
+            primary,
+            secondary: Some(secondary),
+            secondary_fallbacks: &[],
+            group: None,
+            enabled,
         }
     }
 }
@@ -264,13 +278,17 @@ fn picker_row(entry: PickerRow<'_>, width: u16) -> String {
 
 fn picker_line(entry: PickerRow<'_>, width: u16, selected: bool, theme: &Theme) -> Line<'static> {
     if entry.secondary.is_none() {
-        let style = if selected {
-            theme
-                .focused_style()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD)
+        let base = if selected {
+            theme.focused_style()
         } else {
             theme.base_style()
+        };
+        let style = if !entry.enabled {
+            base.fg(theme.muted)
+        } else if selected {
+            base.fg(theme.accent).add_modifier(Modifier::BOLD)
+        } else {
+            base
         };
         let mut content = ellipsize(entry.primary, usize::from(width));
         content.push_str(&" ".repeat(usize::from(width).saturating_sub(cell_width(&content))));
@@ -283,7 +301,9 @@ fn picker_line(entry: PickerRow<'_>, width: u16, selected: bool, theme: &Theme) 
     } else {
         theme.base_style()
     };
-    let primary_style = if selected {
+    let primary_style = if !entry.enabled {
+        base.fg(theme.muted)
+    } else if selected {
         base.fg(theme.accent).add_modifier(Modifier::BOLD)
     } else {
         base.fg(theme.foreground)

--- a/src/ui/render/overlays/tests.rs
+++ b/src/ui/render/overlays/tests.rs
@@ -33,6 +33,47 @@ fn responsive_row_keeps_location_fallbacks_in_priority_order() {
 }
 
 #[test]
+fn prioritized_row_truncates_primary_before_pane_and_state() {
+    let fallbacks = vec!["Workspace · p1 · working".to_owned()];
+    let protected = vec!["p1 · working".to_owned(), "working".to_owned()];
+    let row = PickerRow::responsive_choice(
+        "very-long-agent-name",
+        "Workspace / tab · p1 · codex · working",
+        &fallbacks,
+        &protected,
+        true,
+    );
+
+    assert_eq!(picker_row(row, 26), "very-long-a…  p1 · working");
+    assert_eq!(picker_row(row, 14), "  p1 · working");
+    assert_eq!(picker_row(row, 10), "…  working");
+    assert_eq!(picker_row(row, 7), "working");
+}
+
+#[test]
+fn prioritized_disabled_row_keeps_truthful_state_visible() {
+    let protected = vec!["p8 · blocked".to_owned(), "blocked".to_owned()];
+    let row = PickerRow::responsive_choice(
+        "Blocked receiver with a long name",
+        "Workspace / tab · p8 · codex · blocked",
+        &[],
+        &protected,
+        false,
+    );
+    let theme = Theme::resolve(ThemePreference::Dark, true);
+
+    let rendered = picker_line(row, 20, true, &theme);
+    assert_eq!(rendered.to_string(), "Block…  p8 · blocked");
+    assert!(
+        rendered
+            .spans
+            .iter()
+            .all(|span| span.style.bg == theme.focused_surface)
+    );
+    assert_eq!(rendered.spans[0].style.fg, Some(theme.muted));
+}
+
+#[test]
 fn every_picker_secondary_uses_the_same_quiet_metadata_style() {
     let theme = Theme::resolve(ThemePreference::Dark, true);
     let row = PickerRow::fields("$skill", "Project Skill");

--- a/src/ui/render/overlays/tests.rs
+++ b/src/ui/render/overlays/tests.rs
@@ -59,6 +59,25 @@ fn every_picker_secondary_uses_the_same_quiet_metadata_style() {
 }
 
 #[test]
+fn selected_disabled_choice_keeps_focus_surface_and_muted_text() {
+    let theme = Theme::resolve(ThemePreference::Dark, true);
+    let selected = picker_line(
+        PickerRow::choice("Blocked receiver", "blocked", false),
+        32,
+        true,
+        &theme,
+    );
+
+    assert!(
+        selected
+            .spans
+            .iter()
+            .all(|span| span.style.bg == theme.focused_surface)
+    );
+    assert_eq!(selected.spans[0].style.fg, Some(theme.muted));
+}
+
+#[test]
 fn overlong_token_ellipsizes_on_grapheme_and_cell_boundaries() {
     let rendered = picker_row(PickerRow::fields("$界界e\u{301}🙂", "Global Skill"), 5);
 

--- a/tests/herdr_executable.rs
+++ b/tests/herdr_executable.rs
@@ -24,9 +24,11 @@ fn prove_protocol(protocol: u32) {
     let fixture = herdr_fixture::HerdrFixture::new(protocol);
     let mut gateway = HerdrGateway::new(fixture.program(), SystemProcessRunner::default(), true);
     let references = gateway.discover_live_references().expect("live references");
-    let [reference] = references.references.as_slice() else {
-        panic!("expected one live reference");
-    };
+    let reference = references
+        .references
+        .iter()
+        .find(|reference| reference.pane_id() == "w1:p2")
+        .expect("adjacent live reference");
     assert_eq!(reference.agent_name(), Some("fixture"));
     assert_eq!(reference.workspace_label(), Some("Fixture workspace"));
     assert_eq!(reference.tab_label(), Some("Fixture tab"));
@@ -64,4 +66,24 @@ fn prove_protocol(protocol: u32) {
 
     assert_eq!(receipt.target, *target);
     assert_eq!(fixture.prompt_bytes().as_deref(), Some(exact.as_bytes()));
+
+    let global_targets = gateway.global_targets().expect("current-server targets");
+    let global = global_targets
+        .iter()
+        .find(|target| target.workspace_id() == "w2" && target.tab_id() == "w2:t4")
+        .expect("cross-workspace global target");
+    let global_exact = "global $(touch never); Grüße\n第二行\u{1b}[31m";
+    let global_receipt = gateway
+        .submit(SubmissionRequest {
+            submission_id: ids.submission_id(),
+            target: global.clone(),
+            content: global_exact.to_owned(),
+        })
+        .expect("accepted global prompt");
+    assert_eq!(global_receipt.target.workspace_id(), "w2");
+    assert_eq!(global_receipt.target.tab_id(), "w2:t4");
+    assert_eq!(
+        fixture.prompt_bytes().as_deref(),
+        Some(global_exact.as_bytes())
+    );
 }

--- a/tests/pty/update_migration.rs
+++ b/tests/pty/update_migration.rs
@@ -236,7 +236,7 @@ fn downgrade_to_schema_eleven(state: &Path) {
     Connection::open(state.join("data/proqi.sqlite3"))
         .expect("database")
         .execute_batch(
-            "DELETE FROM migration_history WHERE version = 12;
+            "DELETE FROM migration_history WHERE version IN (12, 13);
              UPDATE schema_meta SET schema_version = 11, storage_protocol = 10;",
         )
         .expect("schema eleven fixture");
@@ -288,12 +288,12 @@ fn assert_store(state: &Path, sessions: &[String]) {
     );
     let migration_rows: i64 = connection
         .query_row(
-            "SELECT count(*) FROM migration_history WHERE version = 12",
+            "SELECT count(*) FROM migration_history WHERE version IN (12, 13)",
             [],
             |row| row.get(0),
         )
         .expect("migration history count");
-    assert_eq!(migration_rows, 1);
+    assert_eq!(migration_rows, 2);
     for (table, expected) in [
         ("sessions", sessions.len()),
         ("session_search", sessions.len()),

--- a/tests/sqlite_store.rs
+++ b/tests/sqlite_store.rs
@@ -144,6 +144,8 @@ mod core;
 mod editor;
 #[path = "sqlite_store/migration_12.rs"]
 mod migration_12;
+#[path = "sqlite_store/migration_13.rs"]
+mod migration_13;
 #[path = "sqlite_store/onboarding.rs"]
 mod onboarding;
 #[path = "sqlite_store/onboarding_migration.rs"]

--- a/tests/sqlite_store/annotations.rs
+++ b/tests/sqlite_store/annotations.rs
@@ -122,7 +122,7 @@ fn invocation_reference_projection_survives_protocol_nine_migration() {
         .expect("version eight database")
         .execute_batch(
             "DROP TABLE onboarding_state;
-             DELETE FROM migration_history WHERE version IN (9, 10, 11, 12);
+             DELETE FROM migration_history WHERE version IN (9, 10, 11, 12, 13);
              UPDATE schema_meta SET schema_version = 8, storage_protocol = 8;",
         )
         .expect("downgrade protocol stamp");
@@ -176,7 +176,7 @@ fn protocol_ten_loads_structurally_valid_direct_shortcut_bytes_and_rejects_corru
     connection
         .execute_batch(
             "DROP TABLE onboarding_state;
-             DELETE FROM migration_history WHERE version IN (10, 11, 12);
+             DELETE FROM migration_history WHERE version IN (10, 11, 12, 13);
              UPDATE schema_meta SET schema_version = 9, storage_protocol = 9;",
         )
         .expect("version nine protocol stamp");

--- a/tests/sqlite_store/migration_12.rs
+++ b/tests/sqlite_store/migration_12.rs
@@ -27,7 +27,7 @@ fn schema_eleven_requires_lease_authorized_backup_before_transformation_protocol
     Connection::open(&fixture.config.database_path)
         .expect("schema eleven fixture")
         .execute_batch(
-            "DELETE FROM migration_history WHERE version = 12;
+            "DELETE FROM migration_history WHERE version IN (12, 13);
              UPDATE schema_meta SET schema_version = 11, storage_protocol = 10;",
         )
         .expect("downgrade transformation protocol stamp");
@@ -38,7 +38,7 @@ fn schema_eleven_requires_lease_authorized_backup_before_transformation_protocol
         SqliteStore::open(&refused),
         Err(StoreError::MigrationRequired {
             found: 11,
-            supported: 12
+            supported: 13
         })
     ));
     let connection = Connection::open(&fixture.config.database_path).expect("unchanged fixture");
@@ -58,12 +58,12 @@ fn schema_eleven_requires_lease_authorized_backup_before_transformation_protocol
     assert_eq!(
         connection
             .query_row(
-                "SELECT count(*) FROM migration_history WHERE version = 12",
+                "SELECT count(*) FROM migration_history WHERE version IN (12, 13)",
                 [],
                 |row| row.get::<_, u32>(0),
             )
             .expect("migration history"),
-        1
+        2
     );
     assert_eq!(onboarding_completed_version(&connection), 0);
     assert_eq!(

--- a/tests/sqlite_store/migration_13.rs
+++ b/tests/sqlite_store/migration_13.rs
@@ -1,0 +1,251 @@
+use super::*;
+
+const DOWNGRADE_TO_12: &str = r"
+PRAGMA foreign_keys = OFF;
+BEGIN IMMEDIATE;
+DROP INDEX submission_attempt_items_active_thought;
+ALTER TABLE submission_attempt_items RENAME TO submission_attempt_items_v13;
+ALTER TABLE submission_attempts RENAME TO submission_attempts_v13;
+CREATE TABLE submission_attempts (
+    id BLOB PRIMARY KEY CHECK (length(id) = 16),
+    session_id BLOB NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    thought_id BLOB NOT NULL REFERENCES thoughts(id) ON DELETE CASCADE,
+    source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
+    source_sequence INTEGER NOT NULL CHECK (source_sequence >= 0),
+    disposition TEXT NOT NULL CHECK (disposition IN ('keep', 'remove_after_success')),
+    direction TEXT NOT NULL CHECK (direction IN ('up', 'right', 'down', 'left')),
+    provider TEXT NOT NULL,
+    protocol INTEGER NOT NULL CHECK (protocol >= 0),
+    target_fingerprint BLOB NOT NULL CHECK (length(target_fingerprint) = 32),
+    pre_state TEXT NOT NULL,
+    post_state TEXT,
+    error_code TEXT,
+    deletion_operation_id BLOB CHECK (
+        deletion_operation_id IS NULL OR length(deletion_operation_id) = 16
+    ),
+    state TEXT NOT NULL CHECK (
+        state IN ('prepared', 'sending', 'accepted', 'failed', 'cancelled', 'outcome_unknown')
+    ),
+    prepared_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+) STRICT;
+INSERT INTO submission_attempts(
+    id, session_id, thought_id, source_digest, source_sequence, disposition, direction,
+    provider, protocol, target_fingerprint, pre_state, post_state, error_code,
+    deletion_operation_id, state, prepared_at, updated_at
+)
+SELECT id, session_id, thought_id, source_digest, source_sequence, disposition, direction,
+       provider, protocol, target_fingerprint, pre_state, post_state, error_code,
+       deletion_operation_id, state, prepared_at, updated_at
+FROM submission_attempts_v13;
+CREATE TABLE submission_attempt_items (
+    submission_id BLOB NOT NULL REFERENCES submission_attempts(id) ON DELETE CASCADE,
+    thought_id BLOB NOT NULL REFERENCES thoughts(id) ON DELETE CASCADE,
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    source_digest BLOB NOT NULL CHECK (length(source_digest) = 32),
+    active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+    PRIMARY KEY(submission_id, ordinal),
+    UNIQUE(submission_id, thought_id)
+) STRICT;
+INSERT INTO submission_attempt_items(submission_id, thought_id, ordinal, source_digest, active)
+SELECT submission_id, thought_id, ordinal, source_digest, active
+FROM submission_attempt_items_v13;
+DROP TABLE submission_attempt_items_v13;
+DROP TABLE submission_attempts_v13;
+CREATE UNIQUE INDEX submission_attempt_items_active_thought
+ON submission_attempt_items(thought_id)
+WHERE active = 1;
+DELETE FROM migration_history WHERE version = 13;
+UPDATE schema_meta SET schema_version = 12, storage_protocol = 11;
+COMMIT;
+PRAGMA foreign_keys = ON;
+";
+
+fn legacy_attempt(
+    ids: &mut FakeIdGenerator,
+    state: &AppState,
+    sources: Vec<SubmissionSource>,
+    direction: Direction,
+    marker: u8,
+) -> SubmissionAttempt {
+    SubmissionAttempt {
+        id: ids.submission_id(),
+        session_id: state.board.session.id,
+        sources,
+        payload_digest: [marker; 32],
+        source_sequence: state.board.session.last_durable_sequence,
+        disposition: SubmissionDisposition::Keep,
+        route: proqi::ports::store::SubmissionJournalRoute::adjacent(direction),
+        provider: "herdr".to_owned(),
+        protocol: 20,
+        target_fingerprint: [marker.saturating_add(1); 32],
+        pre_state: AgentState::Working,
+        prepared_at: Timestamp::from_millis(40),
+    }
+}
+
+#[test]
+fn physical_v12_route_migration_preserves_legacy_bytes_and_recovers_conservatively() {
+    let (fixture, session_id) = physical_v12_database();
+    let mut refused = fixture.config.clone();
+    refused.migration_mode = MigrationMode::Refuse;
+    assert!(matches!(
+        SqliteStore::open(&refused),
+        Err(StoreError::MigrationRequired {
+            found: 12,
+            supported: 13
+        })
+    ));
+
+    let migrated = fixture.open();
+    migrated.quick_check().expect("migrated integrity");
+    let connection = Connection::open(&fixture.config.database_path).expect("migrated database");
+    assert_legacy_route_rows(&connection);
+    drop(connection);
+    assert_conservative_recovery_and_restart(&fixture, migrated, session_id);
+}
+
+fn physical_v12_database() -> (DatabaseFixture, proqi::domain::SessionId) {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(13_000);
+    let mut state = session_state(&mut ids, &test_path("migration-13"));
+    let session_id = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("create session");
+    let first = create_thought(&mut store, &mut state, &mut ids, "first", 2);
+    let second = create_thought(&mut store, &mut state, &mut ids, "second", 3);
+    let prepared = legacy_attempt(
+        &mut ids,
+        &state,
+        vec![SubmissionSource {
+            thought_id: first,
+            source_digest: [31; 32],
+        }],
+        Direction::Left,
+        41,
+    );
+    let sending = legacy_attempt(
+        &mut ids,
+        &state,
+        vec![
+            SubmissionSource {
+                thought_id: first,
+                source_digest: [32; 32],
+            },
+            SubmissionSource {
+                thought_id: second,
+                source_digest: [33; 32],
+            },
+        ],
+        Direction::Right,
+        42,
+    );
+    store
+        .prepare_submission(&prepared)
+        .expect("prepared attempt");
+    store
+        .finish_submission(
+            prepared.id,
+            &SubmissionOutcome {
+                state: SubmissionAttemptState::Cancelled,
+                post_state: None,
+                error_code: Some("fixture".to_owned()),
+                deletion_operation_id: None,
+                at: Timestamp::from_millis(41),
+            },
+        )
+        .expect_err("prepared cannot finish before sending");
+    store
+        .prepare_submission(&sending)
+        .expect_err("shared source stays locked");
+    store
+        .recover_submissions(session_id, Timestamp::from_millis(42))
+        .expect("release first lock");
+    store.prepare_submission(&sending).expect("sending attempt");
+    store
+        .mark_submission_sending(sending.id, Timestamp::from_millis(43))
+        .expect("mark sending");
+    drop(store);
+
+    let connection = Connection::open(&fixture.config.database_path).expect("current database");
+    connection
+        .execute_batch(DOWNGRADE_TO_12)
+        .expect("physical v12 database");
+    drop(connection);
+    (fixture, session_id)
+}
+
+fn assert_legacy_route_rows(connection: &Connection) {
+    let route_rows = connection
+        .prepare(
+            "SELECT route_version, route_kind, direction, target_fingerprint, state
+             FROM submission_attempts ORDER BY prepared_at, id",
+        )
+        .expect("route query")
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, u32>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Vec<u8>>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })
+        .expect("route rows")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect route rows");
+    assert_eq!(route_rows.len(), 2);
+    assert!(
+        route_rows
+            .iter()
+            .all(|row| row.0 == 0 && row.1 == "adjacent_pane")
+    );
+    assert!(
+        route_rows
+            .iter()
+            .any(|row| row.2.as_deref() == Some("left") && row.3 == [42; 32])
+    );
+    assert!(
+        route_rows
+            .iter()
+            .any(|row| row.2.as_deref() == Some("right") && row.3 == [43; 32])
+    );
+}
+
+fn assert_conservative_recovery_and_restart(
+    fixture: &DatabaseFixture,
+    mut migrated: SqliteStore,
+    session_id: proqi::domain::SessionId,
+) {
+    migrated
+        .recover_submissions(session_id, Timestamp::from_millis(44))
+        .expect("conservative recovery");
+    let connection = Connection::open(&fixture.config.database_path).expect("recovered database");
+    let states = connection
+        .prepare("SELECT state FROM submission_attempts ORDER BY prepared_at, id")
+        .expect("state query")
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("states")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect states");
+    assert!(states.contains(&"cancelled".to_owned()));
+    assert!(states.contains(&"outcome_unknown".to_owned()));
+    assert_eq!(
+        std::fs::read_dir(&fixture.config.backup_dir)
+            .expect("migration backup")
+            .count(),
+        1
+    );
+    drop(connection);
+    drop(migrated);
+    let reopened = fixture.open();
+    reopened.quick_check().expect("idempotent restart");
+    assert_eq!(
+        std::fs::read_dir(&fixture.config.backup_dir)
+            .expect("same backup set")
+            .count(),
+        1
+    );
+}

--- a/tests/sqlite_store/recovery.rs
+++ b/tests/sqlite_store/recovery.rs
@@ -137,7 +137,7 @@ fn version_one_database_migrates_annotations_forward_without_reinterpretation() 
              DROP TABLE submission_attempts;
              ALTER TABLE thoughts DROP COLUMN presentation;
              ALTER TABLE thoughts DROP COLUMN annotations_json;
-             DELETE FROM migration_history WHERE version IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+             DELETE FROM migration_history WHERE version IN (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
              UPDATE schema_meta SET schema_version = 1, storage_protocol = 1;",
         )
         .expect("downgrade fixture");
@@ -317,7 +317,7 @@ fn downgrade_collapsed_fixture(fixture: &DatabaseFixture) {
              DROP TABLE screenshot_capture_receipts;
              UPDATE thoughts SET collapsed = 1 WHERE id IS NOT NULL;
              ALTER TABLE thoughts DROP COLUMN presentation;
-             DELETE FROM migration_history WHERE version IN (6, 7, 8, 9, 10, 11, 12);
+             DELETE FROM migration_history WHERE version IN (6, 7, 8, 9, 10, 11, 12, 13);
              UPDATE schema_meta SET schema_version = 5, storage_protocol = 5;",
         )
         .expect("downgrade fixture");

--- a/tests/sqlite_store/screenshot.rs
+++ b/tests/sqlite_store/screenshot.rs
@@ -381,7 +381,7 @@ fn version_seven_receipts_migrate_without_ownership_foreign_keys() {
              SELECT * FROM screenshot_capture_receipts_current;
              DROP TABLE screenshot_capture_receipts_current;
              DROP TABLE onboarding_state;
-             DELETE FROM migration_history WHERE version IN (8, 9, 10, 11, 12);
+             DELETE FROM migration_history WHERE version IN (8, 9, 10, 11, 12, 13);
              UPDATE schema_meta SET schema_version = 7, storage_protocol = 7;",
         )
         .expect("legacy restrictive schema");

--- a/tests/sqlite_store/submission.rs
+++ b/tests/sqlite_store/submission.rs
@@ -16,7 +16,7 @@ fn attempt(
         payload_digest: digest,
         source_sequence: state.board.session.last_durable_sequence,
         disposition: SubmissionDisposition::RemoveAfterSuccess,
-        direction: Direction::Left,
+        route: proqi::ports::store::SubmissionJournalRoute::adjacent(Direction::Left),
         provider: "herdr".to_owned(),
         protocol: 19,
         target_fingerprint: [31; 32],
@@ -73,6 +73,61 @@ fn journal_is_redacted_and_one_thought_has_only_one_active_attempt() {
         )
         .expect("provider");
     assert_eq!(stored_provider, "herdr");
+}
+
+#[test]
+fn current_adjacent_and_global_routes_round_trip_without_topology_identifiers() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_500);
+    let mut state = session_state(&mut ids, &test_path("submission-route-journal"));
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("create session");
+    let adjacent_id = create_thought(&mut store, &mut state, &mut ids, "adjacent", 2);
+    let global_id = create_thought(&mut store, &mut state, &mut ids, "global", 3);
+    let adjacent = attempt(&mut ids, &state, adjacent_id, [21; 32]);
+    let mut global = attempt(&mut ids, &state, global_id, [22; 32]);
+    global.route = proqi::ports::store::SubmissionJournalRoute::herdr_agent();
+    store.prepare_submission(&adjacent).expect("adjacent route");
+    store.prepare_submission(&global).expect("global route");
+
+    let connection = Connection::open(&fixture.config.database_path).expect("journal database");
+    let adjacent_route: (u32, String, Option<String>) = connection
+        .query_row(
+            "SELECT route_version, route_kind, direction FROM submission_attempts WHERE id = ?1",
+            [adjacent.id.database_bytes().as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("adjacent route fields");
+    let global_route: (u32, String, Option<String>) = connection
+        .query_row(
+            "SELECT route_version, route_kind, direction FROM submission_attempts WHERE id = ?1",
+            [global.id.database_bytes().as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("global route fields");
+    assert_eq!(
+        adjacent_route,
+        (1, "adjacent_pane".to_owned(), Some("left".to_owned()))
+    );
+    assert_eq!(global_route, (1, "herdr_agent".to_owned(), None));
+    assert!(
+        connection
+            .execute(
+                "UPDATE submission_attempts SET direction = 'right' WHERE id = ?1",
+                [global.id.database_bytes().as_slice()],
+            )
+            .is_err()
+    );
+    assert!(
+        connection
+            .execute(
+                "UPDATE submission_attempts SET route_version = 0 WHERE id = ?1",
+                [global.id.database_bytes().as_slice()],
+            )
+            .is_err()
+    );
 }
 
 #[test]

--- a/tests/startup_concurrency.rs
+++ b/tests/startup_concurrency.rs
@@ -369,7 +369,7 @@ fn shared_schema_eleven_owner_blocks_migration_without_backup_then_release_recov
     Connection::open(&database)
         .expect("schema eleven fixture")
         .execute_batch(
-            "DELETE FROM migration_history WHERE version = 12;
+            "DELETE FROM migration_history WHERE version IN (12, 13);
              UPDATE schema_meta SET schema_version = 11, storage_protocol = 10;",
         )
         .expect("downgrade transformation protocol stamp");

--- a/tests/support/herdr.rs
+++ b/tests/support/herdr.rs
@@ -48,7 +48,7 @@ fn fixture_script(protocol: u32, prompt_log: &Path) -> String {
 if [ "$1 $2 $3" = "api schema --json" ]; then
   printf '%s\n' '__SCHEMA__'
 elif [ "$1 $2" = "api snapshot" ]; then
-  printf '%s\n' '{"result":{"snapshot":{"protocol":__PROTOCOL__,"version":"__VERSION__","workspaces":[{"workspace_id":"w1","label":"Fixture workspace"}],"tabs":[{"workspace_id":"w1","tab_id":"w1:t1","label":"Fixture tab"}],"agents":[{"pane_id":"w1:p2","workspace_id":"w1","tab_id":"w1:t1","agent":"codex","name":"fixture","agent_status":"idle","cwd":"/private/not-a-label","terminal_title":"private prompt","future_agent_field":true}],"future_snapshot_field":true}},"future_envelope_field":true}'
+  printf '%s\n' '{"result":{"snapshot":{"protocol":__PROTOCOL__,"version":"__VERSION__","workspaces":[{"workspace_id":"w1","label":"Fixture workspace"},{"workspace_id":"w2","label":"Global workspace"}],"tabs":[{"workspace_id":"w1","tab_id":"w1:t1","label":"Fixture tab"},{"workspace_id":"w2","tab_id":"w2:t4","label":"Global tab"}],"agents":[{"pane_id":"w1:p2","workspace_id":"w1","tab_id":"w1:t1","agent":"codex","name":"fixture","agent_status":"idle","cwd":"/private/not-a-label","terminal_title":"private prompt","future_agent_field":true},{"pane_id":"w2:p9","workspace_id":"w2","tab_id":"w2:t4","agent":"codex","name":"global fixture","agent_status":"done","agent_session":{"agent":"codex","kind":"id","source":"herdr:codex","value":"global-session"}}],"future_snapshot_field":true}},"future_envelope_field":true}'
 elif [ "$1 $2 $3" = "pane current --current" ]; then
   printf '%s\n' '{"result":{"pane":{"pane_id":"w1:p1","workspace_id":"w1","tab_id":"w1:t1"}}}'
 elif [ "$1 $2" = "pane layout" ]; then
@@ -64,6 +64,9 @@ elif [ "$1 $2" = "pane neighbor" ]; then
 elif [ "$1 $2 $3" = "agent prompt w1:p2" ]; then
   printf '%s' "$4" > "__PROMPT_LOG__"
   printf '%s\n' '{"result":{"type":"agent_prompted","agent":{"pane_id":"w1:p2","workspace_id":"w1","tab_id":"w1:t1","agent":"codex","name":"fixture","agent_status":"working","agent_session":{"agent":"codex","kind":"id","source":"herdr:codex","value":"fixture-session"}},"future_receipt_field":true}}'
+elif [ "$1 $2 $3" = "agent prompt w2:p9" ]; then
+  printf '%s' "$4" > "__PROMPT_LOG__"
+  printf '%s\n' '{"result":{"type":"agent_prompted","agent":{"pane_id":"w2:p9","workspace_id":"w2","tab_id":"w2:t4","agent":"codex","name":"global fixture","agent_status":"working","agent_session":{"agent":"codex","kind":"id","source":"herdr:codex","value":"global-session"}},"future_receipt_field":true}}'
 else
   printf '%s\n' '{"error":{"code":"fixture_unknown","message":"unexpected command"}}' >&2
   exit 1

--- a/tests/ui_board.rs
+++ b/tests/ui_board.rs
@@ -388,6 +388,8 @@ mod agent_direct;
 mod agent_discovery;
 #[path = "ui_board/agent_hermes.rs"]
 mod agent_hermes;
+#[path = "ui_board/agent_identity.rs"]
+mod agent_identity;
 #[path = "ui_board/agent_pi.rs"]
 mod agent_pi;
 #[path = "ui_board/agent_selection.rs"]
@@ -426,6 +428,12 @@ mod fast_navigation;
 mod first_run;
 #[path = "ui_board/fixture.rs"]
 mod fixture;
+#[path = "ui_board/global_agent_delivery.rs"]
+mod global_agent_delivery;
+#[path = "ui_board/global_agent_delivery_failures.rs"]
+mod global_agent_delivery_failures;
+#[path = "ui_board/global_delivery_snapshots.rs"]
+mod global_delivery_snapshots;
 #[path = "ui_board/insertion_navigation.rs"]
 mod insertion_navigation;
 #[path = "ui_board/kilo.rs"]

--- a/tests/ui_board/agent.rs
+++ b/tests/ui_board/agent.rs
@@ -25,27 +25,30 @@ pub(super) fn target_with_kind(direction: Direction, pane_id: &str, harness: &st
             height: 20,
         },
     };
-    AgentTarget {
-        provider: "herdr".to_owned(),
-        protocol: 19,
+    let address = proqi::ports::agent::HerdrAgentAddress::new(
+        source.workspace_id.clone(),
+        source.tab_id.clone(),
+        pane_id.to_owned(),
+        HarnessKind::new(harness).expect("fixture harness"),
+        AgentSessionBinding::established(format!("session-{pane_id}")).expect("fixture session"),
+    )
+    .expect("fixture address");
+    AgentTarget::adjacent(
+        "herdr".to_owned(),
+        19,
         direction,
-        pane_id: pane_id.to_owned(),
-        workspace_id: source.workspace_id.clone(),
-        tab_id: source.tab_id.clone(),
-        agent_kind: HarnessKind::new(harness).expect("fixture harness"),
-        agent_name: format!("{harness} {pane_id}"),
-        agent_session: AgentSessionBinding::established(format!("session-{pane_id}"))
-            .expect("fixture session"),
-        readiness: AgentState::Idle,
-        delivery: AgentDeliveryCapabilities::SUBMIT_ONLY,
-        rect: PaneRect {
+        address,
+        format!("{harness} {pane_id}"),
+        AgentState::Idle,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
+        PaneRect {
             x: 40,
             y: 0,
             width: 20,
             height: 20,
         },
         source,
-    }
+    )
 }
 
 pub(super) fn prepare_thought(fixture: &mut Fixture) {
@@ -141,38 +144,6 @@ fn failed_submission_preserves_thought_and_accepted_remove_is_undoable() {
 }
 
 #[test]
-fn accepted_receipt_ignores_volatile_target_metadata() {
-    let mut fixture = Fixture::new();
-    prepare_thought(&mut fixture);
-    let target = target(Direction::Right, "w1:p2");
-    fixture
-        .app
-        .complete_agent_discovery(Ok(vec![target.clone()]));
-    let effects = fixture.effects(UiInput::Key(UiKey::Character('s')));
-    let request = start_submission(&mut fixture, &effects);
-    let mut revalidated = target;
-    revalidated.readiness = AgentState::Blocked;
-    revalidated.agent_name = "Renamed agent".to_owned();
-    revalidated.rect.x = revalidated.rect.x.saturating_add(1);
-    revalidated.source.rect.width = revalidated.source.rect.width.saturating_add(1);
-
-    let completion = finish_submission(
-        &mut fixture,
-        &request,
-        Ok(SubmissionReceipt {
-            submission_id: request.submission_id,
-            target: revalidated,
-            post_state: Some(AgentState::Unknown),
-        }),
-    );
-    assert!(matches!(
-        completion.as_slice(),
-        [Effect::StoreIntegrationContext { .. }]
-    ));
-    assert!(fixture.app.state.board.live_thoughts().is_empty());
-}
-
-#[test]
 fn accepted_receipt_rejects_a_different_stable_target() {
     let mut fixture = Fixture::new();
     prepare_thought(&mut fixture);
@@ -182,9 +153,9 @@ fn accepted_receipt_rejects_a_different_stable_target() {
         .complete_agent_discovery(Ok(vec![target.clone()]));
     let effects = fixture.effects(UiInput::Key(UiKey::Character('s')));
     let request = start_submission(&mut fixture, &effects);
-    let mut different = target;
-    different.agent_session =
-        AgentSessionBinding::established("different-session").expect("fixture session");
+    let different = target.with_agent_session(
+        AgentSessionBinding::established("different-session").expect("fixture session"),
+    );
 
     let completion = finish_submission(
         &mut fixture,

--- a/tests/ui_board/agent_hermes.rs
+++ b/tests/ui_board/agent_hermes.rs
@@ -6,12 +6,12 @@ use proqi::{
 };
 
 fn harness_target(direction: Direction, pane_id: &str, kind: &str) -> AgentTarget {
-    let mut target = super::agent::target(direction, pane_id);
-    target.agent_kind = HarnessKind::new(kind).expect("fixture harness");
+    let mut target = super::agent::target(direction, pane_id)
+        .with_agent_kind(HarnessKind::new(kind).expect("fixture harness"));
     target.agent_name = format!("{kind} qualifier");
-    target.agent_session =
-        AgentSessionBinding::established(format!("{kind}-session")).expect("fixture session");
-    target
+    target.with_agent_session(
+        AgentSessionBinding::established(format!("{kind}-session")).expect("fixture session"),
+    )
 }
 
 #[test]
@@ -37,8 +37,11 @@ fn hermes_in_both_mixed_row_positions_never_bypasses_direction_choice() {
             );
             let effects = fixture.effects(UiInput::Key(UiKey::Character(key)));
             let request = super::agent::start_submission(&mut fixture, &effects);
-            assert_eq!(request.target.direction, expected_direction);
-            assert_eq!(request.target.agent_kind.as_str(), expected_kind);
+            assert_eq!(
+                request.target.adjacent_direction(),
+                Some(expected_direction)
+            );
+            assert_eq!(request.target.agent_kind().as_str(), expected_kind);
         }
     }
 }

--- a/tests/ui_board/agent_identity.rs
+++ b/tests/ui_board/agent_identity.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+use proqi::{
+    domain::Direction,
+    ports::agent::{AgentState, SubmissionReceipt},
+};
+
+#[test]
+fn accepted_receipt_ignores_volatile_target_metadata() {
+    let mut fixture = Fixture::new();
+    super::agent::prepare_thought(&mut fixture);
+    let target = super::agent::target(Direction::Right, "w1:p2");
+    fixture
+        .app
+        .complete_agent_discovery(Ok(vec![target.clone()]));
+    let effects = fixture.effects(UiInput::Key(UiKey::Character('s')));
+    let request = super::agent::start_submission(&mut fixture, &effects);
+    let mut revalidated = target;
+    revalidated.readiness = AgentState::Blocked;
+    revalidated.agent_name = "Renamed agent".to_owned();
+    let mut rect = revalidated
+        .route
+        .adjacent_target_rect()
+        .expect("adjacent rect");
+    rect.x = rect.x.saturating_add(1);
+    let mut source = revalidated
+        .route
+        .adjacent_source()
+        .expect("adjacent source")
+        .clone();
+    source.rect.width = source.rect.width.saturating_add(1);
+    revalidated = revalidated.with_adjacent_geometry(rect, source);
+
+    let completion = super::agent::finish_submission(
+        &mut fixture,
+        &request,
+        Ok(SubmissionReceipt {
+            submission_id: request.submission_id,
+            target: revalidated,
+            post_state: Some(AgentState::Unknown),
+        }),
+    );
+    assert!(matches!(
+        completion.as_slice(),
+        [Effect::StoreIntegrationContext { .. }]
+    ));
+    assert!(fixture.app.state.board.live_thoughts().is_empty());
+}

--- a/tests/ui_board/agent_pi.rs
+++ b/tests/ui_board/agent_pi.rs
@@ -10,8 +10,8 @@ fn mixed_target(
     pane_id: &str,
     kind: &str,
 ) -> proqi::ports::agent::AgentTarget {
-    let mut target = super::agent::target(direction, pane_id);
-    target.agent_kind = HarnessKind::new(kind).expect("fixture harness");
+    let mut target = super::agent::target(direction, pane_id)
+        .with_agent_kind(HarnessKind::new(kind).expect("fixture harness"));
     target.agent_name = format!("{kind}-review");
     target
 }
@@ -38,7 +38,7 @@ fn pi_in_both_mixed_row_positions_never_bypasses_direction_choice() {
         );
         let effects = fixture.effects(UiInput::Key(UiKey::Character(choice)));
         let request = super::agent::start_submission(&mut fixture, &effects);
-        assert_eq!(request.target.agent_kind.as_str(), expected);
+        assert_eq!(request.target.agent_kind().as_str(), expected);
     }
 }
 

--- a/tests/ui_board/agent_selection.rs
+++ b/tests/ui_board/agent_selection.rs
@@ -41,7 +41,7 @@ fn opencode_routes_correctly_in_both_mixed_harness_positions() {
         );
         let effects = fixture.effects(UiInput::Key(UiKey::Character(key)));
         let request = super::agent::start_submission(&mut fixture, &effects);
-        assert_eq!(request.target.agent_kind.as_str(), expected_kind);
+        assert_eq!(request.target.agent_kind().as_str(), expected_kind);
     }
 }
 

--- a/tests/ui_board/agent_session.rs
+++ b/tests/ui_board/agent_session.rs
@@ -9,18 +9,17 @@ use proqi::{
 fn accepted_first_opencode_prompt_upgrades_the_cached_target_session() {
     let mut fixture = Fixture::new();
     super::agent::prepare_thought(&mut fixture);
-    let mut provisional =
-        super::agent::target_with_kind(Direction::Left, "w1:p2", OPENCODE_AGENT_KIND);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    let provisional = super::agent::target_with_kind(Direction::Left, "w1:p2", OPENCODE_AGENT_KIND)
+        .with_agent_session(AgentSessionBinding::provisional());
     fixture
         .app
         .complete_agent_discovery(Ok(vec![provisional.clone()]));
 
     let effects = fixture.effects(UiInput::Key(UiKey::Character('S')));
     let request = super::agent::start_submission(&mut fixture, &effects);
-    let mut established = provisional;
-    established.agent_session =
-        AgentSessionBinding::established("new-codex-session").expect("fixture session");
+    let established = provisional.with_agent_session(
+        AgentSessionBinding::established("new-codex-session").expect("fixture session"),
+    );
     let completion = super::agent::finish_submission(
         &mut fixture,
         &request,
@@ -35,7 +34,10 @@ fn accepted_first_opencode_prompt_upgrades_the_cached_target_session() {
         completion.as_slice(),
         [Effect::StoreIntegrationContext { .. }]
     ));
-    assert_eq!(fixture.app.agent_targets(), [established.clone()]);
+    assert_eq!(
+        fixture.app.agent_targets(),
+        std::slice::from_ref(&established)
+    );
 
     let effects = fixture.effects(UiInput::Key(UiKey::Character('S')));
     let second = super::agent::start_submission(&mut fixture, &effects);
@@ -46,9 +48,8 @@ fn accepted_first_opencode_prompt_upgrades_the_cached_target_session() {
 fn an_opencode_receipt_before_the_session_hook_refreshes_without_resending() {
     let mut fixture = Fixture::new();
     super::agent::prepare_thought(&mut fixture);
-    let mut provisional =
-        super::agent::target_with_kind(Direction::Left, "w1:p2", OPENCODE_AGENT_KIND);
-    provisional.agent_session = AgentSessionBinding::provisional();
+    let provisional = super::agent::target_with_kind(Direction::Left, "w1:p2", OPENCODE_AGENT_KIND)
+        .with_agent_session(AgentSessionBinding::provisional());
     fixture
         .app
         .complete_agent_discovery(Ok(vec![provisional.clone()]));
@@ -70,7 +71,7 @@ fn an_opencode_receipt_before_the_session_hook_refreshes_without_resending() {
         [
             Effect::StoreIntegrationContext { target, .. },
             Effect::DiscoverAgents
-        ] if target.agent_session.is_provisional()
+        ] if target.agent_session().is_provisional()
     ));
     assert!(
         !completion
@@ -78,15 +79,18 @@ fn an_opencode_receipt_before_the_session_hook_refreshes_without_resending() {
             .any(|effect| matches!(effect, Effect::SubmitAgent(_)))
     );
     assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
-    assert_eq!(fixture.app.agent_targets(), [provisional.clone()]);
+    assert_eq!(
+        fixture.app.agent_targets(),
+        std::slice::from_ref(&provisional)
+    );
     assert_eq!(
         fixture.app.status_text(),
         Some("submitted left to opencode w1:p2, thought kept")
     );
 
-    let mut established = provisional;
-    established.agent_session =
-        AgentSessionBinding::established("new-codex-session").expect("fixture session");
+    let established = provisional.with_agent_session(
+        AgentSessionBinding::established("new-codex-session").expect("fixture session"),
+    );
     fixture
         .app
         .complete_agent_discovery(Ok(vec![established.clone()]));

--- a/tests/ui_board/attachment_accessibility.rs
+++ b/tests/ui_board/attachment_accessibility.rs
@@ -283,7 +283,7 @@ fn accessible_preflight_preserves_direct_herdr_submission_and_source_changes_fai
     );
 }
 
-fn submission_fixture() -> Fixture {
+pub(super) fn submission_fixture() -> Fixture {
     let mut fixture = Fixture::new();
     let path = "/private/TemporaryItems/expired.png";
     let effects = fixture.effects(UiInput::PasteAnnotated(attachment_payload(path, true)));
@@ -393,7 +393,7 @@ fn attachment_payload(path: &str, image: bool) -> PastePayload {
     .expect("valid attachment payload")
 }
 
-fn attachment_batch(effects: &[Effect]) -> AttachmentCheckBatch {
+pub(super) fn attachment_batch(effects: &[Effect]) -> AttachmentCheckBatch {
     effects
         .iter()
         .find_map(|effect| match effect {
@@ -403,7 +403,7 @@ fn attachment_batch(effects: &[Effect]) -> AttachmentCheckBatch {
         .unwrap_or_else(|| panic!("attachment batch missing: {effects:?}"))
 }
 
-fn complete(
+pub(super) fn complete(
     batch: AttachmentCheckBatch,
     result: Result<(), AttachmentAccessFailure>,
 ) -> AttachmentCheckBatchResult {

--- a/tests/ui_board/direction_modifier_parity.rs
+++ b/tests/ui_board/direction_modifier_parity.rs
@@ -55,6 +55,10 @@ fn direction_chooser_accepts_modified_arrows_and_vim_spellings_equally() {
         fixture.input(UiInput::Key(UiKey::Character('S')));
         let effects = fixture.effects(UiInput::Key(key));
         let request = super::agent::start_submission(&mut fixture, &effects);
-        assert_eq!(request.target.direction, expected, "key: {key:?}");
+        assert_eq!(
+            request.target.adjacent_direction(),
+            Some(expected),
+            "key: {key:?}"
+        );
     }
 }

--- a/tests/ui_board/global_agent_delivery.rs
+++ b/tests/ui_board/global_agent_delivery.rs
@@ -1,0 +1,443 @@
+use super::*;
+
+use proqi::ports::agent::{
+    AgentAvailability, AgentDeliveryCapabilities, AgentSessionBinding, AgentState, AgentTarget,
+    HarnessKind, HerdrAgentAddress, SubmissionReceipt, SubmissionRouteKind,
+};
+
+pub(super) fn target(
+    workspace: &str,
+    tab: &str,
+    pane: &str,
+    name: &str,
+    readiness: AgentState,
+    availability: AgentAvailability,
+) -> AgentTarget {
+    AgentTarget::herdr_agent(
+        20,
+        HerdrAgentAddress::new(
+            workspace.to_owned(),
+            tab.to_owned(),
+            pane.to_owned(),
+            HarnessKind::new("codex").expect("harness"),
+            AgentSessionBinding::established(format!("session-{pane}")).expect("session"),
+        )
+        .expect("address"),
+        name.to_owned(),
+        Some(format!("Workspace {workspace}")),
+        Some(format!("Tab {tab}")),
+        readiness,
+        availability,
+        AgentDeliveryCapabilities::SUBMIT_ONLY,
+    )
+}
+
+pub(super) fn open(fixture: &mut Fixture) -> u64 {
+    fixture.input(UiInput::Key(UiKey::Character(':')));
+    for character in "submit to agent".chars() {
+        fixture.input(UiInput::Key(UiKey::Character(character)));
+    }
+    assert_eq!(
+        fixture.app.palette_view().expect("commands").1,
+        ["Submit to agent..."]
+    );
+    let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+    let [Effect::DiscoverGlobalAgents { generation }] = effects.as_slice() else {
+        panic!("expected current-server discovery: {effects:?}");
+    };
+    *generation
+}
+
+pub(super) fn prepare(fixture: &mut Fixture, content: &str) {
+    let sequence = fixture.paste(content);
+    fixture.app.acknowledge_persistence(sequence, true);
+    fixture.input(UiInput::Key(UiKey::Escape));
+}
+
+#[test]
+fn commands_only_target_search_requires_an_explicit_disposition() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "focused Grüße\n\u{1b}[31m");
+    let normal = text(draw(&mut fixture, 80, 8).backend().buffer());
+    assert!(!normal.contains("Submit to agent"));
+
+    let generation = open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![
+            target(
+                "w1",
+                "w1:t2",
+                "w1:p2",
+                "Alpha",
+                AgentState::Idle,
+                AgentAvailability::Available,
+            ),
+            target(
+                "w2",
+                "w2:t1",
+                "w2:p8",
+                "Béta 世界",
+                AgentState::Working,
+                AgentAvailability::Available,
+            ),
+        ]),
+    );
+    for character in "béta".chars() {
+        fixture.input(UiInput::Key(UiKey::Character(character)));
+    }
+    let chooser = text(draw(&mut fixture, 72, 9).backend().buffer());
+    assert!(chooser.contains("Béta"), "{chooser}");
+    assert!(chooser.contains("世 界"), "{chooser}");
+    assert!(!chooser.contains("Alpha"));
+
+    assert!(fixture.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    let disposition = text(draw(&mut fixture, 72, 8).backend().buffer());
+    assert!(disposition.contains("Submit"));
+    assert!(disposition.contains("Submit and keep"));
+    let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+    let [Effect::PrepareSubmission(attempt)] = effects.as_slice() else {
+        panic!("expected durable reservation: {effects:?}");
+    };
+    assert_eq!(attempt.route.kind(), SubmissionRouteKind::HerdrAgent);
+    assert_eq!(attempt.route.adjacent_direction(), None);
+    assert_eq!(attempt.route.version(), 1);
+    let request = super::agent::start_submission(&mut fixture, &effects);
+    assert_eq!(request.content, "focused Grüße\n\u{1b}[31m");
+    assert_eq!(request.target.pane_id(), "w2:p8");
+}
+
+#[test]
+fn keep_and_remove_dispositions_share_receipt_matching_and_removal_contracts() {
+    for keep in [false, true] {
+        let mut fixture = Fixture::new();
+        prepare(&mut fixture, "one");
+        let destination = target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Receiver",
+            AgentState::Done,
+            AgentAvailability::Available,
+        );
+        let generation = open(&mut fixture);
+        fixture
+            .app
+            .complete_global_agent_discovery(generation, Ok(vec![destination.clone()]));
+        fixture.input(UiInput::Key(UiKey::Enter));
+        if keep {
+            fixture.input(UiInput::Key(UiKey::Move {
+                movement: CursorMovement::VisualDown,
+                extend_selection: false,
+            }));
+        }
+        let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+        let request = super::agent::start_submission(&mut fixture, &effects);
+        let completion = super::agent::finish_submission(
+            &mut fixture,
+            &request,
+            Ok(SubmissionReceipt {
+                submission_id: request.submission_id,
+                target: destination,
+                post_state: Some(AgentState::Working),
+            }),
+        );
+        assert!(
+            completion.is_empty(),
+            "global delivery stores no adjacent context"
+        );
+        assert_eq!(
+            fixture.app.state.board.live_thoughts().len(),
+            usize::from(keep)
+        );
+        if !keep {
+            fixture.input(UiInput::Key(UiKey::Escape));
+            fixture.input(UiInput::Key(UiKey::Undo));
+            assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
+        }
+    }
+}
+
+#[test]
+fn global_provisional_receipt_does_not_refresh_adjacent_targets() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "sessionless global");
+    let destination = target(
+        "w2",
+        "w2:t1",
+        "w2:p8",
+        "Sessionless",
+        AgentState::Idle,
+        AgentAvailability::Available,
+    )
+    .with_agent_session(AgentSessionBinding::provisional());
+    let generation = open(&mut fixture);
+    fixture
+        .app
+        .complete_global_agent_discovery(generation, Ok(vec![destination.clone()]));
+    fixture.input(UiInput::Key(UiKey::Enter));
+    fixture.input(UiInput::Key(UiKey::Move {
+        movement: CursorMovement::VisualDown,
+        extend_selection: false,
+    }));
+    let prepared = fixture.effects(UiInput::Key(UiKey::Enter));
+    let request = super::agent::start_submission(&mut fixture, &prepared);
+    let completion = super::agent::finish_submission(
+        &mut fixture,
+        &request,
+        Ok(SubmissionReceipt {
+            submission_id: request.submission_id,
+            target: destination,
+            post_state: Some(AgentState::Idle),
+        }),
+    );
+
+    assert!(completion.is_empty());
+    assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
+}
+
+#[test]
+fn blocked_unknown_launching_and_noninteractive_targets_stay_visible_but_disabled() {
+    for (availability, expected) in [
+        (AgentAvailability::Blocked, "agent is blocked"),
+        (AgentAvailability::Unknown, "agent state is unknown"),
+        (AgentAvailability::Launching, "agent is still launching"),
+        (
+            AgentAvailability::NotInteractive,
+            "agent is not interactive yet",
+        ),
+    ] {
+        let mut fixture = Fixture::new();
+        prepare(&mut fixture, "keep me");
+        let generation = open(&mut fixture);
+        fixture.app.complete_global_agent_discovery(
+            generation,
+            Ok(vec![target(
+                "w1",
+                "w1:t2",
+                "w1:p2",
+                "Unavailable",
+                AgentState::Unknown,
+                availability,
+            )]),
+        );
+        let rendered = text(draw(&mut fixture, 70, 7).backend().buffer());
+        assert!(rendered.contains(availability.as_str()));
+        assert!(fixture.effects(UiInput::Key(UiKey::Enter)).is_empty());
+        assert!(
+            fixture
+                .app
+                .status_text()
+                .is_some_and(|status| status.starts_with(expected))
+        );
+        assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
+    }
+}
+
+#[test]
+fn stale_completion_is_ignored_and_reopening_refreshes_new_targets() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "source");
+    let stale = open(&mut fixture);
+    fixture.input(UiInput::Key(UiKey::Escape));
+    let current = open(&mut fixture);
+    assert_ne!(stale, current);
+    fixture.app.complete_global_agent_discovery(
+        stale,
+        Ok(vec![target(
+            "w1",
+            "w1:t2",
+            "w1:p2",
+            "Stale",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    fixture.app.complete_global_agent_discovery(
+        current,
+        Ok(vec![target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "New target",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    let rendered = text(draw(&mut fixture, 60, 7).backend().buffer());
+    assert!(rendered.contains("New target"));
+    assert!(!rendered.contains("Stale"));
+}
+
+#[test]
+fn mouse_activation_and_shallow_resize_use_the_same_semantic_rows() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "mouse source");
+    let generation = open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Mäuse 世界",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    for (width, height) in [(22, 5), (80, 9), (30, 4)] {
+        let _terminal = draw(&mut fixture, width, height);
+    }
+    let target_area = fixture
+        .app
+        .prepare_frame(Rect::new(0, 0, 64, 7))
+        .overlay
+        .expect("target overlay")
+        .items[0];
+    let target_effects = fixture.effects(UiInput::Pointer(PointerInput {
+        column: target_area.x,
+        row: target_area.y,
+        kind: PointerKind::Down(PointerButton::Left),
+        extend_selection: false,
+    }));
+    assert!(target_effects.is_empty());
+    fixture.clock.set(Timestamp::from_millis(1_000));
+    let behavior_area = fixture
+        .app
+        .prepare_frame(Rect::new(0, 0, 64, 7))
+        .overlay
+        .expect("behavior overlay")
+        .items[1];
+    let effects = fixture.effects(UiInput::Pointer(PointerInput {
+        column: behavior_area.x,
+        row: behavior_area.y,
+        kind: PointerKind::Down(PointerButton::Left),
+        extend_selection: false,
+    }));
+    let [Effect::PrepareSubmission(attempt)] = effects.as_slice() else {
+        panic!("expected mouse submission reservation: {effects:?}");
+    };
+    assert_eq!(
+        attempt.disposition,
+        proqi::ports::agent::SubmissionDisposition::Keep
+    );
+}
+
+#[test]
+fn discontiguous_selection_keeps_exact_board_order_for_global_delivery() {
+    let mut fixture = Fixture::new();
+    for content in ["first", "second", "third"] {
+        prepare(&mut fixture, content);
+    }
+    fixture.input(UiInput::Key(UiKey::Character(' ')));
+    fixture.input(UiInput::Key(UiKey::Character('k')));
+    fixture.input(UiInput::Key(UiKey::Character('k')));
+    fixture.input(UiInput::Key(UiKey::Character(' ')));
+    let generation = open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Receiver",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    fixture.input(UiInput::Key(UiKey::Enter));
+    fixture.input(UiInput::Key(UiKey::Move {
+        movement: CursorMovement::VisualDown,
+        extend_selection: false,
+    }));
+    let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+    let request = super::agent::start_submission(&mut fixture, &effects);
+    assert_eq!(request.content, "first\n\nthird");
+}
+
+#[test]
+fn invocation_reference_annotations_remain_inert_exact_prompt_content() {
+    let mut fixture = Fixture::new();
+    let content = "Ask @receiver to inspect this";
+    let start = content.find("@receiver").expect("reference start");
+    let end = start + "@receiver".len();
+    let payload = PastePayload::annotated(
+        content.to_owned(),
+        vec![ContentAnnotation {
+            start,
+            end,
+            kind: ContentAnnotationKind::InvocationReference {
+                display_name: "@receiver · codex".to_owned(),
+            },
+        }],
+    )
+    .expect("annotated prompt");
+    let effects = fixture.effects(UiInput::PasteAnnotated(payload));
+    let sequence = effects
+        .first()
+        .and_then(Effect::persistence_batch)
+        .and_then(|batch| batch.sequence())
+        .expect("persistence sequence");
+    fixture.app.acknowledge_persistence(sequence, true);
+    fixture.input(UiInput::Key(UiKey::Escape));
+
+    let generation = open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Different receiver",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    fixture.input(UiInput::Key(UiKey::Enter));
+    let prepared = fixture.effects(UiInput::Key(UiKey::Enter));
+    let request = super::agent::start_submission(&mut fixture, &prepared);
+    assert_eq!(request.content, content);
+    assert_eq!(request.target.pane_id(), "w2:p8");
+}
+
+#[test]
+fn source_change_during_discovery_aborts_before_journal_or_delivery() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "original");
+    let thought = fixture.app.state.board.live_thoughts()[0].clone();
+    let generation = open(&mut fixture);
+    let effects = proqi::application::reduce(
+        &mut fixture.app.state,
+        proqi::application::Action::EditThought {
+            thought_id: thought.id,
+            revision_id: fixture.ids.revision_id(),
+            before_content: thought.content,
+            after_content: "changed externally".to_owned(),
+            before_annotations: thought.annotations,
+            after_annotations: Vec::new(),
+            before_cursor: proqi::domain::TextPosition::default(),
+            after_cursor: proqi::domain::TextPosition::default(),
+            at: Timestamp::from_millis(30),
+        },
+    )
+    .expect("external edit");
+    assert!(matches!(effects.as_slice(), [Effect::CommitRevision(_)]));
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Receiver",
+            AgentState::Idle,
+            AgentAvailability::Available,
+        )]),
+    );
+    fixture.input(UiInput::Key(UiKey::Enter));
+    let submission = fixture.effects(UiInput::Key(UiKey::Enter));
+    assert!(submission.is_empty());
+    assert_eq!(
+        fixture.app.status_text(),
+        Some("source changed during agent selection; thoughts kept")
+    );
+}

--- a/tests/ui_board/global_agent_delivery.rs
+++ b/tests/ui_board/global_agent_delivery.rs
@@ -324,6 +324,43 @@ fn mouse_activation_and_shallow_resize_use_the_same_semantic_rows() {
 }
 
 #[test]
+fn target_rows_preserve_pane_identity_and_state_before_long_agent_names() {
+    let mut fixture = Fixture::new();
+    prepare(&mut fixture, "source");
+    let generation = open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![
+            target(
+                "w2",
+                "w2:t1",
+                "w2:p8",
+                "A receiver name that cannot fit beside metadata",
+                AgentState::Working,
+                AgentAvailability::Available,
+            ),
+            target(
+                "w3",
+                "w3:t9",
+                "w3:p2",
+                "A receiver name that cannot fit beside metadata",
+                AgentState::Blocked,
+                AgentAvailability::Blocked,
+            ),
+        ]),
+    );
+
+    let narrow = text(draw(&mut fixture, 34, 8).backend().buffer());
+    assert!(narrow.contains("p8 · working"), "{narrow}");
+    assert!(narrow.contains("p2 · blocked"), "{narrow}");
+    assert!(!narrow.contains("cannot fit"), "{narrow}");
+
+    let extreme = text(draw(&mut fixture, 14, 8).backend().buffer());
+    assert!(extreme.contains("working"), "{extreme}");
+    assert!(extreme.contains("blocked"), "{extreme}");
+}
+
+#[test]
 fn discontiguous_selection_keeps_exact_board_order_for_global_delivery() {
     let mut fixture = Fixture::new();
     for content in ["first", "second", "third"] {

--- a/tests/ui_board/global_agent_delivery_failures.rs
+++ b/tests/ui_board/global_agent_delivery_failures.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+use proqi::ports::{
+    agent::{AgentAvailability, AgentError, AgentState},
+    attachment_accessibility::AttachmentAccessFailure,
+};
+
+#[test]
+fn rapid_activation_reports_loading_and_discovery_failure_truthfully() {
+    let mut fixture = Fixture::new();
+    super::global_agent_delivery::prepare(&mut fixture, "keep me");
+    let generation = super::global_agent_delivery::open(&mut fixture);
+
+    assert!(fixture.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    assert_eq!(
+        fixture.app.status_text(),
+        Some("agent discovery is still in progress")
+    );
+
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Err(AgentError::Unavailable("synthetic failure".to_owned())),
+    );
+    assert!(fixture.effects(UiInput::Key(UiKey::Enter)).is_empty());
+    assert_eq!(
+        fixture.app.status_text(),
+        Some("agent discovery failed; refresh and try again")
+    );
+    assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
+}
+
+#[test]
+fn cancellation_failures_and_repeated_activation_preserve_sources_without_resubmission() {
+    let mut cancelled = Fixture::new();
+    super::global_agent_delivery::prepare(&mut cancelled, "cancelled");
+    let generation = super::global_agent_delivery::open(&mut cancelled);
+    cancelled
+        .app
+        .complete_global_agent_discovery(generation, Ok(vec![receiver()]));
+    assert!(cancelled.effects(UiInput::Key(UiKey::Escape)).is_empty());
+    assert_eq!(cancelled.app.state.board.live_thoughts().len(), 1);
+
+    for error in [
+        AgentError::TimedOut,
+        AgentError::Rejected {
+            code: "busy".to_owned(),
+            message: "receiver rejected".to_owned(),
+        },
+    ] {
+        let mut fixture = Fixture::new();
+        super::global_agent_delivery::prepare(&mut fixture, "failure source");
+        let destination = receiver();
+        let generation = super::global_agent_delivery::open(&mut fixture);
+        fixture
+            .app
+            .complete_global_agent_discovery(generation, Ok(vec![destination.clone()]));
+        fixture.input(UiInput::Key(UiKey::Enter));
+        let prepared = fixture.effects(UiInput::Key(UiKey::Enter));
+        let request = super::agent::start_submission(&mut fixture, &prepared);
+
+        let repeated_generation = super::global_agent_delivery::open(&mut fixture);
+        fixture
+            .app
+            .complete_global_agent_discovery(repeated_generation, Ok(vec![destination]));
+        fixture.input(UiInput::Key(UiKey::Enter));
+        assert!(fixture.effects(UiInput::Key(UiKey::Enter)).is_empty());
+        assert_eq!(
+            fixture.app.status_text(),
+            Some("a selected thought already has a submission in progress")
+        );
+
+        super::agent::finish_submission(&mut fixture, &request, Err(error));
+        assert_eq!(fixture.app.state.board.live_thoughts().len(), 1);
+    }
+}
+
+#[test]
+fn global_delivery_uses_the_shared_fresh_attachment_preflight() {
+    let mut fixture = super::attachment_accessibility::submission_fixture();
+    fixture.input(UiInput::Key(UiKey::Character('k')));
+    let generation = super::global_agent_delivery::open(&mut fixture);
+    fixture
+        .app
+        .complete_global_agent_discovery(generation, Ok(vec![receiver()]));
+    fixture.input(UiInput::Key(UiKey::Enter));
+    let effects = fixture.effects(UiInput::Key(UiKey::Enter));
+    let preflight = super::attachment_accessibility::attachment_batch(&effects);
+    assert!(
+        effects
+            .iter()
+            .all(|effect| !matches!(effect, Effect::PrepareSubmission(_)))
+    );
+    let completion = super::attachment_accessibility::complete(
+        preflight,
+        Err(AttachmentAccessFailure::TimedOut),
+    );
+    assert!(
+        fixture
+            .app
+            .complete_attachment_checks(completion)
+            .is_empty()
+    );
+    assert_eq!(
+        fixture.app.status_text(),
+        Some("Proqi cannot access 1 attachment")
+    );
+    assert_eq!(fixture.app.state.board.live_thoughts().len(), 2);
+}
+
+fn receiver() -> proqi::ports::agent::AgentTarget {
+    super::global_agent_delivery::target(
+        "w2",
+        "w2:t1",
+        "w2:p8",
+        "Receiver",
+        AgentState::Idle,
+        AgentAvailability::Available,
+    )
+}

--- a/tests/ui_board/global_delivery_snapshots.rs
+++ b/tests/ui_board/global_delivery_snapshots.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+use proqi::ports::agent::{AgentAvailability, AgentState};
+
+#[test]
+fn current_server_target_chooser_is_complete_in_a_narrow_viewport() {
+    let mut fixture = Fixture::new();
+    super::global_agent_delivery::prepare(&mut fixture, "focused prompt");
+    let generation = super::global_agent_delivery::open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![
+            super::global_agent_delivery::target(
+                "w1",
+                "w1:t2",
+                "w1:p2",
+                "Béta 世界",
+                AgentState::Working,
+                AgentAvailability::Available,
+            ),
+            super::global_agent_delivery::target(
+                "w2",
+                "w2:t1",
+                "w2:p8",
+                "Blocked receiver",
+                AgentState::Blocked,
+                AgentAvailability::Blocked,
+            ),
+        ]),
+    );
+    let _initial_layout = screen(&mut fixture, 64, 10);
+    fixture.input(UiInput::Key(UiKey::Move {
+        movement: proqi::ports::editor::CursorMovement::VisualDown,
+        extend_selection: false,
+    }));
+
+    insta::assert_snapshot!(
+        "global_delivery_target_chooser",
+        screen(&mut fixture, 64, 10)
+    );
+}
+
+#[test]
+fn explicit_disposition_chooser_is_complete_in_a_shallow_viewport() {
+    let mut fixture = Fixture::new();
+    super::global_agent_delivery::prepare(&mut fixture, "focused prompt");
+    let generation = super::global_agent_delivery::open(&mut fixture);
+    fixture.app.complete_global_agent_discovery(
+        generation,
+        Ok(vec![super::global_agent_delivery::target(
+            "w2",
+            "w2:t1",
+            "w2:p8",
+            "Receiver",
+            AgentState::Done,
+            AgentAvailability::Available,
+        )]),
+    );
+    fixture.input(UiInput::Key(UiKey::Enter));
+
+    insta::assert_snapshot!("global_delivery_disposition", screen(&mut fixture, 50, 6));
+}
+
+fn screen(fixture: &mut Fixture, width: u16, height: u16) -> String {
+    let terminal = draw_theme(fixture, width, height, ThemePreference::Dark);
+    snapshot_support::snapshot_buffer(terminal.backend().buffer())
+}

--- a/tests/ui_board/kilo.rs
+++ b/tests/ui_board/kilo.rs
@@ -9,12 +9,13 @@ use proqi::{
 };
 
 fn mixed_target(direction: Direction, pane_id: &str, kind: &str, name: &str) -> AgentTarget {
-    let mut target = super::agent::target(direction, pane_id);
-    target.agent_kind = HarnessKind::new(kind).expect("fixture harness kind");
+    let mut target = super::agent::target(direction, pane_id)
+        .with_agent_kind(HarnessKind::new(kind).expect("fixture harness kind"));
     name.clone_into(&mut target.agent_name);
-    target.agent_session = AgentSessionBinding::established(format!("session-{kind}-{pane_id}"))
-        .expect("fixture harness session");
-    target
+    target.with_agent_session(
+        AgentSessionBinding::established(format!("session-{kind}-{pane_id}"))
+            .expect("fixture harness session"),
+    )
 }
 
 #[test]
@@ -67,8 +68,8 @@ fn kilo_in_either_mixed_row_position_never_bypasses_direction_choice() {
             extend_selection: false,
         }));
         let request = super::agent::start_submission(&mut fixture, &effects);
-        assert_eq!(request.target.direction, kilo_direction);
-        assert_eq!(request.target.agent_kind.as_str(), KILO_AGENT_KIND);
+        assert_eq!(request.target.adjacent_direction(), Some(kilo_direction));
+        assert_eq!(request.target.agent_kind().as_str(), KILO_AGENT_KIND);
     }
 }
 
@@ -76,17 +77,17 @@ fn kilo_in_either_mixed_row_position_never_bypasses_direction_choice() {
 fn kilo_receipt_with_session_upgrades_the_target_for_established_follow_up() {
     let mut fixture = Fixture::new();
     super::agent::prepare_thought(&mut fixture);
-    let mut provisional = mixed_target(Direction::Right, "w1:p2", KILO_AGENT_KIND, "kilo-reviewer");
-    provisional.agent_session = AgentSessionBinding::provisional();
+    let provisional = mixed_target(Direction::Right, "w1:p2", KILO_AGENT_KIND, "kilo-reviewer")
+        .with_agent_session(AgentSessionBinding::provisional());
     fixture
         .app
         .complete_agent_discovery(Ok(vec![provisional.clone()]));
 
     let effects = fixture.effects(UiInput::Key(UiKey::Character('S')));
     let request = super::agent::start_submission(&mut fixture, &effects);
-    let mut established = provisional;
-    established.agent_session =
-        AgentSessionBinding::established("session-kilo-established").expect("fixture Kilo session");
+    let established = provisional.with_agent_session(
+        AgentSessionBinding::established("session-kilo-established").expect("fixture Kilo session"),
+    );
     let completion = super::agent::finish_submission(
         &mut fixture,
         &request,
@@ -104,7 +105,7 @@ fn kilo_receipt_with_session_upgrades_the_target_for_established_follow_up() {
     let follow_up = fixture.effects(UiInput::Key(UiKey::Character('S')));
     let follow_up_request = super::agent::start_submission(&mut fixture, &follow_up);
     assert_eq!(
-        follow_up_request.target.agent_session.as_id(),
+        follow_up_request.target.agent_session().as_id(),
         Some("session-kilo-established")
     );
 }
@@ -113,8 +114,8 @@ fn kilo_receipt_with_session_upgrades_the_target_for_established_follow_up() {
 fn provisional_kilo_receipt_removes_once_then_rediscovers_without_resending() {
     let mut fixture = Fixture::new();
     super::agent::prepare_thought(&mut fixture);
-    let mut provisional = mixed_target(Direction::Right, "w1:p2", KILO_AGENT_KIND, "kilo-reviewer");
-    provisional.agent_session = AgentSessionBinding::provisional();
+    let provisional = mixed_target(Direction::Right, "w1:p2", KILO_AGENT_KIND, "kilo-reviewer")
+        .with_agent_session(AgentSessionBinding::provisional());
     fixture
         .app
         .complete_agent_discovery(Ok(vec![provisional.clone()]));

--- a/tests/ui_board/snapshots.rs
+++ b/tests/ui_board/snapshots.rs
@@ -273,10 +273,10 @@ fn mixed_claude_and_hermes_targets_have_equal_directional_controls() {
     fixture.input(UiInput::Paste("selected prompt".to_owned()));
     fixture.input(UiInput::Key(UiKey::Escape));
     let mut left = adjacent_target(Direction::Left, "w1:p2", AgentState::Idle);
-    left.agent_kind = HarnessKind::new("claude").expect("fixture harness");
+    left = left.with_agent_kind(HarnessKind::new("claude").expect("fixture harness"));
     left.agent_name = "Claude qualifier".to_owned();
     let mut right = adjacent_target(Direction::Right, "w1:p3", AgentState::Idle);
-    right.agent_kind = HarnessKind::new("hermes").expect("fixture harness");
+    right = right.with_agent_kind(HarnessKind::new("hermes").expect("fixture harness"));
     right.agent_name = "Hermes qualifier".to_owned();
     fixture.app.complete_agent_discovery(Ok(vec![left, right]));
     insta::assert_snapshot!(snapshot(&mut fixture, 88, 9, ThemePreference::Dark));

--- a/tests/ui_board/snapshots/support.rs
+++ b/tests/ui_board/snapshots/support.rs
@@ -117,20 +117,23 @@ pub(super) fn adjacent_target(
             height: 20,
         },
     };
-    AgentTarget {
-        provider: "herdr".to_owned(),
-        protocol: 19,
+    let address = proqi::ports::agent::HerdrAgentAddress::new(
+        source.workspace_id.clone(),
+        source.tab_id.clone(),
+        pane_id.to_owned(),
+        HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
+        AgentSessionBinding::established(format!("session-{pane_id}")).expect("fixture session"),
+    )
+    .expect("fixture address");
+    AgentTarget::adjacent(
+        "herdr".to_owned(),
+        19,
         direction,
-        pane_id: pane_id.to_owned(),
-        workspace_id: source.workspace_id.clone(),
-        tab_id: source.tab_id.clone(),
-        agent_kind: HarnessKind::new(CODEX_AGENT_KIND).expect("fixture harness"),
-        agent_name: format!("Codex {pane_id}"),
-        agent_session: AgentSessionBinding::established(format!("session-{pane_id}"))
-            .expect("fixture session"),
+        address,
+        format!("Codex {pane_id}"),
         readiness,
-        delivery: proqi::ports::agent::AgentDeliveryCapabilities::SUBMIT_ONLY,
-        rect: source.rect,
+        proqi::ports::agent::AgentDeliveryCapabilities::SUBMIT_ONLY,
+        source.rect,
         source,
-    }
+    )
 }

--- a/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_disposition.snap
+++ b/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_disposition.snap
@@ -1,0 +1,22 @@
+---
+source: tests/ui_board/global_delivery_snapshots.rs
+assertion_line: 56
+expression: "screen(&mut fixture, 50, 6)"
+---
+SIZE 50x6
+
+TEXT
+00│┌ submission behavior ─────────────────────────[x]│
+01││›                                               ││
+02││Submit             remove after accepted receipt││
+03││Submit and keep      keep after accepted receipt││
+04│└────────────────────────────────────────────────┘│
+05│  n New   : Commands  ? Shortcuts│
+
+STYLE RUNS
+0: 0-46 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 47-49 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 1-48 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 49-49 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+2: 0-0 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 1-6 fg=Rgb(112, 214, 155) bg=Rgb(39, 40, 48) mod=BOLD | 7-19 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 20-48 fg=Rgb(176, 169, 160) bg=Rgb(39, 40, 48) mod=NONE | 49-49 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+3: 0-21 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 22-48 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 49-49 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-49 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 11-21 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 22-22 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 23-49 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE

--- a/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_target_chooser.snap
+++ b/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_target_chooser.snap
@@ -8,8 +8,8 @@ SIZE 64x10
 TEXT
 00│   ┌ submit to agent ─────────────────────────────────────[x]│
 01│⋮  │›                                                       ││
-02│   │Béta 世 界      Workspace w1 / Tab w1:t2 · codex · working││
-03│   │Blocked receiver                                        ││
+02│   │Béta 世 界         Workspace w1 / Tab w1:t2 · p2 · working││
+03│   │Blocked receiver             Workspace w2 · p8 · blocked││
 04│   └────────────────────────────────────────────────────────┘│
 05││
 06││
@@ -20,8 +20,8 @@ TEXT
 STYLE RUNS
 0: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-57 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 58-60 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-3 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 4-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
-2: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Reset bg=Reset mod=NONE | 11-11 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 12-12 fg=Reset bg=Reset mod=NONE | 13-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-59 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
-3: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-3 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 4-19 fg=Rgb(176, 169, 160) bg=Rgb(39, 40, 48) mod=NONE | 20-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+2: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Reset bg=Reset mod=NONE | 11-11 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 12-12 fg=Reset bg=Reset mod=NONE | 13-20 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 21-59 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+3: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-3 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 4-19 fg=Rgb(176, 169, 160) bg=Rgb(39, 40, 48) mod=NONE | 20-32 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 33-59 fg=Rgb(176, 169, 160) bg=Rgb(39, 40, 48) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 4: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 5: 0-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
 6: 0-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE

--- a/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_target_chooser.snap
+++ b/tests/ui_board/snapshots/ui_board__global_delivery_snapshots__global_delivery_target_chooser.snap
@@ -1,0 +1,30 @@
+---
+source: tests/ui_board/global_delivery_snapshots.rs
+assertion_line: 37
+expression: "screen(&mut fixture, 64, 10)"
+---
+SIZE 64x10
+
+TEXT
+00│   ┌ submit to agent ─────────────────────────────────────[x]│
+01│⋮  │›                                                       ││
+02│   │Béta 世 界      Workspace w1 / Tab w1:t2 · codex · working││
+03│   │Blocked receiver                                        ││
+04│   └────────────────────────────────────────────────────────┘│
+05││
+06││
+07│  proqi-ui-contract│
+08│  1 thought · board · saved│
+09│  n New   y Copy  x Cut  d/Del  Space Select u Undo  / Search│
+
+STYLE RUNS
+0: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-57 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 58-60 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-3 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 4-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+2: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Reset bg=Reset mod=NONE | 11-11 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 12-12 fg=Reset bg=Reset mod=NONE | 13-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-59 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+3: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-3 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 4-19 fg=Rgb(176, 169, 160) bg=Rgb(39, 40, 48) mod=NONE | 20-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 60-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Reset bg=Reset mod=NONE | 3-60 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 61-61 fg=Reset bg=Reset mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+6: 0-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+7: 0-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+8: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-61 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 62-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+9: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 11-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-18 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 19-24 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 25-29 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 30-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 32-36 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 37-44 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 45-45 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 46-52 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 53-53 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 54-63 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE

--- a/tests/ui_board/submit_all.rs
+++ b/tests/ui_board/submit_all.rs
@@ -87,6 +87,7 @@ fn palette_submission_labels_use_one_concise_vocabulary() {
         vec![
             "Submit",
             "Submit and keep",
+            "Submit to agent...",
             "Submit all",
             "Submit all and keep",
         ]


### PR DESCRIPTION
## Summary

Adds verified current server Herdr agent delivery through the searchable Commands overlay.

The new `Submit to agent...` command discovers compatible coding agents in other tabs and workspaces, presents truthful eligibility, requires an explicit keep or remove disposition, and revalidates the exact route immediately before the structured Herdr prompt request. Its target rows now reuse the responsive picker qualifier layout, including workspace, tab, pane, harness, and state fallbacks. Pane identity and truthful state take priority over a complete display name when space is constrained. Existing adjacent `s` and `S` paths, Primary aliases, footer controls, geometry, mouse behavior, and invocation references remain unchanged. No global shortcut or always visible control was added.

## Acceptance criteria

1. The focused thought or current ordered multi thought selection can be delivered to a verified compatible agent on the current Herdr server.
2. Global delivery is available only through Commands and supports both `Submit` and `Submit and keep`.
3. Idle, done, and working targets are enabled. Blocked, unknown, launching, and noninteractive targets remain visible but disabled with truthful feedback.
4. Each target row uses responsive verified topology metadata. Rich layouts show workspace, tab, pane, harness, and state. Narrow layouts preserve compact pane identity and state before the full agent display name.
5. Delivery fails closed for stale discovery, disappearance, address movement, session replacement, protocol disagreement, duplicate identity, eligibility change, and receipt mismatch.
6. Existing source locks, prompt assembly, attachment preflight, durable reservation, sending compare and set, exact receipt matching, recovery, accepted only removal, undo, and no resubmit behavior are reused.
7. Diagnostics remain content redacted and do not contain prompt or topology identifiers.

## Design and compatibility

`SubmissionRoute` is now a closed discriminated route with `AdjacentPane` and `HerdrAgent`. Adjacent routes preserve their direction, source context, geometry, identity, protocol compatibility, and receipt behavior. Global routes carry verified current server workspace, tab, pane, harness, and established or explicitly qualified provisional session identity without fabricated geometry.

SQLite schema 13 and storage protocol 12 add versioned route kind plus optional adjacent direction. Migration decodes every prior attempt exactly as legacy version 0 `adjacent_pane`, preserves fingerprints and state, and retains conservative recovery. New version 1 rows encode adjacent or global routes. Public CLI and JSON spelling are unchanged.

Discovery and submission run asynchronously on the existing cancellable external lane. Rendering, filtering, paging, selection, enabled state, and hit geometry derive from one semantic chooser owner. The target chooser supplies a delivery specific qualifier sequence to the existing picker projection. It does not consume invocation annotations or live reference rows as delivery identity.

## Verification

1. Focused global delivery, responsive metadata, and picker overlay tests are green. Regression coverage includes duplicate long names, Unicode, full metadata, fallback thresholds, pane and state priority, state only extreme widths, and selected disabled styling.
2. Herdr adapter coverage is green across qualified protocols 19 and 20 plus provisional protocol 21.
3. SQLite route migration, journal recovery, restart, and idempotency coverage is green.
4. `cargo xtask check`: green on exact head, 1,484 tests passed, 5 skipped, and 1 doctest passed. One unrelated PTY fairness test exceeded the Nextest post-test leak timeout under full parallel load but passed. Its immediate isolated Nextest rerun passed cleanly in 4.09 seconds. All 81 snapshots were reviewed, with no pending snapshot.
5. `cargo xtask audit`: green. Known duplicate dependency warnings remain unchanged. Advisories, bans, licenses, sources, and unused dependency checks passed.
6. `cargo xtask package`: green, including the installed product contract.
7. `cargo xtask test-pty`: green, 72 passed serially.
8. Three bounded read only Codex review passes completed before the walkthrough. Findings from passes one and two were repaired and proportionally requalified. Pass three was clean. The lifetime three pass cap was not exceeded for the metadata repair.

Automated coverage includes focused and discontiguous selection order, both dispositions, attachment preflight, source mutation and locking, acceptance, rejection, mismatch, timeout, cancellation, outcome unknown recovery, rename, move, disappearance, session replacement, duplicate identity, provisional identity, concurrency, repeated activation, stale discovery, refresh, every live state, legacy migration, backup and restart, idempotency, undo, no replay, Commands only availability, adjacent shortcut preservation, keyboard, mouse, narrow and shallow layouts, overflow, Unicode, control heavy text, rapid input, resize, diagnostics privacy, and terminal restoration.

## Exact live stress evidence

The exact topic binary was exercised in disposable ticket owned panes with a synthetic compatible receiver through the real Herdr structured `agent prompt` API. No user agent or user content was contacted.

1. Cross tab keep delivered `GLOBAL_TAB_KEEP_α` exactly once. The receiver byte digest was `aec4e31da7ac4fda0324e1a2cce2cac6e8b0643882e0f8709ad9a0dbb6c4b3fc`, and the source remained.
2. Cross workspace remove delivered `GLOBAL_WORKSPACE_REMOVE_β` exactly once. The receiver byte digest was `608a432c5eb0c5d2a83f69feddeeb19a1ab22587195065cb941513e45e4a86e8`, the source was removed only after acceptance, and one undo restored it.
3. Workspace and tab label renames preserved address identity and accepted `RENAMED_WORKSPACE_ACCEPT_γ` exactly once.
4. Moving the selected target before final disposition rejected `MOVED_TARGET_MUST_NOT_DELIVER` with `target changed before submission`. Receiver bytes did not change and the source remained.
5. A 55 by 10 chooser remained stable, searchable, and operable. Quit and restart restored the shell, retained terminal state, produced no replay, and preserved accepted, failed, keep, and remove journal outcomes.
6. Diagnostics contained none of the synthetic prompts or topology identifiers.
7. The metadata repair was exercised from the exact committed topic binary in `w1N:t7`, pane `w1N:pC`, against a ticket owned structured protocol 20 fixture. Duplicate long display names remained distinguishable as `p77 · blocked` and `p98 · working`. The Unicode unknown target showed `p78 · unknown`. The binary SHA-256 was `aad6b96ad68067782edd6e842ec50c9a124714e0b148f8afcc8e9f5228ca47e6`, and the pane returned cleanly to zsh.

Disposable panes `w1N:p2`, `w1Q:p1`, `w1N:p3`, `w1N:p4`, `w1N:p5`, `w1N:p6`, and `w1R:p1`, plus state root `/private/tmp/proqi-global-delivery-01a071af`, were removed during the original stress run. Metadata repair tabs `w1N:t6` and `w1N:t7`, panes `w1N:pB` and `w1N:pC`, and state roots `/private/tmp/proqi-metadata-repair.99SpfS` and `/private/tmp/proqi-metadata-final.xQJY6d` were also removed. `w1N:p1` was preserved.

## Risks, limitations, and follow ups

Scope is deliberately limited to recognized compatible harnesses on the current Herdr server. Named remote servers, SSH hosts, historical sessions, arbitrary panes, and unrecognized shells are not implied or supported.

Herdr protocols 19 through 21 acknowledge accepted text entry but cannot guarantee a distinct prompt boundary against a concurrent external sender. Proqi therefore preserves exact receipts, durable outcomes, and the existing no resubmit contract without overstating delivery semantics.

The parallel shortcut architecture foundation was not present on `main` at final qualification time. The intended integration seam is the typed `Command::SubmitToAgent` identity, its Commands inventory label, and dispatch to `begin_global_delivery`. Likely overlapping UI files are `src/ui/app/palette/command.rs`, `src/ui/app/palette/dispatch.rs`, `src/ui/app/palette.rs`, `src/ui/app.rs`, `src/ui/app/pointer.rs`, `src/ui/app/view_frame.rs`, `src/ui/control_labels.rs`, `src/ui/render.rs`, `src/ui/render/overlay_composition.rs`, and `src/ui/render/overlays.rs`. The action has no binding or footer identity and can be registered directly in the future semantic action registry. The metadata repair additionally overlaps `src/ui/render/overlays.rs` at the responsive `PickerRow` projection. Its integration seam is the delivery owned `GlobalDeliveryChoiceView` qualifier and protected secondary lists passed to that projection.
