### PR TITLE
Keep attachment numbers stable across a session

### DIFF
--- a/.github/release-notes/v0.8.0.md
+++ b/.github/release-notes/v0.8.0.md
@@ -58,3 +58,13 @@ cannot be eliminated locally.
 New practice boards name actions and point to the current footer and Help instead
 of saving configurable key labels that would become stale after a remap. Existing
 practice thoughts remain untouched.
+
+
+Attachment labels now use durable session-wide Image and File sequences. Reorder,
+folding, accessibility changes, transformations, undo, redo and restart preserve
+the assigned numbers. New pasted or duplicated occurrences receive fresh numbers,
+and deleted numbers are not reused. Schema 14 migrates current and retained
+historical annotations once using deterministic legacy matching; storage protocol
+13 excludes older writers. Attachment-bearing owner-control creation requires
+protocol 8. Canonical paths and plain-text clipboard and submission payloads stay
+exact. Typed clipboard schema 2 retains reading of verified schema 1 items.

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -781,6 +781,45 @@ rows store `adjacent_pane` with a direction or `herdr_agent` without one. Neithe
 form stores workspace, tab, pane, session, labels, prompt content, or raw Herdr
 responses.
 
+### Stable session attachment ordinals
+
+Schema 14 and storage protocol 13 add separate session image and file allocation
+high-water marks and a positive typed ordinal on each durable attachment kind.
+Input payloads may be unassigned until the destination session prepares their
+mutation. Domain allocation reads no filesystem, clock or layout state. The
+canonical application creation paths renew copied occurrence identity, while
+range transformations and history replay preserve it. The single session lease,
+owner-control admission and operation sequence protect allocation; SQLite
+persists the high-water marks in the same transaction as the introducing
+mutation. Counters never roll back with an undo cursor and survive compaction.
+
+Rendering reads the ordinal directly through the existing shared annotation
+projection. Expanded and inaccessible presentations retain the same identity.
+There is no per-thought counting fallback. Canonical paths, clipboard plain text,
+submission content and annotation ranges remain exact.
+
+Migration assigns current live-board occurrences first in durable position and
+annotation byte order, separately by kind. It propagates retained snapshot and
+structural links and matches indistinguishable legacy occurrences by byte order.
+This is one-time deterministic synthesis, not reconstruction of unknowable
+original occurrence identity from coalesced legacy edits. History-only occurrences
+are allocated afterward by durable sequence and payload order. Every synthesized
+snapshot persists its ordinal, and counters cover dormant history as well as
+current content. Legacy compacted receipt hashes retain their original encoding;
+creation replay compares source metadata independently of destination allocation.
+Legacy snapshot matching is scoped to retained history steps. Equal text and
+annotation ranges at different steps do not by themselves establish occurrence
+identity: a split followed by reinserting the same path must retain two live
+identities. Structural snapshots and their inverse reuse the same step bindings;
+retained undo and redo receipts restore the corresponding active bindings before
+current snapshots are anchored. A dormant identical editor snapshot therefore
+cannot replace the occurrence expected by an undone structural operation.
+Only missing or indistinguishable legacy lineage uses the documented one-time
+deterministic matching fallback.
+
+Control protocol 8 is required for attachment-bearing destination creation, so
+older owners cannot silently drop the new identity contract.
+
 ## Multiple running versions during an update
 
 ### Installation-wide update boundary
@@ -1537,7 +1576,8 @@ bounded messages, protocol negotiation, idempotency keys, and timeouts are
 mandatory. If forwarding is unsupported or the owner cannot be verified, the
 CLI returns `session_busy`.
 
-Control protocol version 7 is current. Version 2 introduced legacy durable
+Control protocol version 8 is current. Attachment-bearing creation requires
+version 8 to retain destination occurrence numbering. Version 2 introduced legacy durable
 presentation annotations. Version 4 added session rename, owner synchronization,
 exact editor replacement, and durable collapse state. An add mutation carrying
 an invocation-reference annotation requires version 6, so an older active owner

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -362,7 +362,25 @@ board and edit mode while their canonical text remains exact. Images appear as
 `[Image 1]`, other files as `[File 1]`, and context at or above 12 logical lines
 or 1,200 perceived Unicode characters as
 `[Pasted text · N lines · N characters]`. Thousands use comma grouping.
-Numbering restarts for each thought. The complete bracketed token uses the
+Each session has independent monotonically increasing Image and File sequences.
+An attachment occurrence receives its durable positive number when introduced.
+Reordering, editing around it, folding, health changes, split, extract, merge,
+restart, recovery, undo and redo preserve that number. Deleted numbers are never
+reused. Screenshot Inbox captures, clipboard images, pasted files, duplication
+and paste or transfer into a destination session create new occurrences and
+receive new destination-session numbers. Cut followed by paste is a new
+occurrence; structural movement within the session is not.
+
+Legacy databases receive these identities once during migration. Current live
+thoughts are numbered first in durable board position and annotation byte order,
+separately by kind. Retained history propagates provable lineage; indistinguishable
+legacy occurrences use deterministic byte-order matching rather than a claim of
+recovering original occurrence identity. Remaining history-only occurrences
+receive numbers afterward in durable history sequence and payload order. Counters
+advance beyond all assigned numbers, including dormant history. Exact historical
+text, ranges, cursors and undo/redo operations remain unchanged.
+
+The complete bracketed token uses the
 forest-green accent plus bold as a non-color cue, without exposing temporary
 paths or filenames.
 

--- a/src/adapters/clipboard/mod.rs
+++ b/src/adapters/clipboard/mod.rs
@@ -23,7 +23,7 @@ use provenance::{FileClipboardProvenance, ProvenanceRecord};
 
 const OSC52_MAX_BYTES: usize = 100_000;
 const METADATA_MAX_BYTES: usize = 512 * 1024;
-const WIRE_SCHEMA_VERSION: u8 = 1;
+const WIRE_SCHEMA_VERSION: u8 = 2;
 
 /// Native clipboard adapter with a bounded terminal fallback.
 pub struct PlatformClipboard {
@@ -314,7 +314,7 @@ fn decode_payload(content: &str, encoded: &str) -> Option<(ClipboardText, String
         return None;
     }
     let wire: WirePayload = serde_json::from_slice(&bytes).ok()?;
-    if wire.schema_version != WIRE_SCHEMA_VERSION {
+    if !(1..=WIRE_SCHEMA_VERSION).contains(&wire.schema_version) {
         return None;
     }
     let _: RequestId = wire.request_id.parse().ok()?;

--- a/src/adapters/clipboard/tests.rs
+++ b/src/adapters/clipboard/tests.rs
@@ -157,6 +157,7 @@ fn attachment(content: &str) -> ClipboardText {
             start: 0,
             end: content.len(),
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "Grüße 🖼️.png".to_owned(),
             },

--- a/src/adapters/sqlite/attachment_migration.rs
+++ b/src/adapters/sqlite/attachment_migration.rs
@@ -1,0 +1,196 @@
+//! Migration 14: synthesize legacy identities once, including dormant history.
+
+mod history;
+mod lineage;
+
+use rusqlite::{Connection, params};
+use serde_json::Value;
+
+use super::support::{map_sql_error, session_id_from_blob, thought_id_from_blob};
+use crate::{
+    domain::{BoardOperation, SessionId, ThoughtRevision},
+    ports::store::StoreError,
+};
+use lineage::Lineage;
+
+struct ThoughtRow {
+    id: Vec<u8>,
+    identity: String,
+    content: String,
+    annotations: Value,
+    live: bool,
+}
+
+struct PayloadRow {
+    table: String,
+    id: Vec<u8>,
+    original: Value,
+}
+
+pub(super) fn migrate(connection: &Connection) -> Result<(), StoreError> {
+    let mut statement = connection
+        .prepare("SELECT id FROM sessions ORDER BY id")
+        .map_err(map_sql_error)?;
+    let sessions = statement
+        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .map_err(map_sql_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_sql_error)?;
+    for session in sessions {
+        migrate_session(connection, session_id_from_blob(session)?)?;
+    }
+    Ok(())
+}
+
+fn migrate_session(connection: &Connection, session: SessionId) -> Result<(), StoreError> {
+    let mut thoughts = thoughts(connection, session)?;
+    let payloads = payloads(connection, session)?;
+    let mut lineage = Lineage::default();
+    for payload in &payloads {
+        lineage.collect(&payload.original)?;
+    }
+    for payload in &payloads {
+        lineage.link_payload(&payload.original)?;
+    }
+    lineage.current_board();
+    // Current live board anchors all identities before any dormant snapshot receives a number.
+    for thought in thoughts.iter_mut().filter(|thought| thought.live) {
+        lineage.assign(
+            &thought.identity,
+            &thought.content,
+            &mut thought.annotations,
+        )?;
+    }
+    for payload in payloads {
+        let mut assigned = payload.original.clone();
+        lineage.assign_payload(&mut assigned)?;
+        if assigned == payload.original {
+            continue;
+        }
+        let encoded = canonical_payload(assigned)?;
+        let (sql, column) = match payload.table.as_str() {
+            "board_operations" => (
+                "UPDATE board_operations SET payload_json = ?2 WHERE id = ?1",
+                "id",
+            ),
+            "thought_revisions" => (
+                "UPDATE thought_revisions SET payload_json = ?2 WHERE id = ?1",
+                "id",
+            ),
+            "commit_receipts" => (
+                "UPDATE commit_receipts SET request_json = ?2 WHERE external_id = ?1",
+                "external_id",
+            ),
+            _ => return Err(corrupt("invalid migration payload owner")),
+        };
+        let _ = column;
+        connection
+            .execute(sql, params![payload.id, encoded])
+            .map_err(map_sql_error)?;
+    }
+    lineage.current_board();
+    for thought in &mut thoughts {
+        if !thought.live {
+            lineage.assign(
+                &thought.identity,
+                &thought.content,
+                &mut thought.annotations,
+            )?;
+        }
+        let annotations: Vec<crate::domain::ContentAnnotation> =
+            serde_json::from_value(thought.annotations.clone()).map_err(corrupt)?;
+        connection
+            .execute(
+                "UPDATE thoughts SET annotations_json = ?2 WHERE id = ?1",
+                params![
+                    thought.id,
+                    serde_json::to_string(&annotations).map_err(corrupt)?
+                ],
+            )
+            .map_err(map_sql_error)?;
+    }
+    super::attachment_numbering::persist(connection, session, lineage.counters())?;
+    // Check the synthesized live uniqueness invariant before the migration transaction commits.
+    super::load::load_board(connection, session)?;
+    Ok(())
+}
+
+fn thoughts(connection: &Connection, session: SessionId) -> Result<Vec<ThoughtRow>, StoreError> {
+    let mut statement = connection.prepare("SELECT id, content, annotations_json, deleted_at IS NULL FROM thoughts WHERE session_id = ?1 ORDER BY deleted_at IS NOT NULL, position, id").map_err(map_sql_error)?;
+    let rows = statement
+        .query_map([session.database_bytes().as_slice()], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, bool>(3)?,
+            ))
+        })
+        .map_err(map_sql_error)?;
+    rows.map(|row| {
+        let (id, content, annotations, live) = row.map_err(map_sql_error)?;
+        Ok(ThoughtRow {
+            identity: thought_id_from_blob(id.clone())?.to_string(),
+            id,
+            content,
+            annotations: serde_json::from_str(&annotations).map_err(corrupt)?,
+            live,
+        })
+    })
+    .collect()
+}
+
+fn payloads(connection: &Connection, session: SessionId) -> Result<Vec<PayloadRow>, StoreError> {
+    let mut statement = connection.prepare(
+        "SELECT owner, id, payload FROM (
+         SELECT 'board_operations' AS owner, id, payload_json AS payload, sequence, 0 AS rank FROM board_operations WHERE session_id = ?1
+         UNION ALL SELECT 'thought_revisions', id, payload_json, sequence, 1 FROM thought_revisions WHERE session_id = ?1
+         UNION ALL SELECT 'commit_receipts', external_id, request_json, sequence, 2 FROM commit_receipts WHERE session_id = ?1
+         ) ORDER BY sequence, rank, id"
+    ).map_err(map_sql_error)?;
+    let rows = statement
+        .query_map([session.database_bytes().as_slice()], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .map_err(map_sql_error)?;
+    let mut result = Vec::new();
+    for row in rows {
+        let (table, id, encoded) = row.map_err(map_sql_error)?;
+        let original: Value = serde_json::from_str(&encoded).map_err(corrupt)?;
+        if original.get("compacted_version").is_some() {
+            super::receipt_compaction::decode(&encoded)?
+                .ok_or_else(|| corrupt("invalid compacted receipt"))?;
+            continue;
+        }
+        // Validate typed history before introducing any metadata.
+        canonical_payload(original.clone())?;
+        result.push(PayloadRow {
+            table,
+            id,
+            original,
+        });
+    }
+    Ok(result)
+}
+
+fn canonical_payload(value: Value) -> Result<String, StoreError> {
+    if value.get("forward").is_some() {
+        let operation: BoardOperation = serde_json::from_value(value).map_err(corrupt)?;
+        operation.validate_annotations().map_err(corrupt)?;
+        serde_json::to_string(&operation).map_err(corrupt)
+    } else if value.get("before_content").is_some() {
+        let revision: ThoughtRevision = serde_json::from_value(value).map_err(corrupt)?;
+        revision.validate_annotations().map_err(corrupt)?;
+        serde_json::to_string(&revision).map_err(corrupt)
+    } else {
+        serde_json::to_string(&value).map_err(corrupt)
+    }
+}
+
+fn corrupt(error: impl std::fmt::Display) -> StoreError {
+    StoreError::Corrupt(error.to_string())
+}

--- a/src/adapters/sqlite/attachment_migration/history.rs
+++ b/src/adapters/sqlite/attachment_migration/history.rs
@@ -1,0 +1,57 @@
+//! Retained receipt chronology distinguishes active state from dormant redo snapshots.
+use crate::domain::UndoScope;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub(super) struct History {
+    board: Branch,
+    editors: BTreeMap<String, Branch>,
+}
+
+#[derive(Default)]
+struct Branch {
+    entries: Vec<Value>,
+    cursor: usize,
+}
+
+impl Branch {
+    fn push(&mut self, value: &Value) {
+        self.entries.truncate(self.cursor);
+        self.entries.push(value.clone());
+        self.cursor = self.entries.len();
+    }
+
+    fn step(&mut self, undo: bool) -> Option<Value> {
+        let index = if undo {
+            self.cursor.checked_sub(1)?
+        } else {
+            self.cursor
+        };
+        let value = self.entries.get(index)?.clone();
+        self.cursor = if undo { index } else { index + 1 };
+        Some(value)
+    }
+}
+
+impl History {
+    pub(super) fn observe(&mut self, value: &Value) -> Option<(Value, bool)> {
+        if value.get("forward").is_some() {
+            self.board.push(value);
+            return Some((value.clone(), true));
+        }
+        if value.get("before_content").is_some() {
+            let id = value.get("thought_id")?.as_str()?;
+            self.editors.entry(id.to_owned()).or_default().push(value);
+            return Some((value.clone(), true));
+        }
+        let receipt = value.as_array()?;
+        let scope: UndoScope = serde_json::from_value(receipt.get(1)?.clone()).ok()?;
+        let undo = receipt.get(2)?.as_bool()?;
+        let branch = match scope {
+            UndoScope::Board => &mut self.board,
+            UndoScope::Editor { thought_id } => self.editors.get_mut(&thought_id.to_string())?,
+        };
+        branch.step(undo).map(|payload| (payload, !undo))
+    }
+}

--- a/src/adapters/sqlite/attachment_migration/lineage.rs
+++ b/src/adapters/sqlite/attachment_migration/lineage.rs
@@ -1,0 +1,435 @@
+//! One-time deterministic synthesis over legacy snapshots, never runtime allocation.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use crate::{
+    domain::{AttachmentCounters, ContentAnnotation},
+    ports::store::StoreError,
+};
+
+#[derive(Default)]
+pub(super) struct Lineage {
+    snapshots: BTreeMap<(String, String), Vec<usize>>,
+    versions: BTreeMap<String, Vec<usize>>,
+    current: BTreeMap<String, (String, Vec<usize>)>,
+    history: super::history::History,
+    scope: String,
+    collected: BTreeSet<String>,
+    nodes: Vec<Node>,
+    counters: AttachmentCounters,
+}
+
+struct Node {
+    parent: usize,
+    signature: String,
+    snapshots: BTreeSet<usize>,
+    image: bool,
+    ordinal: Option<u64>,
+}
+
+impl Lineage {
+    pub(super) fn register(
+        &mut self,
+        id: &str,
+        content: &str,
+        annotations: &Value,
+    ) -> Result<Vec<usize>, StoreError> {
+        self.register_version(id, content, annotations, false)
+    }
+
+    fn register_version(
+        &mut self,
+        id: &str,
+        content: &str,
+        annotations: &Value,
+        fresh: bool,
+    ) -> Result<Vec<usize>, StoreError> {
+        let key = snapshot_key(id, content, annotations)?;
+        let scoped = (self.scope.clone(), key.clone());
+        if let Some(existing) = self.snapshots.get(&scoped) {
+            return Ok(existing.clone());
+        }
+        if !fresh
+            && let Some((current_key, existing)) = self.current.get(id)
+            && current_key == &key
+        {
+            let nodes = existing.clone();
+            self.snapshots.insert(scoped, nodes.clone());
+            return Ok(nodes);
+        }
+        if !fresh && let Some(existing) = self.versions.get(&key) {
+            let nodes = existing.clone();
+            self.snapshots.insert(scoped, nodes.clone());
+            return Ok(nodes);
+        }
+        let decoded: Vec<ContentAnnotation> =
+            serde_json::from_value(annotations.clone()).map_err(corrupt)?;
+        crate::domain::validate_annotations(content, &decoded).map_err(corrupt)?;
+        let snapshot = self.snapshots.len();
+        let mut nodes = Vec::new();
+        for annotation in decoded {
+            let crate::domain::ContentAnnotationKind::Attachment {
+                image,
+                display_name,
+                ordinal,
+            } = annotation.kind
+            else {
+                continue;
+            };
+            if ordinal.is_some() {
+                return Err(corrupt("ordinal in legacy schema"));
+            }
+            let node = self.nodes.len();
+            let signature = serde_json::to_string(&(
+                image,
+                display_name,
+                &content[annotation.start..annotation.end],
+            ))
+            .map_err(corrupt)?;
+            self.nodes.push(Node {
+                parent: node,
+                signature,
+                snapshots: BTreeSet::from([snapshot]),
+                image,
+                ordinal: None,
+            });
+            nodes.push(node);
+        }
+        self.snapshots.insert(scoped, nodes.clone());
+        self.versions.insert(key, nodes.clone());
+        Ok(nodes)
+    }
+
+    pub(super) fn collect(&mut self, value: &Value) -> Result<(), StoreError> {
+        self.scope = serde_json::to_string(value).map_err(corrupt)?;
+        if !self.collected.insert(self.scope.clone()) {
+            return Ok(());
+        }
+        if let Some(forward) = value.get("forward") {
+            self.collect_value(forward, true)?;
+            if let Some(inverse) = value.get("inverse") {
+                self.collect_value(inverse, false)?;
+            }
+        } else {
+            self.collect_value(value, true)?;
+        }
+        if let Some((payload, forward)) = self.history.observe(value) {
+            self.scope = serde_json::to_string(&payload).map_err(corrupt)?;
+            self.apply_state(&payload, forward)?;
+        }
+        Ok(())
+    }
+
+    fn apply_state(&mut self, value: &Value, forward: bool) -> Result<(), StoreError> {
+        if let Some(mutation) = value.get(if forward { "forward" } else { "inverse" }) {
+            return self.apply_state(mutation, forward);
+        }
+        if let Some(children) = value.get("mutations").and_then(Value::as_array) {
+            for child in children {
+                self.apply_state(child, forward)?;
+            }
+            return Ok(());
+        }
+        if let Some(thought) = value.get("thought") {
+            return self.bind_current(thought, "id", "content", "annotations");
+        }
+        if value.get("before_content").is_some() {
+            let prefix = if value.get("mutation").is_some() || forward {
+                "after"
+            } else {
+                "before"
+            };
+            return self.bind_current(
+                value,
+                "thought_id",
+                &format!("{prefix}_content"),
+                &format!("{prefix}_annotations"),
+            );
+        }
+        Ok(())
+    }
+
+    fn bind_current(
+        &mut self,
+        value: &Value,
+        id_key: &str,
+        content_key: &str,
+        annotations_key: &str,
+    ) -> Result<(), StoreError> {
+        let id = string(value, id_key)?;
+        let content = string(value, content_key)?;
+        let annotations = &value[annotations_key];
+        let key = snapshot_key(id, content, annotations)?;
+        let nodes = self.register(id, content, annotations)?;
+        self.current.insert(id.to_owned(), (key, nodes));
+        Ok(())
+    }
+
+    pub(super) fn current_board(&mut self) {
+        self.scope.clear();
+    }
+
+    fn collect_value(&mut self, value: &Value, forward: bool) -> Result<(), StoreError> {
+        match value {
+            Value::Object(object) => {
+                if let (Some(id), Some(content), Some(annotations)) = (
+                    object.get("id").and_then(Value::as_str),
+                    object.get("content").and_then(Value::as_str),
+                    object.get("annotations"),
+                ) {
+                    self.register_version(id, content, annotations, forward)?;
+                }
+                self.collect_prefixed(value, forward)?;
+                for child in object.values() {
+                    self.collect_value(child, forward)?;
+                }
+            }
+            Value::Array(values) => {
+                for child in values {
+                    self.collect_value(child, forward)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn collect_prefixed(&mut self, value: &Value, forward: bool) -> Result<(), StoreError> {
+        let Some(id) = value.get("thought_id").and_then(Value::as_str) else {
+            return Ok(());
+        };
+        for prefix in ["before", "after", "expected"] {
+            if let (Some(content), Some(annotations)) = (
+                value
+                    .get(format!("{prefix}_content"))
+                    .and_then(Value::as_str),
+                value.get(format!("{prefix}_annotations")),
+            ) {
+                self.register_version(id, content, annotations, forward && prefix == "after")?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn link_payload(&mut self, value: &Value) -> Result<(), StoreError> {
+        self.scope = serde_json::to_string(value).map_err(corrupt)?;
+        if value.get("before_annotations").is_some() {
+            let before = self.prefixed(value, "before")?;
+            let after = self.prefixed(value, "after")?;
+            self.link(&before, &after);
+        } else if matches!(
+            value.get("kind").and_then(Value::as_str),
+            Some("split" | "extract" | "merge")
+        ) {
+            let forward = value
+                .get("forward")
+                .ok_or_else(|| corrupt("missing forward mutation"))?;
+            let mut sources = Vec::new();
+            let mut destinations = Vec::new();
+            self.transform_sides(forward, &mut sources, &mut destinations)?;
+            sources.sort_by_key(|(position, _)| *position);
+            let sources = sources
+                .into_iter()
+                .flat_map(|(_, nodes)| nodes)
+                .collect::<Vec<_>>();
+            self.link(&sources, &destinations);
+        }
+        Ok(())
+    }
+
+    fn transform_sides(
+        &mut self,
+        value: &Value,
+        sources: &mut Vec<(u64, Vec<usize>)>,
+        destinations: &mut Vec<usize>,
+    ) -> Result<(), StoreError> {
+        match value.get("mutation").and_then(Value::as_str) {
+            Some("batch") => {
+                for child in value["mutations"]
+                    .as_array()
+                    .ok_or_else(|| corrupt("invalid batch"))?
+                {
+                    self.transform_sides(child, sources, destinations)?;
+                }
+            }
+            Some("replace_content") => {
+                sources.push((0, self.prefixed(value, "before")?));
+                destinations.extend(self.prefixed(value, "after")?);
+            }
+            Some("set_deletion_exact") => {
+                sources.push((
+                    value["expected_position"]
+                        .as_u64()
+                        .ok_or_else(|| corrupt("invalid position"))?,
+                    self.prefixed(value, "expected")?,
+                ));
+            }
+            Some("add_thought") => {
+                let thought = &value["thought"];
+                destinations.extend(self.register(
+                    string(thought, "id")?,
+                    string(thought, "content")?,
+                    &thought["annotations"],
+                )?);
+            }
+            _ => return Err(corrupt("invalid transformation mutation")),
+        }
+        Ok(())
+    }
+
+    fn prefixed(&mut self, value: &Value, prefix: &str) -> Result<Vec<usize>, StoreError> {
+        self.register(
+            string(value, "thought_id")?,
+            string(value, &format!("{prefix}_content"))?,
+            &value[format!("{prefix}_annotations")],
+        )
+    }
+
+    fn root(&self, mut node: usize) -> usize {
+        while self.nodes[node].parent != node {
+            node = self.nodes[node].parent;
+        }
+        node
+    }
+
+    fn link(&mut self, sources: &[usize], destinations: &[usize]) {
+        let mut used = BTreeSet::new();
+        for &source in sources {
+            let Some(&destination) = destinations.iter().find(|&&destination| {
+                !used.contains(&destination)
+                    && self.nodes[source].signature == self.nodes[destination].signature
+            }) else {
+                continue;
+            };
+            used.insert(destination);
+            let left = self.root(source);
+            let right = self.root(destination);
+            if left == right
+                || !self.nodes[left]
+                    .snapshots
+                    .is_disjoint(&self.nodes[right].snapshots)
+            {
+                continue;
+            }
+            let snapshots = self.nodes[right].snapshots.clone();
+            self.nodes[left].snapshots.extend(snapshots);
+            self.nodes[right].parent = left;
+        }
+    }
+
+    pub(super) fn assign(
+        &mut self,
+        id: &str,
+        content: &str,
+        annotations: &mut Value,
+    ) -> Result<(), StoreError> {
+        let nodes = self.register(id, content, annotations)?;
+        let mut nodes = nodes.into_iter();
+        for annotation in annotations
+            .as_array_mut()
+            .ok_or_else(|| corrupt("invalid annotation array"))?
+        {
+            if annotation["kind"]["kind"] != "attachment" {
+                continue;
+            }
+            let root = self.root(nodes.next().ok_or_else(|| corrupt("missing occurrence"))?);
+            let ordinal = self.ordinal(root)?;
+            annotation["kind"]["ordinal"] = Value::from(ordinal);
+        }
+        Ok(())
+    }
+
+    fn ordinal(&mut self, root: usize) -> Result<u64, StoreError> {
+        if let Some(ordinal) = self.nodes[root].ordinal {
+            return Ok(ordinal);
+        }
+        let image = self.nodes[root].image;
+        let next = if image {
+            self.counters.image()
+        } else {
+            self.counters.file()
+        }
+        .checked_add(1)
+        .ok_or_else(|| corrupt("ordinal overflow"))?;
+        self.counters = AttachmentCounters::new(
+            if image { next } else { self.counters.image() },
+            if image { self.counters.file() } else { next },
+        )
+        .map_err(corrupt)?;
+        self.nodes[root].ordinal = Some(next);
+        Ok(next)
+    }
+
+    fn assign_prefixed(&mut self, value: &mut Value) -> Result<(), StoreError> {
+        let Some(id) = value
+            .get("thought_id")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        else {
+            return Ok(());
+        };
+        for prefix in ["before", "after", "expected"] {
+            if let Some(content) = value
+                .get(format!("{prefix}_content"))
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+            {
+                self.assign(&id, &content, &mut value[format!("{prefix}_annotations")])?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn assign_payload(&mut self, value: &mut Value) -> Result<(), StoreError> {
+        self.scope = serde_json::to_string(value).map_err(corrupt)?;
+        self.assign_value(value)
+    }
+
+    fn assign_value(&mut self, value: &mut Value) -> Result<(), StoreError> {
+        if value.get("annotations").is_some()
+            && value.get("content").is_some()
+            && value.get("id").is_some()
+        {
+            let id = string(value, "id")?.to_owned();
+            let content = string(value, "content")?.to_owned();
+            self.assign(&id, &content, &mut value["annotations"])?;
+            return Ok(());
+        }
+        self.assign_prefixed(value)?;
+        match value {
+            Value::Object(object) => {
+                for child in object.values_mut() {
+                    self.assign_value(child)?;
+                }
+            }
+            Value::Array(values) => {
+                for child in values {
+                    self.assign_value(child)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(super) const fn counters(&self) -> AttachmentCounters {
+        self.counters
+    }
+}
+
+fn snapshot_key(id: &str, content: &str, annotations: &Value) -> Result<String, StoreError> {
+    serde_json::to_string(&(id, content, annotations)).map_err(corrupt)
+}
+
+fn string<'a>(value: &'a Value, key: &str) -> Result<&'a str, StoreError> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| corrupt(format!("missing {key}")))
+}
+
+fn corrupt(error: impl std::fmt::Display) -> StoreError {
+    StoreError::Corrupt(error.to_string())
+}

--- a/src/adapters/sqlite/attachment_numbering.rs
+++ b/src/adapters/sqlite/attachment_numbering.rs
@@ -1,0 +1,148 @@
+//! Transactional attachment high-water marks and introducing-mutation validation.
+
+use rusqlite::{Connection, params};
+
+use crate::{
+    domain::{
+        AttachmentCounters, ContentAnnotation, ContentAnnotationKind, SessionBoard, SessionId,
+    },
+    ports::store::StoreError,
+};
+
+use super::support::map_sql_error;
+
+pub(super) fn load(
+    connection: &Connection,
+    session: SessionId,
+) -> Result<AttachmentCounters, StoreError> {
+    let (image, file): (i64, i64) = connection
+        .query_row(
+            "SELECT attachment_image_high, attachment_file_high FROM sessions WHERE id = ?1",
+            [session.database_bytes().as_slice()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(map_sql_error)?;
+    AttachmentCounters::new(
+        u64::try_from(image).map_err(corrupt)?,
+        u64::try_from(file).map_err(corrupt)?,
+    )
+    .map_err(corrupt)
+}
+
+pub(super) fn restore(connection: &Connection, board: &mut SessionBoard) -> Result<(), StoreError> {
+    board
+        .restore_attachment_counters(load(connection, board.session.id)?)
+        .map_err(corrupt)
+}
+
+pub(super) fn persist(
+    connection: &Connection,
+    session: SessionId,
+    counters: AttachmentCounters,
+) -> Result<(), StoreError> {
+    connection
+        .execute(
+            "UPDATE sessions SET attachment_image_high = max(attachment_image_high, ?2),
+         attachment_file_high = max(attachment_file_high, ?3) WHERE id = ?1",
+            params![
+                session.database_bytes().as_slice(),
+                i64::try_from(counters.image()).map_err(corrupt)?,
+                i64::try_from(counters.file()).map_err(corrupt)?
+            ],
+        )
+        .map_err(map_sql_error)?;
+    Ok(())
+}
+
+pub(super) fn revision(
+    connection: &Connection,
+    revision: &crate::domain::ThoughtRevision,
+) -> Result<(), StoreError> {
+    let mut counters = load(connection, revision.session_id)?;
+    for annotation in &revision.after_annotations {
+        let ContentAnnotationKind::Attachment { image, ordinal, .. } = &annotation.kind else {
+            continue;
+        };
+        let ordinal = ordinal.ok_or_else(|| corrupt("unassigned durable attachment"))?;
+        let retained = revision.before_annotations.iter().any(|before| matches!(
+            &before.kind, ContentAnnotationKind::Attachment { image: old_image, ordinal: old, .. }
+            if old_image == image && *old == Some(ordinal)
+        ));
+        if !retained
+            && ordinal.get()
+                <= if *image {
+                    counters.image()
+                } else {
+                    counters.file()
+                }
+        {
+            return Err(StoreError::Conflict(
+                "attachment ordinal was already allocated".to_owned(),
+            ));
+        }
+    }
+    let mut board = super::load::load_board(connection, revision.session_id)?;
+    let thought = board
+        .thought_mut(revision.thought_id)
+        .ok_or_else(|| corrupt("missing revision thought"))?;
+    thought.content.clone_from(&revision.after_content);
+    thought.annotations.clone_from(&revision.after_annotations);
+    board.validate().map_err(corrupt)?;
+    counters
+        .observe(&revision.after_annotations)
+        .map_err(corrupt)?;
+    persist(connection, revision.session_id, counters)
+}
+
+pub(super) fn validate_new(
+    counters: AttachmentCounters,
+    annotations: &[ContentAnnotation],
+) -> Result<(), StoreError> {
+    for annotation in annotations {
+        if let ContentAnnotationKind::Attachment { image, ordinal, .. } = &annotation.kind {
+            let ordinal = ordinal.ok_or_else(|| corrupt("unassigned durable attachment"))?;
+            if ordinal.get()
+                <= if *image {
+                    counters.image()
+                } else {
+                    counters.file()
+                }
+            {
+                return Err(StoreError::Conflict(
+                    "attachment ordinal was already allocated".to_owned(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn validate_creation(
+    board: &SessionBoard,
+    operation: &crate::domain::BoardOperation,
+) -> Result<(), StoreError> {
+    use crate::domain::{BoardMutation, BoardOperationKind};
+    fn visit(counters: AttachmentCounters, mutation: &BoardMutation) -> Result<(), StoreError> {
+        match mutation {
+            BoardMutation::AddThought { thought } => validate_new(counters, &thought.annotations),
+            BoardMutation::Batch { mutations } => {
+                for mutation in mutations {
+                    visit(counters, mutation)?;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+    if !matches!(
+        operation.kind,
+        BoardOperationKind::Create | BoardOperationKind::Duplicate
+    ) {
+        return Ok(());
+    }
+    visit(board.attachment_counters(), &operation.forward)
+}
+
+fn corrupt(error: impl std::fmt::Display) -> StoreError {
+    StoreError::Corrupt(error.to_string())
+}

--- a/src/adapters/sqlite/board_commit.rs
+++ b/src/adapters/sqlite/board_commit.rs
@@ -126,6 +126,7 @@ pub(super) fn commit_board(
     }
     require_next_sequence(transaction, operation.session_id, operation.sequence)?;
     let mut board = load_board(transaction, operation.session_id)?;
+    super::attachment_numbering::validate_creation(&board, operation)?;
     board
         .apply_mutation(&operation.forward, operation.created_at)
         .map_err(|error| StoreError::Invariant(error.to_string()))?;
@@ -253,6 +254,7 @@ fn commit_revision(
     }
     require_next_sequence(transaction, revision.session_id, revision.sequence)?;
     let cursor = revision_cursor(transaction, revision)?;
+    super::attachment_numbering::revision(transaction, revision)?;
     truncate_conflicting_board_redo(transaction, revision.session_id, revision.thought_id)?;
     persist_revision(transaction, revision, cursor, &request_json)?;
     insert_receipt(

--- a/src/adapters/sqlite/config.rs
+++ b/src/adapters/sqlite/config.rs
@@ -1,0 +1,69 @@
+//! SQLite opening, migration and bounded retry configuration.
+
+use crate::{domain::Timestamp, ports::store::MigrationMode};
+use std::{path::PathBuf, time::Duration};
+
+/// Bounded SQLite contention policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RetryPolicy {
+    /// Busy timeout applied inside SQLite.
+    pub busy_timeout: Duration,
+    /// Total transaction attempts, including the initial attempt.
+    pub max_attempts: u32,
+    /// Base delay used by deterministic bounded jitter.
+    pub base_delay: Duration,
+    /// Per-process seed used to vary retries between competing processes.
+    pub jitter_seed: u64,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        let seed = u64::from(std::process::id())
+            ^ u64::try_from(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_or(0, |duration| duration.as_nanos()),
+            )
+            .unwrap_or(u64::MAX);
+        Self {
+            busy_timeout: Duration::from_millis(250),
+            max_attempts: 4,
+            base_delay: Duration::from_millis(8),
+            jitter_seed: seed,
+        }
+    }
+}
+
+/// SQLite opening and migration configuration.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StoreConfig {
+    /// Canonical database path.
+    pub database_path: PathBuf,
+    /// Directory retaining pre-migration backups.
+    pub backup_dir: PathBuf,
+    /// Whether the caller holds exclusive migration authority.
+    pub migration_mode: MigrationMode,
+    /// Timestamp recorded for migrations and backup names.
+    pub migration_time: Timestamp,
+    /// Bounded contention behavior.
+    pub retry: RetryPolicy,
+}
+
+impl StoreConfig {
+    /// Construct configuration with the production retry policy.
+    #[must_use]
+    pub fn new(
+        database_path: PathBuf,
+        backup_dir: PathBuf,
+        migration_mode: MigrationMode,
+        migration_time: Timestamp,
+    ) -> Self {
+        Self {
+            database_path,
+            backup_dir,
+            migration_mode,
+            migration_time,
+            retry: RetryPolicy::default(),
+        }
+    }
+}

--- a/src/adapters/sqlite/history_commit.rs
+++ b/src/adapters/sqlite/history_commit.rs
@@ -384,6 +384,11 @@ pub(super) fn persist_board(
     transaction: &Transaction<'_>,
     board: &SessionBoard,
 ) -> Result<(), StoreError> {
+    super::attachment_numbering::persist(
+        transaction,
+        board.session.id,
+        board.attachment_counters(),
+    )?;
     let maximum: Option<i64> = transaction
         .query_row(
             "SELECT max(position) FROM thoughts WHERE session_id = ?1 AND deleted_at IS NULL",

--- a/src/adapters/sqlite/load.rs
+++ b/src/adapters/sqlite/load.rs
@@ -22,8 +22,9 @@ pub(super) fn load_snapshot(
 ) -> Result<SessionSnapshot, StoreError> {
     let session = load_session_record(connection, session_id)?;
     let thoughts = load_thoughts(connection, session_id)?;
-    let board = SessionBoard::new(session, thoughts)
-        .map_err(|error| StoreError::Invariant(error.to_string()))?;
+    let mut board =
+        SessionBoard::new(session, thoughts).map_err(|error| board_load_error(&error))?;
+    super::attachment_numbering::restore(connection, &mut board)?;
     let board_history_cursor: i64 = connection
         .query_row(
             "SELECT board_history_cursor FROM sessions WHERE id = ?1",
@@ -33,6 +34,28 @@ pub(super) fn load_snapshot(
         .map_err(map_sql_error)?;
     let board_operations = load_board_operations(connection, session_id)?;
     let revisions = load_revisions(connection, session_id)?;
+    let mut counters = board.attachment_counters();
+    for operation in &board_operations {
+        counters
+            .observe_mutation(&operation.forward)
+            .map_err(|error| StoreError::Corrupt(error.to_string()))?;
+        counters
+            .observe_mutation(&operation.inverse)
+            .map_err(|error| StoreError::Corrupt(error.to_string()))?;
+    }
+    for revision in &revisions {
+        counters
+            .observe(&revision.before_annotations)
+            .map_err(|error| StoreError::Corrupt(error.to_string()))?;
+        counters
+            .observe(&revision.after_annotations)
+            .map_err(|error| StoreError::Corrupt(error.to_string()))?;
+    }
+    if counters != board.attachment_counters() {
+        return Err(StoreError::Corrupt(
+            "attachment counters precede retained history".to_owned(),
+        ));
+    }
     let editor_history_cursors = load_editor_cursors(connection, session_id)?;
     let integration_context = load_integration_context(connection, session_id)?;
     let cursor = i64_to_usize(board_history_cursor)?;
@@ -67,11 +90,13 @@ pub(super) fn load_board(
     connection: &Connection,
     session_id: SessionId,
 ) -> Result<SessionBoard, StoreError> {
-    SessionBoard::new(
+    let mut board = SessionBoard::new(
         load_session_record(connection, session_id)?,
         load_thoughts(connection, session_id)?,
     )
-    .map_err(|error| StoreError::Invariant(error.to_string()))
+    .map_err(|error| board_load_error(&error))?;
+    super::attachment_numbering::restore(connection, &mut board)?;
+    Ok(board)
 }
 
 pub(super) fn load_session_record(
@@ -316,4 +341,13 @@ pub(super) fn load_integration_context(
             serde_json::from_str(&payload).map_err(|error| StoreError::Corrupt(error.to_string()))
         })
         .transpose()
+}
+
+fn board_load_error(error: &crate::domain::DomainError) -> StoreError {
+    match error {
+        crate::domain::DomainError::InvalidContentAnnotation => {
+            StoreError::Corrupt(error.to_string())
+        }
+        _ => StoreError::Invariant(error.to_string()),
+    }
 }

--- a/src/adapters/sqlite/migration.rs
+++ b/src/adapters/sqlite/migration.rs
@@ -18,6 +18,7 @@ use super::{
     schema::{
         MIGRATION_1, MIGRATION_2, MIGRATION_3, MIGRATION_4, MIGRATION_5, MIGRATION_6, MIGRATION_7,
         MIGRATION_8, MIGRATION_9, MIGRATION_10, MIGRATION_11, MIGRATION_12, MIGRATION_13,
+        MIGRATION_14,
     },
     support::{
         create_private_dir, map_sql_error, set_private_file_permissions, set_private_open_mode,
@@ -111,13 +112,14 @@ fn apply_migrations(connection: &Connection, found: u32) -> Result<(), StoreErro
         MIGRATION_11,
         MIGRATION_12,
         MIGRATION_13,
+        MIGRATION_14,
     ];
     let first = usize::try_from(found - 1)
         .map_err(|_| StoreError::Corrupt("invalid schema version".to_owned()))?;
     for migration in &forward[first..] {
         connection.execute_batch(migration).map_err(map_sql_error)?;
     }
-    Ok(())
+    super::attachment_migration::migrate(connection)
 }
 
 pub(super) fn create_backup(

--- a/src/adapters/sqlite/mod.rs
+++ b/src/adapters/sqlite/mod.rs
@@ -1,8 +1,12 @@
 //! SQLite persistence adapter.
 
+mod attachment_migration;
+mod attachment_numbering;
 mod board_commit;
 mod capture;
 mod compaction;
+mod config;
+pub use config::{RetryPolicy, StoreConfig};
 mod doctor;
 mod history_commit;
 mod load;
@@ -21,7 +25,7 @@ mod tests;
 
 pub use doctor::{SqliteHealth, inspect_read_only_snapshot};
 
-use std::{path::PathBuf, thread, time::Duration};
+use std::{path::PathBuf, thread};
 
 use rusqlite::{
     Connection, OpenFlags, OptionalExtension, Transaction, TransactionBehavior, params,
@@ -49,71 +53,6 @@ use self::{
         set_private_file_permissions, set_sqlite_permissions,
     },
 };
-
-/// Bounded SQLite contention policy.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct RetryPolicy {
-    /// Busy timeout applied inside SQLite.
-    pub busy_timeout: Duration,
-    /// Total transaction attempts, including the initial attempt.
-    pub max_attempts: u32,
-    /// Base delay used by deterministic bounded jitter.
-    pub base_delay: Duration,
-    /// Per-process seed used to vary retries between competing processes.
-    pub jitter_seed: u64,
-}
-
-impl Default for RetryPolicy {
-    fn default() -> Self {
-        let seed = u64::from(std::process::id())
-            ^ u64::try_from(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_or(0, |duration| duration.as_nanos()),
-            )
-            .unwrap_or(u64::MAX);
-        Self {
-            busy_timeout: Duration::from_millis(250),
-            max_attempts: 4,
-            base_delay: Duration::from_millis(8),
-            jitter_seed: seed,
-        }
-    }
-}
-
-/// SQLite opening and migration configuration.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct StoreConfig {
-    /// Canonical database path.
-    pub database_path: PathBuf,
-    /// Directory retaining pre-migration backups.
-    pub backup_dir: PathBuf,
-    /// Whether the caller holds exclusive migration authority.
-    pub migration_mode: MigrationMode,
-    /// Timestamp recorded for migrations and backup names.
-    pub migration_time: Timestamp,
-    /// Bounded contention behavior.
-    pub retry: RetryPolicy,
-}
-
-impl StoreConfig {
-    /// Construct configuration with the production retry policy.
-    #[must_use]
-    pub fn new(
-        database_path: PathBuf,
-        backup_dir: PathBuf,
-        migration_mode: MigrationMode,
-        migration_time: Timestamp,
-    ) -> Self {
-        Self {
-            database_path,
-            backup_dir,
-            migration_mode,
-            migration_time,
-            retry: RetryPolicy::default(),
-        }
-    }
-}
 
 /// Bundled SQLite store.
 pub struct SqliteStore {

--- a/src/adapters/sqlite/schema.rs
+++ b/src/adapters/sqlite/schema.rs
@@ -28,6 +28,8 @@ CREATE TABLE sessions (
     last_active_at INTEGER NOT NULL,
     last_durable_sequence INTEGER NOT NULL DEFAULT 0 CHECK (last_durable_sequence >= 0),
     board_history_cursor INTEGER NOT NULL DEFAULT 0 CHECK (board_history_cursor >= 0),
+    attachment_image_high INTEGER NOT NULL DEFAULT 0 CHECK (attachment_image_high >= 0),
+    attachment_file_high INTEGER NOT NULL DEFAULT 0 CHECK (attachment_file_high >= 0),
     deleted_at INTEGER
 ) STRICT;
 
@@ -164,6 +166,7 @@ INSERT INTO migration_history(version, applied_at) VALUES (10, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (11, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (12, 0);
 INSERT INTO migration_history(version, applied_at) VALUES (13, 0);
+INSERT INTO migration_history(version, applied_at) VALUES (14, 0);
 ";
 
 pub(super) const MIGRATION_2: &str = r"
@@ -355,4 +358,10 @@ ON submission_attempt_items(thought_id)
 WHERE active = 1;
 UPDATE schema_meta SET schema_version = 13, storage_protocol = 12;
 INSERT INTO migration_history(version, applied_at) VALUES (13, 0);
+";
+
+pub(super) const MIGRATION_14: &str = r"
+ALTER TABLE sessions ADD COLUMN attachment_image_high INTEGER NOT NULL DEFAULT 0 CHECK (attachment_image_high >= 0);
+ALTER TABLE sessions ADD COLUMN attachment_file_high INTEGER NOT NULL DEFAULT 0 CHECK (attachment_file_high >= 0);
+INSERT INTO migration_history(version, applied_at) VALUES (14, 0);
 ";

--- a/src/adapters/terminal/accessibility_lane.rs
+++ b/src/adapters/terminal/accessibility_lane.rs
@@ -266,6 +266,7 @@ mod tests {
             id,
             purpose: AttachmentCheckPurpose::Background,
             checks: vec![AttachmentCheckKey {
+                ordinal: 1_u64.try_into().expect("fixture ordinal"),
                 thought_id: "tht_06g30t7dv5qv55n1ppn3clis3k"
                     .parse()
                     .expect("thought id"),

--- a/src/adapters/terminal/external/tests.rs
+++ b/src/adapters/terminal/external/tests.rs
@@ -158,6 +158,7 @@ fn verified_clipboard_metadata_preserves_every_supported_kind_on_paste() {
             start: ranges[0].start,
             end: ranges[0].end,
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "界.png".to_owned(),
             },

--- a/src/adapters/terminal/path_import.rs
+++ b/src/adapters/terminal/path_import.rs
@@ -224,6 +224,7 @@ mod tests {
         assert!(matches!(
             &payload.annotations[0].kind,
             ContentAnnotationKind::Attachment {
+                ordinal: None,
                 image: true,
                 display_name,
             } if display_name == "Bild (18) [final] & notes #1.png"

--- a/src/application/attachments/keys.rs
+++ b/src/application/attachments/keys.rs
@@ -34,6 +34,7 @@ pub fn attachment_keys(thought: &Thought) -> Vec<AttachmentCheckKey> {
         .enumerate()
         .filter_map(|(annotation_index, annotation)| {
             let ContentAnnotationKind::Attachment {
+                ordinal,
                 image,
                 display_name,
             } = &annotation.kind
@@ -47,6 +48,7 @@ pub fn attachment_keys(thought: &Thought) -> Vec<AttachmentCheckKey> {
                 annotation_start: annotation.start,
                 annotation_end: annotation.end,
                 image: *image,
+                ordinal: (*ordinal)?,
                 display_name: display_name.clone(),
                 canonical_path: canonical_path.to_owned(),
                 content_revision: revision,
@@ -281,6 +283,7 @@ fn matching_index(
 fn same_attachment(left: &AttachmentCheckKey, right: &AttachmentCheckKey) -> bool {
     left.thought_id == right.thought_id
         && left.image == right.image
+        && left.ordinal == right.ordinal
         && left.display_name == right.display_name
         && left.canonical_path == right.canonical_path
 }

--- a/src/application/attachments/tests.rs
+++ b/src/application/attachments/tests.rs
@@ -139,6 +139,7 @@ fn exact_duplicate_match_is_reserved_before_shifted_semantic_migration() {
                 start: 0,
                 end: path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "duplicate.png".to_owned(),
                 },
@@ -155,6 +156,7 @@ fn exact_duplicate_match_is_reserved_before_shifted_semantic_migration() {
                 start: path.len() + 1,
                 end: path.len() * 2 + 1,
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "duplicate.png".to_owned(),
                 },
@@ -435,6 +437,12 @@ fn board_with_attachments(count: usize) -> (SessionBoard, Vec<crate::domain::Tho
                     start: 0,
                     end: path.len(),
                     kind: ContentAnnotationKind::Attachment {
+                        ordinal: Some(
+                            u64::try_from(index + 1)
+                                .expect("index")
+                                .try_into()
+                                .expect("fixture ordinal"),
+                        ),
                         image: true,
                         display_name: format!("Grüße-{index}.png"),
                     },

--- a/src/application/capture.rs
+++ b/src/application/capture.rs
@@ -40,6 +40,7 @@ pub fn prepare_capture(
         start: 0,
         end: path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: None,
             image: true,
             display_name,
         },
@@ -50,7 +51,9 @@ pub fn prepare_capture(
         .map(ThoughtPosition::new)
         .map_err(|_| ApplicationError::InvalidState)?;
     let mut thought = Thought::new(thought_id, state.board.session.id, content, position, at);
-    thought.set_annotations(vec![annotation])?;
+    let mut annotations = vec![annotation];
+    state.board.attachment_counters().assign(&mut annotations)?;
+    thought.set_annotations(annotations)?;
     let operation = BoardOperation {
         id: operation_id,
         session_id: state.board.session.id,
@@ -83,13 +86,27 @@ pub fn apply_capture(
     commit: &CaptureCommit,
     outcome: &CaptureCommitOutcome,
 ) -> ApplicationResult<Option<ThoughtId>> {
-    let CaptureCommitOutcome::Created { durable, capture } = outcome else {
-        return Ok(None);
+    let capture = match outcome {
+        CaptureCommitOutcome::Created { durable, capture } => {
+            if durable.sequence != commit.operation.sequence
+                || durable.identity
+                    != crate::ports::store::DurableIdentity::Operation(commit.operation.id)
+            {
+                return Err(ApplicationError::InvalidState);
+            }
+            capture
+        }
+        CaptureCommitOutcome::AlreadyCaptured(capture) => {
+            if capture.operation_id != commit.operation.id {
+                return Ok(None);
+            }
+            if state.board.session.last_durable_sequence >= commit.operation.sequence {
+                return Ok(None);
+            }
+            capture
+        }
     };
-    if durable.sequence != commit.operation.sequence
-        || durable.identity != crate::ports::store::DurableIdentity::Operation(commit.operation.id)
-        || capture.source != commit.source
-    {
+    if capture.source != commit.source || capture.session_id != commit.operation.session_id {
         return Err(ApplicationError::InvalidState);
     }
     let operation = &commit.operation;
@@ -97,6 +114,9 @@ pub fn apply_capture(
         BoardMutation::AddThought { thought } => thought.id,
         _ => return Err(ApplicationError::InvalidState),
     };
+    if capture.thought_id != thought_id {
+        return Err(ApplicationError::InvalidState);
+    }
     state.apply_durable_capture(operation)?;
     state.insertion_index = state.board.live_thoughts().len();
     Ok(Some(thought_id))

--- a/src/application/control.rs
+++ b/src/application/control.rs
@@ -143,7 +143,7 @@ fn matches_add(
             BoardMutation::AddThought { thought }
                 if thought.id == *thought_id
                     && thought.content == *content
-                    && thought.annotations == *annotations
+                    && same_creation_annotations(&thought.annotations, annotations)
                     && position.is_none_or(|value| {
                         u32::try_from(value).ok() == Some(thought.position.get())
                     })
@@ -284,3 +284,14 @@ fn matches_history(
 
 #[cfg(test)]
 mod tests;
+
+fn same_creation_annotations(
+    left: &[crate::domain::ContentAnnotation],
+    right: &[crate::domain::ContentAnnotation],
+) -> bool {
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    crate::domain::renew_attachment_occurrences(&mut left);
+    crate::domain::renew_attachment_occurrences(&mut right);
+    left == right
+}

--- a/src/application/mutations.rs
+++ b/src/application/mutations.rs
@@ -1,7 +1,9 @@
 //! Focused domain mutations used by the reducer router.
 
 pub(super) mod bulk;
+mod history;
 pub(super) mod transform;
+pub(super) use history::history_move;
 
 use super::error::{ApplicationError, ApplicationResult, FailureCode};
 use super::{mutations::bulk::delete_thoughts, prompt::MULTI_THOUGHT_SEPARATOR};
@@ -13,8 +15,7 @@ use crate::{
     domain::{
         BoardMutation, BoardOperation, BoardOperationKind, ContentAnnotation, DomainError,
         OperationId, RequestId, RevisionId, TextPosition, Thought, ThoughtId, ThoughtPosition,
-        ThoughtPresentation, ThoughtRevision, Timestamp, UndoScope, merge_annotations,
-        validate_annotations,
+        ThoughtPresentation, ThoughtRevision, Timestamp, merge_annotations, validate_annotations,
     },
 };
 
@@ -29,6 +30,9 @@ pub(super) fn create_thought(
 ) -> ApplicationResult<Vec<Effect>> {
     let sequence = state.next_sequence()?;
     validate_annotations(&content, &annotations)?;
+    let mut annotations = annotations;
+    crate::domain::renew_attachment_occurrences(&mut annotations);
+    state.board.attachment_counters().assign(&mut annotations)?;
     let mut thought = Thought::new(
         thought_id,
         state.board.session.id,
@@ -83,6 +87,22 @@ pub(super) fn edit_thought(
     if before_content == after_content && before_annotations == after_annotations {
         return Ok(Vec::new());
     }
+    let mut after_annotations = after_annotations;
+    for annotation in &mut after_annotations {
+        if matches!(
+            annotation.kind,
+            crate::domain::ContentAnnotationKind::Attachment { .. }
+        ) && !before_annotations
+            .iter()
+            .any(|before| before.kind == annotation.kind)
+        {
+            crate::domain::renew_attachment_occurrences(std::slice::from_mut(annotation));
+        }
+    }
+    state
+        .board
+        .attachment_counters()
+        .assign(&mut after_annotations)?;
     let sequence = state.next_sequence()?;
     let revision = ThoughtRevision {
         id: revision_id,
@@ -104,6 +124,8 @@ pub(super) fn edit_thought(
     thought.content = after_content;
     thought.annotations = after_annotations;
     thought.updated_at = at;
+    board.observe_attachments()?;
+    board.validate()?;
     state.board = board;
     state.truncate_conflicting_board_redo(thought_id);
     let history = state.editor_histories.entry(thought_id).or_default();
@@ -342,152 +364,6 @@ pub(super) fn set_presentation(
     };
     state.record_board_operation(&operation)?;
     Ok(vec![Effect::CommitBoardOperation(operation)])
-}
-
-pub(super) fn history_move(
-    state: &mut AppState,
-    operation_id: OperationId,
-    scope: UndoScope,
-    at: Timestamp,
-    undo: bool,
-) -> ApplicationResult<Vec<Effect>> {
-    let sequence = state.next_sequence()?;
-    match scope {
-        UndoScope::Board => move_board_history(state, at, undo)?,
-        UndoScope::Editor { thought_id } => move_editor_history(state, thought_id, at, undo)?,
-    }
-    state.track_pending(sequence);
-    Ok(vec![Effect::CommitHistoryMove {
-        operation_id,
-        session_id: state.board.session.id,
-        scope,
-        undo,
-        sequence,
-        at,
-    }])
-}
-
-fn move_board_history(state: &mut AppState, at: Timestamp, undo: bool) -> ApplicationResult<()> {
-    let operation = if undo {
-        state
-            .board_history_cursor
-            .checked_sub(1)
-            .and_then(|index| state.board_history.get(index))
-    } else {
-        state.board_history.get(state.board_history_cursor)
-    }
-    .cloned()
-    .ok_or(ApplicationError::InvalidState)?;
-    let mutation = if undo {
-        &operation.inverse
-    } else {
-        &operation.forward
-    };
-    let focused_before = state.focused_thought;
-    let transform_source = undo.then(|| transform_source(&operation)).flatten();
-    let mut board = state.board.clone();
-    board.apply_mutation(mutation, at)?;
-    state.board = board;
-    state.board_history_cursor =
-        state
-            .board_history_cursor
-            .saturating_add_signed(if undo { -1 } else { 1 });
-    let focus_was_removed = focused_before.is_some_and(|thought_id| {
-        state
-            .board
-            .thought(thought_id)
-            .is_none_or(|thought| !thought.is_live())
-    });
-    state.keep_focus_valid();
-    if focus_was_removed
-        && let Some(thought_id) = transform_source
-        && state
-            .board
-            .thought(thought_id)
-            .is_some_and(Thought::is_live)
-    {
-        state.focused_thought = Some(thought_id);
-    }
-    Ok(())
-}
-
-fn transform_source(operation: &BoardOperation) -> Option<ThoughtId> {
-    if !matches!(
-        operation.kind,
-        BoardOperationKind::Split | BoardOperationKind::Extract
-    ) {
-        return None;
-    }
-    replaced_thought(&operation.forward)
-}
-
-fn replaced_thought(mutation: &BoardMutation) -> Option<ThoughtId> {
-    match mutation {
-        BoardMutation::Batch { mutations } => mutations.iter().find_map(replaced_thought),
-        BoardMutation::ReplaceContent { thought_id, .. } => Some(*thought_id),
-        BoardMutation::AddThought { .. }
-        | BoardMutation::SetDeletion { .. }
-        | BoardMutation::SetDeletionExact { .. }
-        | BoardMutation::MoveThought { .. }
-        | BoardMutation::SetPresentation { .. }
-        | BoardMutation::LegacySetCollapsed { .. } => None,
-    }
-}
-
-fn move_editor_history(
-    state: &mut AppState,
-    thought_id: ThoughtId,
-    at: Timestamp,
-    undo: bool,
-) -> ApplicationResult<()> {
-    let history = state
-        .editor_histories
-        .get(&thought_id)
-        .ok_or(ApplicationError::InvalidState)?;
-    let revision = if undo {
-        history
-            .cursor
-            .checked_sub(1)
-            .and_then(|index| history.revisions.get(index))
-    } else {
-        history.revisions.get(history.cursor)
-    }
-    .cloned()
-    .ok_or(ApplicationError::InvalidState)?;
-    let (expected, expected_annotations, content, annotations) = if undo {
-        (
-            &revision.after_content,
-            &revision.after_annotations,
-            revision.before_content,
-            revision.before_annotations,
-        )
-    } else {
-        (
-            &revision.before_content,
-            &revision.before_annotations,
-            revision.after_content,
-            revision.after_annotations,
-        )
-    };
-    let current = state.live_thought(thought_id)?;
-    if &current.content != expected || &current.annotations != expected_annotations {
-        return Err(ApplicationError::RevisionConflict(thought_id));
-    }
-    let thought = state
-        .board
-        .thought_mut(thought_id)
-        .ok_or(ApplicationError::ThoughtNotFound(thought_id))?;
-    thought.content = content;
-    thought.annotations = annotations;
-    thought.updated_at = at;
-    let history = state
-        .editor_histories
-        .get_mut(&thought_id)
-        .ok_or(ApplicationError::InvalidState)?;
-    history.cursor = history
-        .cursor
-        .saturating_add_signed(if undo { -1 } else { 1 });
-    Ok(())
 }
 
 fn position_u32(value: usize) -> Result<u32, ApplicationError> {

--- a/src/application/mutations/bulk.rs
+++ b/src/application/mutations/bulk.rs
@@ -146,12 +146,15 @@ pub(in crate::application) fn duplicate_thoughts(
     )
     .map_err(|_| ApplicationError::InvalidState)?
     .saturating_add(1);
+    let mut counters = state.board.attachment_counters();
     let duplicates = selected
         .iter()
         .zip(duplicate_ids)
         .enumerate()
         .map(|(offset, (source, duplicate_id))| {
             let mut duplicate = source.clone();
+            crate::domain::renew_attachment_occurrences(&mut duplicate.annotations);
+            counters.assign(&mut duplicate.annotations)?;
             duplicate.id = *duplicate_id;
             duplicate.position = ThoughtPosition::new(super::position_u32(insertion + offset)?);
             duplicate.created_at = at;

--- a/src/application/mutations/history.rs
+++ b/src/application/mutations/history.rs
@@ -1,0 +1,153 @@
+//! Exact board and editor history replay without allocating attachment identities.
+
+use super::{
+    AppState, ApplicationError, ApplicationResult, BoardMutation, BoardOperation,
+    BoardOperationKind, Effect, OperationId, ThoughtId, Timestamp,
+};
+use crate::domain::{Thought, UndoScope};
+
+pub(in crate::application) fn history_move(
+    state: &mut AppState,
+    operation_id: OperationId,
+    scope: UndoScope,
+    at: Timestamp,
+    undo: bool,
+) -> ApplicationResult<Vec<Effect>> {
+    let sequence = state.next_sequence()?;
+    match scope {
+        UndoScope::Board => move_board_history(state, at, undo)?,
+        UndoScope::Editor { thought_id } => move_editor_history(state, thought_id, at, undo)?,
+    }
+    state.track_pending(sequence);
+    Ok(vec![Effect::CommitHistoryMove {
+        operation_id,
+        session_id: state.board.session.id,
+        scope,
+        undo,
+        sequence,
+        at,
+    }])
+}
+
+fn move_board_history(state: &mut AppState, at: Timestamp, undo: bool) -> ApplicationResult<()> {
+    let operation = if undo {
+        state
+            .board_history_cursor
+            .checked_sub(1)
+            .and_then(|index| state.board_history.get(index))
+    } else {
+        state.board_history.get(state.board_history_cursor)
+    }
+    .cloned()
+    .ok_or(ApplicationError::InvalidState)?;
+    let mutation = if undo {
+        &operation.inverse
+    } else {
+        &operation.forward
+    };
+    let focused_before = state.focused_thought;
+    let transform_source = undo.then(|| transform_source(&operation)).flatten();
+    let mut board = state.board.clone();
+    board.apply_mutation(mutation, at)?;
+    state.board = board;
+    state.board_history_cursor =
+        state
+            .board_history_cursor
+            .saturating_add_signed(if undo { -1 } else { 1 });
+    let focus_was_removed = focused_before.is_some_and(|thought_id| {
+        state
+            .board
+            .thought(thought_id)
+            .is_none_or(|thought| !thought.is_live())
+    });
+    state.keep_focus_valid();
+    if focus_was_removed
+        && let Some(thought_id) = transform_source
+        && state
+            .board
+            .thought(thought_id)
+            .is_some_and(Thought::is_live)
+    {
+        state.focused_thought = Some(thought_id);
+    }
+    Ok(())
+}
+
+fn transform_source(operation: &BoardOperation) -> Option<ThoughtId> {
+    if !matches!(
+        operation.kind,
+        BoardOperationKind::Split | BoardOperationKind::Extract
+    ) {
+        return None;
+    }
+    replaced_thought(&operation.forward)
+}
+
+fn replaced_thought(mutation: &BoardMutation) -> Option<ThoughtId> {
+    match mutation {
+        BoardMutation::Batch { mutations } => mutations.iter().find_map(replaced_thought),
+        BoardMutation::ReplaceContent { thought_id, .. } => Some(*thought_id),
+        BoardMutation::AddThought { .. }
+        | BoardMutation::SetDeletion { .. }
+        | BoardMutation::SetDeletionExact { .. }
+        | BoardMutation::MoveThought { .. }
+        | BoardMutation::SetPresentation { .. }
+        | BoardMutation::LegacySetCollapsed { .. } => None,
+    }
+}
+
+fn move_editor_history(
+    state: &mut AppState,
+    thought_id: ThoughtId,
+    at: Timestamp,
+    undo: bool,
+) -> ApplicationResult<()> {
+    let history = state
+        .editor_histories
+        .get(&thought_id)
+        .ok_or(ApplicationError::InvalidState)?;
+    let revision = if undo {
+        history
+            .cursor
+            .checked_sub(1)
+            .and_then(|index| history.revisions.get(index))
+    } else {
+        history.revisions.get(history.cursor)
+    }
+    .cloned()
+    .ok_or(ApplicationError::InvalidState)?;
+    let (expected, expected_annotations, content, annotations) = if undo {
+        (
+            &revision.after_content,
+            &revision.after_annotations,
+            revision.before_content,
+            revision.before_annotations,
+        )
+    } else {
+        (
+            &revision.before_content,
+            &revision.before_annotations,
+            revision.after_content,
+            revision.after_annotations,
+        )
+    };
+    let current = state.live_thought(thought_id)?;
+    if &current.content != expected || &current.annotations != expected_annotations {
+        return Err(ApplicationError::RevisionConflict(thought_id));
+    }
+    let thought = state
+        .board
+        .thought_mut(thought_id)
+        .ok_or(ApplicationError::ThoughtNotFound(thought_id))?;
+    thought.content = content;
+    thought.annotations = annotations;
+    thought.updated_at = at;
+    let history = state
+        .editor_histories
+        .get_mut(&thought_id)
+        .ok_or(ApplicationError::InvalidState)?;
+    history.cursor = history
+        .cursor
+        .saturating_add_signed(if undo { -1 } else { 1 });
+    Ok(())
+}

--- a/src/application/rehydrate.rs
+++ b/src/application/rehydrate.rs
@@ -17,6 +17,18 @@ impl AppState {
     /// not belong to the board or a retained cursor is out of bounds.
     pub fn from_snapshot(snapshot: SessionSnapshot) -> ApplicationResult<Self> {
         let session_id = snapshot.board.session.id;
+        let mut counters = snapshot.board.attachment_counters();
+        for operation in &snapshot.board_operations {
+            counters.observe_mutation(&operation.forward)?;
+            counters.observe_mutation(&operation.inverse)?;
+        }
+        for revision in &snapshot.revisions {
+            counters.observe(&revision.before_annotations)?;
+            counters.observe(&revision.after_annotations)?;
+        }
+        if counters != snapshot.board.attachment_counters() {
+            return Err(ApplicationError::InvalidState);
+        }
         if snapshot.board_history_cursor > snapshot.board_operations.len()
             || snapshot
                 .board_operations

--- a/src/cli/execute/forwarding.rs
+++ b/src/cli/execute/forwarding.rs
@@ -368,6 +368,6 @@ mod tests {
             Some(4)
         );
         assert_eq!(sync_protocol(Some(7)).expect("current owner"), Some(7));
-        assert!(sync_protocol(Some(8)).is_err());
+        assert!(sync_protocol(Some(crate::ports::control::CONTROL_PROTOCOL_VERSION + 1)).is_err());
     }
 }

--- a/src/domain/annotation.rs
+++ b/src/domain/annotation.rs
@@ -65,6 +65,9 @@ pub struct ContentAnnotation {
 pub enum ContentAnnotationKind {
     /// One absolute local file path.
     Attachment {
+        /// Assigned occurrence identity; absent only in input awaiting destination allocation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ordinal: Option<super::AttachmentOrdinal>,
         /// Whether the file should receive image-specific presentation.
         image: bool,
         /// Safe basename shown instead of the complete path.
@@ -188,6 +191,7 @@ mod tests {
             start: 0,
             end: path.len(),
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "Grüße 🖼️.png".to_owned(),
             },

--- a/src/domain/annotation/ranges/tests.rs
+++ b/src/domain/annotation/ranges/tests.rs
@@ -17,6 +17,7 @@ fn attachment(start: usize, end: usize, display_name: &str) -> ContentAnnotation
         start,
         end,
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: std::path::Path::new(display_name)
                 .extension()
                 .is_some_and(|extension| extension.eq_ignore_ascii_case("png")),

--- a/src/domain/attachment_numbering.rs
+++ b/src/domain/attachment_numbering.rs
@@ -1,0 +1,232 @@
+//! Session-scoped attachment occurrence numbering, independent of text and filesystem state.
+
+use serde::{Deserialize, Serialize};
+
+use super::{ContentAnnotation, ContentAnnotationKind, DomainError};
+
+/// Positive durable ordinal within one session and attachment kind.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(try_from = "u64", into = "u64")]
+pub struct AttachmentOrdinal(u64);
+
+impl AttachmentOrdinal {
+    /// Read the assigned positive number.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for AttachmentOrdinal {
+    type Error = DomainError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value == 0 || value > i64::MAX as u64 {
+            return Err(DomainError::InvalidContentAnnotation);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl From<AttachmentOrdinal> for u64 {
+    fn from(value: AttachmentOrdinal) -> Self {
+        value.0
+    }
+}
+
+/// Monotonic high-water marks, retained independently of current content and undo cursors.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AttachmentCounters {
+    image: u64,
+    file: u64,
+}
+
+impl AttachmentCounters {
+    /// Observe every assigned snapshot in a retained mutation, including inverse-only state.
+    ///
+    /// # Errors
+    /// Rejects unassigned durable occurrences.
+    pub fn observe_mutation(&mut self, mutation: &super::BoardMutation) -> Result<(), DomainError> {
+        use super::BoardMutation;
+        match mutation {
+            BoardMutation::Batch { mutations } => {
+                for mutation in mutations {
+                    self.observe_mutation(mutation)?;
+                }
+            }
+            BoardMutation::AddThought { thought } => self.observe(&thought.annotations)?,
+            BoardMutation::ReplaceContent {
+                before_annotations,
+                after_annotations,
+                ..
+            } => {
+                self.observe(before_annotations)?;
+                self.observe(after_annotations)?;
+            }
+            BoardMutation::SetDeletionExact {
+                expected_annotations,
+                ..
+            } => self.observe(expected_annotations)?,
+            BoardMutation::SetDeletion { .. }
+            | BoardMutation::MoveThought { .. }
+            | BoardMutation::SetPresentation { .. }
+            | BoardMutation::LegacySetCollapsed { .. } => {}
+        }
+        Ok(())
+    }
+    /// Restore validated durable high-water marks. Zero means no allocation yet.
+    ///
+    /// # Errors
+    /// Rejects values beyond the durable integer range.
+    pub fn new(image: u64, file: u64) -> Result<Self, DomainError> {
+        if image > i64::MAX as u64 || file > i64::MAX as u64 {
+            return Err(DomainError::InvalidContentAnnotation);
+        }
+        Ok(Self { image, file })
+    }
+
+    /// Last allocated image ordinal, including deleted and dormant occurrences.
+    #[must_use]
+    pub const fn image(self) -> u64 {
+        self.image
+    }
+
+    /// Last allocated file ordinal, including deleted and dormant occurrences.
+    #[must_use]
+    pub const fn file(self) -> u64 {
+        self.file
+    }
+
+    fn counter_mut(&mut self, image: bool) -> &mut u64 {
+        if image {
+            &mut self.image
+        } else {
+            &mut self.file
+        }
+    }
+
+    /// Allocate each unassigned occurrence atomically in annotation order.
+    ///
+    /// # Errors
+    /// Returns an annotation error on sequence exhaustion without changing either argument.
+    pub fn assign(&mut self, annotations: &mut [ContentAnnotation]) -> Result<(), DomainError> {
+        let mut candidate = *self;
+        let mut assigned = annotations.to_vec();
+        for annotation in &mut assigned {
+            if let ContentAnnotationKind::Attachment { image, ordinal, .. } = &mut annotation.kind
+                && ordinal.is_none()
+            {
+                let counter = candidate.counter_mut(*image);
+                let next = counter
+                    .checked_add(1)
+                    .ok_or(DomainError::InvalidContentAnnotation)?;
+                *ordinal = Some(AttachmentOrdinal::try_from(next)?);
+                *counter = next;
+            }
+        }
+        annotations.clone_from_slice(&assigned);
+        *self = candidate;
+        Ok(())
+    }
+
+    /// Observe an already assigned snapshot without allocating or decreasing a counter.
+    ///
+    /// # Errors
+    /// Rejects an unassigned attachment in durable state.
+    pub fn observe(&mut self, annotations: &[ContentAnnotation]) -> Result<(), DomainError> {
+        for annotation in annotations {
+            if let ContentAnnotationKind::Attachment { image, ordinal, .. } = &annotation.kind {
+                let ordinal = ordinal.ok_or(DomainError::InvalidContentAnnotation)?.get();
+                let counter = self.counter_mut(*image);
+                *counter = (*counter).max(ordinal);
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn validate_unique(
+    annotations: &[ContentAnnotation],
+    identities: &mut std::collections::HashSet<(bool, AttachmentOrdinal)>,
+) -> Result<(), DomainError> {
+    for annotation in annotations {
+        let ContentAnnotationKind::Attachment { image, ordinal, .. } = &annotation.kind else {
+            continue;
+        };
+        let ordinal = ordinal.ok_or(DomainError::InvalidContentAnnotation)?;
+        if !identities.insert((*image, ordinal)) {
+            return Err(DomainError::InvalidContentAnnotation);
+        }
+    }
+    Ok(())
+}
+
+/// Mark copied input as new occurrences before destination allocation.
+pub fn renew_attachment_occurrences(annotations: &mut [ContentAnnotation]) {
+    for annotation in annotations {
+        if let ContentAnnotationKind::Attachment { ordinal, .. } = &mut annotation.kind {
+            *ordinal = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attachment(image: bool) -> ContentAnnotation {
+        ContentAnnotation {
+            start: 0,
+            end: 1,
+            kind: ContentAnnotationKind::Attachment {
+                ordinal: None,
+                image,
+                display_name: "asset".to_owned(),
+            },
+        }
+    }
+
+    #[test]
+    fn sequences_are_independent_and_retained_identity_never_reallocates() {
+        let mut counters = AttachmentCounters::default();
+        let mut annotations = vec![attachment(true), attachment(false), attachment(true)];
+        counters.assign(&mut annotations).expect("assign");
+        assert_eq!((counters.image(), counters.file()), (2, 1));
+        let saved = annotations.clone();
+        counters.assign(&mut annotations).expect("preserve");
+        assert_eq!(annotations, saved);
+        renew_attachment_occurrences(&mut annotations);
+        counters.assign(&mut annotations).expect("new occurrences");
+        assert_eq!((counters.image(), counters.file()), (4, 2));
+        assert_ne!(annotations, saved);
+    }
+
+    #[test]
+    fn overflow_rolls_back_the_complete_mixed_allocation() {
+        let mut counters = AttachmentCounters::new(i64::MAX as u64, 3).expect("counters");
+        let mut annotations = vec![attachment(false), attachment(true)];
+        let before = annotations.clone();
+        assert_eq!(
+            counters.assign(&mut annotations),
+            Err(DomainError::InvalidContentAnnotation)
+        );
+        assert_eq!(annotations, before);
+        assert_eq!(counters.file(), 3);
+    }
+
+    #[test]
+    fn durable_ordinal_decoding_rejects_zero_negative_fraction_and_overflow() {
+        for encoded in ["0", "-1", "1.5", "9223372036854775808", "null"] {
+            assert!(
+                serde_json::from_str::<AttachmentOrdinal>(encoded).is_err(),
+                "{encoded}"
+            );
+        }
+        assert_eq!(
+            serde_json::from_str::<AttachmentOrdinal>("9223372036854775807")
+                .expect("maximum")
+                .get(),
+            i64::MAX as u64
+        );
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,6 +1,7 @@
 //! Entities, value objects, identifiers, and invariants.
 
 mod annotation;
+mod attachment_numbering;
 mod identifiers;
 mod model;
 mod operations;
@@ -12,6 +13,9 @@ pub use annotation::{
     AnnotationBehavior, AnnotationTextChange, ContentAnnotation, ContentAnnotationKind,
     InlineStyleKind, ShortcutEmphasis, extract_annotations, merge_annotations,
     partition_annotations, rebase_annotations, validate_annotations,
+};
+pub use attachment_numbering::{
+    AttachmentCounters, AttachmentOrdinal, renew_attachment_occurrences,
 };
 pub use identifiers::{
     InstanceId, OperationId, RequestId, RevisionId, SessionId, SubmissionId, ThoughtId,

--- a/src/domain/operations.rs
+++ b/src/domain/operations.rs
@@ -255,6 +255,7 @@ pub struct SessionBoard {
     /// Session metadata.
     pub session: Session,
     thoughts: Vec<Thought>,
+    attachment_counters: super::AttachmentCounters,
 }
 
 impl SessionBoard {
@@ -264,9 +265,48 @@ impl SessionBoard {
     ///
     /// Returns a domain error when ownership, identity, or live positions are invalid.
     pub fn new(session: Session, thoughts: Vec<Thought>) -> Result<Self, DomainError> {
-        let board = Self { session, thoughts };
+        let mut board = Self {
+            session,
+            thoughts,
+            attachment_counters: super::AttachmentCounters::default(),
+        };
+        board.observe_attachments()?;
         board.validate()?;
         Ok(board)
+    }
+
+    /// Session attachment allocation high-water marks.
+    #[must_use]
+    pub const fn attachment_counters(&self) -> super::AttachmentCounters {
+        self.attachment_counters
+    }
+
+    /// Restore counters without losing any retained occurrence.
+    ///
+    /// # Errors
+    /// Rejects a counter below any already observed ordinal.
+    pub fn restore_attachment_counters(
+        &mut self,
+        counters: super::AttachmentCounters,
+    ) -> Result<(), DomainError> {
+        if counters.image() < self.attachment_counters.image()
+            || counters.file() < self.attachment_counters.file()
+        {
+            return Err(DomainError::InvalidContentAnnotation);
+        }
+        self.attachment_counters = counters;
+        Ok(())
+    }
+
+    /// Incorporate assigned annotations after an editor revision.
+    ///
+    /// # Errors
+    /// Rejects unassigned durable attachments.
+    pub fn observe_attachments(&mut self) -> Result<(), DomainError> {
+        for thought in &self.thoughts {
+            self.attachment_counters.observe(&thought.annotations)?;
+        }
+        Ok(())
     }
 
     /// All thoughts, including recoverably deleted records.
@@ -310,6 +350,7 @@ impl SessionBoard {
     ) -> Result<(), DomainError> {
         let mut candidate = self.clone();
         candidate.apply_mutation_in_place(mutation, at)?;
+        candidate.observe_attachments()?;
         candidate.validate()?;
         *self = candidate;
         Ok(())
@@ -418,7 +459,12 @@ impl SessionBoard {
             }
             validate_annotations(&thought.content, &thought.annotations)?;
         }
+        let mut attachment_ids = HashSet::new();
         for (expected, thought) in self.live_thoughts().into_iter().enumerate() {
+            super::attachment_numbering::validate_unique(
+                &thought.annotations,
+                &mut attachment_ids,
+            )?;
             if usize::try_from(thought.position.get()).ok() != Some(expected) {
                 return Err(DomainError::NonNormalizedPositions);
             }

--- a/src/ports/attachment_accessibility.rs
+++ b/src/ports/attachment_accessibility.rs
@@ -19,6 +19,8 @@ pub struct AttachmentCheckKey {
     pub annotation_end: usize,
     /// Whether presentation uses the image label.
     pub image: bool,
+    /// Stable session occurrence identity.
+    pub ordinal: crate::domain::AttachmentOrdinal,
     /// Exact presentation metadata participating in cache identity.
     pub display_name: String,
     /// Exact canonical path stored in prompt content.

--- a/src/ports/control.rs
+++ b/src/ports/control.rs
@@ -15,7 +15,7 @@ use super::update::{
 use super::{runtime::InstanceInfo, store::CommitReceipt};
 
 /// Current local owner-control protocol.
-pub const CONTROL_PROTOCOL_VERSION: u32 = 7;
+pub const CONTROL_PROTOCOL_VERSION: u32 = 8;
 /// Current compatible screenshot takeover protocol.
 pub const CAPTURE_CONTROL_PROTOCOL_VERSION: u32 = 1;
 /// Oldest owner-control protocol accepted for plain-text mutations.
@@ -268,7 +268,10 @@ impl ControlMutation {
     /// Oldest control protocol capable of representing this request.
     #[must_use]
     pub fn minimum_protocol(&self) -> u32 {
-        if self.requires_protocol_seven() {
+        if matches!(self, Self::Add { annotations, .. } | Self::PreserveAdd { annotations, .. } if annotations.iter().any(|annotation| matches!(annotation.kind, ContentAnnotationKind::Attachment { .. })))
+        {
+            8
+        } else if self.requires_protocol_seven() {
             7
         } else if self.requires_protocol_six() {
             6

--- a/src/ports/control/tests.rs
+++ b/src/ports/control/tests.rs
@@ -13,7 +13,7 @@ use super::{
 };
 
 #[test]
-fn plain_and_legacy_annotations_keep_their_existing_minimum_protocols() {
+fn plain_text_keeps_legacy_protocol_while_attachments_require_session_numbering() {
     let mut ids = FakeIdGenerator::new(1_725_200_000_000);
     let plain = ControlRequest {
         protocol: 1,
@@ -41,6 +41,7 @@ fn plain_and_legacy_annotations_keep_their_existing_minimum_protocols() {
             start: 0,
             end: 10,
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "a.png".to_owned(),
             },
@@ -48,7 +49,7 @@ fn plain_and_legacy_annotations_keep_their_existing_minimum_protocols() {
         position: None,
     };
     assert!(annotated.requires_protocol_two());
-    assert_eq!(annotated.minimum_protocol(), 2);
+    assert_eq!(annotated.minimum_protocol(), 8);
 }
 
 #[test]

--- a/src/ports/store.rs
+++ b/src/ports/store.rs
@@ -21,9 +21,9 @@ pub use onboarding::{FirstRunBoard, FirstRunOutcome, OnboardingVersion};
 pub use submission_route::{SUBMISSION_ROUTE_VERSION, SubmissionJournalRoute};
 
 /// Current storage schema understood by this binary.
-pub const SUPPORTED_SCHEMA_VERSION: u32 = 13;
+pub const SUPPORTED_SCHEMA_VERSION: u32 = 14;
 /// Current local storage protocol understood by this binary.
-pub const STORAGE_PROTOCOL_VERSION: u32 = 12;
+pub const STORAGE_PROTOCOL_VERSION: u32 = 13;
 
 /// One ordered, content-redacted source included in a submission.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/ports/store/compaction.rs
+++ b/src/ports/store/compaction.rs
@@ -61,7 +61,9 @@ pub fn thought_payload_digest(
 ) -> Result<[u8; 32], StoreError> {
     use sha2::{Digest as _, Sha256};
 
-    let annotations = serde_json::to_vec(annotations)
+    let mut input_annotations = annotations.to_vec();
+    crate::domain::renew_attachment_occurrences(&mut input_annotations);
+    let annotations = serde_json::to_vec(&input_annotations)
         .map_err(|error| StoreError::Serialization(error.to_string()))?;
     let mut digest = Sha256::new();
     digest.update(

--- a/src/ui/annotations.rs
+++ b/src/ui/annotations.rs
@@ -76,6 +76,7 @@ impl PastePayload {
                 start: range.start,
                 end: range.end,
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: None,
                     image,
                     display_name,
                 },
@@ -227,8 +228,6 @@ struct ProjectionBuilder {
     substitutions: Vec<PresentedSubstitution>,
     styles: Vec<PresentedStyle>,
     cursor: usize,
-    image: usize,
-    file: usize,
 }
 
 impl ProjectionBuilder {
@@ -253,7 +252,7 @@ impl ProjectionBuilder {
                 self.push_expanded(content, annotation_index, annotation, start, inaccessible)?;
             }
             AnnotationBehavior::Substitution => {
-                self.push_collapsed(annotation_index, annotation, start, inaccessible);
+                self.push_collapsed(annotation_index, annotation, start, inaccessible)?;
             }
         }
         self.cursor = annotation.end;
@@ -289,11 +288,6 @@ impl ProjectionBuilder {
         start: usize,
         inaccessible: bool,
     ) -> Result<(), ProjectionError> {
-        match &annotation.kind {
-            ContentAnnotationKind::Attachment { image: true, .. } => self.image += 1,
-            ContentAnnotationKind::Attachment { image: false, .. } => self.file += 1,
-            _ => {}
-        }
         let exact = content
             .get(annotation.start..annotation.end)
             .ok_or(ProjectionError::InvalidAnnotationRange)?;
@@ -327,14 +321,8 @@ impl ProjectionBuilder {
         annotation: &ContentAnnotation,
         start: usize,
         inaccessible: bool,
-    ) {
-        push_collapsed_label(
-            &mut self.output,
-            &annotation.kind,
-            &mut self.image,
-            &mut self.file,
-            inaccessible,
-        );
+    ) -> Result<(), ProjectionError> {
+        push_collapsed_label(&mut self.output, &annotation.kind, inaccessible)?;
         self.substitutions.push(substitution(
             annotation_index,
             start,
@@ -353,6 +341,7 @@ impl ProjectionBuilder {
                 PresentedStyleKind::Annotation
             },
         });
+        Ok(())
     }
 
     fn finish(mut self, content: &str) -> Result<Presentation, ProjectionError> {
@@ -371,19 +360,14 @@ impl ProjectionBuilder {
 fn push_collapsed_label(
     output: &mut String,
     kind: &ContentAnnotationKind,
-    image_count: &mut usize,
-    file_count: &mut usize,
     inaccessible: bool,
-) {
+) -> Result<(), ProjectionError> {
     match kind {
-        ContentAnnotationKind::Attachment { image, .. } => {
-            let (label, number) = if *image {
-                *image_count += 1;
-                ("Image", *image_count)
-            } else {
-                *file_count += 1;
-                ("File", *file_count)
-            };
+        ContentAnnotationKind::Attachment { image, ordinal, .. } => {
+            let label = if *image { "Image" } else { "File" };
+            let number = ordinal
+                .ok_or(ProjectionError::InvalidAnnotationRange)?
+                .get();
             output.push('[');
             output.push_str(label);
             output.push(' ');
@@ -405,6 +389,7 @@ fn push_collapsed_label(
         }
         ContentAnnotationKind::ShortcutEmphasis(_) => {}
     }
+    Ok(())
 }
 
 fn substitution(

--- a/src/ui/app/editing.rs
+++ b/src/ui/app/editing.rs
@@ -12,6 +12,7 @@ use crate::{
 use super::{BoardApp, EditorOwner, UiKey};
 use crate::ui::annotations;
 
+mod attachment_insertion;
 mod navigation;
 
 pub(super) fn command_for_key(
@@ -364,6 +365,12 @@ impl BoardApp {
         if self.edit_command_blocked(&command) {
             return;
         }
+        let Some((current_annotations, inserted_annotations)) =
+            self.prepare_attachment_insertion(inserted_annotations)
+        else {
+            return;
+        };
+        let inserted_annotations = inserted_annotations.as_slice();
         let edit = self.editor.as_mut().and_then(|(owner, editor)| {
             let EditorOwner::Thought(thought_id) = owner else {
                 return None;
@@ -381,19 +388,6 @@ impl BoardApp {
             return;
         };
         self.clear_expanded_folds(thought_id);
-        let current_annotations = self
-            .pending_edit
-            .as_ref()
-            .filter(|pending| pending.thought_id == thought_id)
-            .map_or_else(
-                || {
-                    self.state
-                        .board
-                        .thought(thought_id)
-                        .map_or_else(Vec::new, |thought| thought.annotations.clone())
-                },
-                |pending| pending.after_annotations.clone(),
-            );
         let after_annotations = if preserve_owned {
             annotations::rebase_preserved(
                 &before.content,

--- a/src/ui/app/editing/attachment_insertion.rs
+++ b/src/ui/app/editing/attachment_insertion.rs
@@ -1,0 +1,25 @@
+//! Allocate pasted occurrences before mutating an editor buffer.
+
+use crate::{domain::ContentAnnotation, ui::BoardApp};
+
+impl BoardApp {
+    pub(in crate::ui::app) fn prepare_attachment_insertion(
+        &mut self,
+        inserted: &[ContentAnnotation],
+    ) -> Option<(Vec<ContentAnnotation>, Vec<ContentAnnotation>)> {
+        let thought = self.active_thought_id()?;
+        let current = self.current_annotations(thought);
+        let mut inserted = inserted.to_vec();
+        crate::domain::renew_attachment_occurrences(&mut inserted);
+        let mut counters = self.state.board.attachment_counters();
+        if counters
+            .observe(&current)
+            .and_then(|()| counters.assign(&mut inserted))
+            .is_err()
+        {
+            self.set_error("attachment numbering exhausted");
+            return None;
+        }
+        Some((current, inserted))
+    }
+}

--- a/tests/cli_workflow.rs
+++ b/tests/cli_workflow.rs
@@ -419,7 +419,7 @@ fn launch_modes_and_capability_discovery_have_stable_output() {
     let capabilities = success(root, &["capabilities"], None);
     assert_eq!(capabilities["cli_schema_version"], 1);
     assert_eq!(capabilities["active_session_control"], cfg!(unix));
-    assert_eq!(capabilities["control_protocol"], 7);
+    assert_eq!(capabilities["control_protocol"], 8);
     assert_eq!(capabilities["active_session_read_sync"], true);
     assert_eq!(capabilities["cross_session_transfer"], true);
     assert_eq!(capabilities["exact_thought_replacement"], true);

--- a/tests/control_contract.rs
+++ b/tests/control_contract.rs
@@ -6,14 +6,14 @@ use proqi::ports::control::{
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
-const REQUEST: &str = include_str!("fixtures/control/v7/add.request.json");
-const ACCEPTED: &str = include_str!("fixtures/control/v7/add.accepted.json");
-const REJECTED: &str = include_str!("fixtures/control/v7/add.rejected.json");
-const PRESERVE: &str = include_str!("fixtures/control/v7/preserve_add.request.json");
-const UPDATE_PREPARE: &str = include_str!("fixtures/control/v7/update_prepare.request.json");
-const UPDATE_READY: &str = include_str!("fixtures/control/v7/update_prepare.ready.json");
-const CAPTURE_TAKEOVER: &str = include_str!("fixtures/control/v7/capture_takeover.request.json");
-const CAPTURE_SCHEDULED: &str = include_str!("fixtures/control/v7/capture_takeover.scheduled.json");
+const REQUEST: &str = include_str!("fixtures/control/v8/add.request.json");
+const ACCEPTED: &str = include_str!("fixtures/control/v8/add.accepted.json");
+const REJECTED: &str = include_str!("fixtures/control/v8/add.rejected.json");
+const PRESERVE: &str = include_str!("fixtures/control/v8/preserve_add.request.json");
+const UPDATE_PREPARE: &str = include_str!("fixtures/control/v8/update_prepare.request.json");
+const UPDATE_READY: &str = include_str!("fixtures/control/v8/update_prepare.ready.json");
+const CAPTURE_TAKEOVER: &str = include_str!("fixtures/control/v8/capture_takeover.request.json");
+const CAPTURE_SCHEDULED: &str = include_str!("fixtures/control/v8/capture_takeover.scheduled.json");
 
 #[test]
 fn current_request_success_and_error_fixtures_round_trip_canonically() {

--- a/tests/domain_reducer/clipboard.rs
+++ b/tests/domain_reducer/clipboard.rs
@@ -180,6 +180,7 @@ fn cut_success_does_not_delete_an_intervening_annotated_edit() {
         start: 0,
         end: after.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "replacement.png".to_owned(),
         },
@@ -231,6 +232,7 @@ fn annotated_cut_restores_exact_metadata_in_one_board_undo() {
         start: 0,
         end: path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "Grüße.png".to_owned(),
         },

--- a/tests/fixtures/control/v8/add.accepted.json
+++ b/tests/fixtures/control/v8/add.accepted.json
@@ -1,0 +1,17 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "result": {
+    "status": "accepted",
+    "thought_id": "tht_06g30t8fudrq55fdkk348i7388",
+    "durable": {
+      "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k",
+      "sequence": 1,
+      "identity": {
+        "kind": "operation",
+        "id": "op_06g30t8fudrq55fdkjqr6mpe44"
+      },
+      "idempotent_replay": false
+    }
+  }
+}

--- a/tests/fixtures/control/v8/add.rejected.json
+++ b/tests/fixtures/control/v8/add.rejected.json
@@ -1,0 +1,9 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "result": {
+    "status": "rejected",
+    "code": "idempotency_conflict",
+    "message": "operation identity was already used for another request"
+  }
+}

--- a/tests/fixtures/control/v8/add.request.json
+++ b/tests/fixtures/control/v8/add.request.json
@@ -1,0 +1,22 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k",
+  "mutation": {
+    "mutation": "add",
+    "operation_id": "op_06g30t8fudrq55fdkjqr6mpe44",
+    "thought_id": "tht_06g30t8fudrq55fdkk348i7388",
+    "content": "Review Unicode wrapping.\n",
+    "annotations": [
+      {
+        "start": 0,
+        "end": 25,
+        "kind": {
+          "kind": "invocation_reference",
+          "display_name": "@reviewer · codex"
+        }
+      }
+    ],
+    "position": null
+  }
+}

--- a/tests/fixtures/control/v8/capture_takeover.request.json
+++ b/tests/fixtures/control/v8/capture_takeover.request.json
@@ -1,0 +1,11 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k",
+  "mutation": {
+    "mutation": "capture_takeover",
+    "expected_owner_instance_id": "ins_06g3cnfeelq3707alnmfsvn1vo",
+    "requester_instance_id": "ins_06g3cnfeelq3707alnmfsvn1vs",
+    "capture_protocol": 1
+  }
+}

--- a/tests/fixtures/control/v8/capture_takeover.scheduled.json
+++ b/tests/fixtures/control/v8/capture_takeover.scheduled.json
@@ -1,0 +1,9 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "result": {
+    "status": "capture",
+    "capture": "takeover_scheduled",
+    "owner_instance_id": "ins_06g3cnfeelq3707alnmfsvn1vo"
+  }
+}

--- a/tests/fixtures/control/v8/preserve_add.request.json
+++ b/tests/fixtures/control/v8/preserve_add.request.json
@@ -1,0 +1,21 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k",
+  "mutation": {
+    "mutation": "preserve_add",
+    "operation_id": "op_06g30t8fudrq55fdkjqr6mpe44",
+    "thought_id": "tht_06g30t8fudrq55fdkk348i7388",
+    "content": "Press Enter",
+    "annotations": [
+      {
+        "start": 6,
+        "end": 11,
+        "kind": {
+          "kind": "shortcut_emphasis"
+        }
+      }
+    ],
+    "position": null
+  }
+}

--- a/tests/fixtures/control/v8/update_prepare.ready.json
+++ b/tests/fixtures/control/v8/update_prepare.ready.json
@@ -1,0 +1,11 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "result": {
+    "status": "update",
+    "update": "prepared",
+    "readiness": "ready",
+    "instance_id": "ins_06g3cnfeelq3707alnmfsvn1vo",
+    "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k"
+  }
+}

--- a/tests/fixtures/control/v8/update_prepare.request.json
+++ b/tests/fixtures/control/v8/update_prepare.request.json
@@ -1,0 +1,14 @@
+{
+  "protocol": 8,
+  "request_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+  "session_id": "ses_06g30t7dv5qv55n1ppn3clis3k",
+  "mutation": {
+    "mutation": "update_prepare",
+    "request": {
+      "operation_id": "req_06g30t8fudrq55fdkjqr6mpe44",
+      "target_version": "1.2.3",
+      "installation_identity": "0707070707070707070707070707070707070707070707070707070707070707",
+      "deadline": 9
+    }
+  }
+}

--- a/tests/pty/update_migration.rs
+++ b/tests/pty/update_migration.rs
@@ -236,7 +236,9 @@ fn downgrade_to_schema_eleven(state: &Path) {
     Connection::open(state.join("data/proqi.sqlite3"))
         .expect("database")
         .execute_batch(
-            "DELETE FROM migration_history WHERE version IN (12, 13);
+            "ALTER TABLE sessions DROP COLUMN attachment_image_high;
+             ALTER TABLE sessions DROP COLUMN attachment_file_high;
+             DELETE FROM migration_history WHERE version IN (12, 13, 14);
              UPDATE schema_meta SET schema_version = 11, storage_protocol = 10;",
         )
         .expect("schema eleven fixture");

--- a/tests/sqlite_store.rs
+++ b/tests/sqlite_store.rs
@@ -164,3 +164,6 @@ mod submission;
 mod top_boundary;
 #[path = "sqlite_store/transformations.rs"]
 mod transformations;
+
+#[path = "sqlite_store/attachment_numbering.rs"]
+mod attachment_numbering;

--- a/tests/sqlite_store/annotations.rs
+++ b/tests/sqlite_store/annotations.rs
@@ -22,6 +22,7 @@ fn folded_provenance_and_editor_undo_survive_reopen() {
         start: 0,
         end: content.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "screenshot.png".to_owned(),
         },
@@ -118,6 +119,7 @@ fn invocation_reference_projection_survives_protocol_nine_migration() {
         .expect("durable create");
     persist_effect(&mut store, create);
     drop(store);
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     Connection::open(&fixture.config.database_path)
         .expect("version eight database")
         .execute_batch(
@@ -166,6 +168,7 @@ fn protocol_ten_loads_structurally_valid_direct_shortcut_bytes_and_rejects_corru
     persist_effect(&mut store, &effects[0]);
     drop(store);
 
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     let connection = Connection::open(&fixture.config.database_path).expect("direct fixture");
     connection
         .execute(
@@ -347,6 +350,7 @@ fn placeholder_space_revision_undo_and_redo_survive_every_reopen() {
         start,
         end: start + value.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "restart.png".to_owned(),
         },

--- a/tests/sqlite_store/attachment_numbering.rs
+++ b/tests/sqlite_store/attachment_numbering.rs
@@ -1,0 +1,326 @@
+//! Durable session allocation, deletion, replay and one-time legacy synthesis.
+
+use super::{DatabaseFixture, persist_effect, session_state, test_path};
+use proqi::{
+    adapters::memory::FakeIdGenerator,
+    application::{Action, AppState, reduce},
+    domain::{
+        ContentAnnotation, ContentAnnotationKind, TextPosition, ThoughtId, Timestamp, UndoScope,
+    },
+    ports::{
+        environment::IdGenerator,
+        store::{OperationBatch, Store},
+    },
+};
+
+fn annotation(start: usize, end: usize, image: bool) -> ContentAnnotation {
+    ContentAnnotation {
+        start,
+        end,
+        kind: ContentAnnotationKind::Attachment {
+            ordinal: None,
+            image,
+            display_name: "asset".to_owned(),
+        },
+    }
+}
+
+fn ordinal(state: &AppState, thought: ThoughtId) -> u64 {
+    let ContentAnnotationKind::Attachment { ordinal, .. } =
+        state.board.thought(thought).expect("thought").annotations[0].kind
+    else {
+        panic!("attachment")
+    };
+    ordinal.expect("assigned").get()
+}
+
+fn apply(store: &mut proqi::adapters::sqlite::SqliteStore, state: &mut AppState, action: Action) {
+    for effect in reduce(state, action).expect("reduce") {
+        if effect.persistence_batch().is_some() {
+            persist_effect(store, &effect);
+        }
+    }
+}
+
+fn create(
+    store: &mut proqi::adapters::sqlite::SqliteStore,
+    state: &mut AppState,
+    ids: &mut FakeIdGenerator,
+    image: bool,
+) -> ThoughtId {
+    let id = ids.thought_id();
+    let content = "/offline/Grüße asset.png".to_owned();
+    let annotations = vec![annotation(0, content.len(), image)];
+    apply(
+        store,
+        state,
+        Action::CreateThought {
+            thought_id: id,
+            operation_id: ids.operation_id(),
+            content,
+            annotations,
+            insertion_index: None,
+            at: Timestamp::from_millis(2),
+        },
+    );
+    id
+}
+
+#[test]
+fn long_mixed_sequence_survives_shuffle_deletion_history_and_restart_without_reuse() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("numbering"));
+    let session = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let mut images = Vec::new();
+    for index in 1..=14 {
+        let image = create(&mut store, &mut state, &mut ids, true);
+        assert_eq!(ordinal(&state, image), index);
+        images.push(image);
+        if index % 3 == 0 {
+            let file = create(&mut store, &mut state, &mut ids, false);
+            assert_eq!(ordinal(&state, file), index / 3);
+        }
+    }
+    for image in &images {
+        apply(
+            &mut store,
+            &mut state,
+            Action::MoveThought {
+                thought_id: *image,
+                operation_id: ids.operation_id(),
+                to: 0,
+                at: Timestamp::from_millis(3),
+            },
+        );
+    }
+    for (index, image) in images.iter().enumerate() {
+        assert_eq!(ordinal(&state, *image), index as u64 + 1);
+    }
+    let removed = images[13];
+    apply(
+        &mut store,
+        &mut state,
+        Action::DeleteThought {
+            thought_id: removed,
+            operation_id: ids.operation_id(),
+            kind: proqi::domain::BoardOperationKind::Delete,
+            at: Timestamp::from_millis(4),
+        },
+    );
+    drop(store);
+    let mut store = fixture.open();
+    let mut state =
+        AppState::from_snapshot(store.load_session(session).expect("snapshot")).expect("state");
+    apply(
+        &mut store,
+        &mut state,
+        Action::Undo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Board,
+            at: Timestamp::from_millis(5),
+        },
+    );
+    assert_eq!(ordinal(&state, removed), 14);
+    apply(
+        &mut store,
+        &mut state,
+        Action::Redo {
+            operation_id: ids.operation_id(),
+            scope: UndoScope::Board,
+            at: Timestamp::from_millis(6),
+        },
+    );
+    let next = create(&mut store, &mut state, &mut ids, true);
+    assert_eq!(ordinal(&state, next), 15);
+    assert_eq!(
+        store
+            .load_session(session)
+            .expect("durable")
+            .board
+            .attachment_counters()
+            .image(),
+        15
+    );
+}
+
+#[test]
+fn ambiguous_legacy_coalesced_edit_is_synthesized_once_and_replays_stably() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("legacy-numbering"));
+    let session = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let (id, content) = coalesced_legacy_edit(&mut store, &mut state, &mut ids);
+    drop(store);
+    downgrade_to_legacy(&fixture);
+    let mut store = fixture.open();
+    let migrated = store.load_session(session).expect("migrated");
+    assert_eq!(migrated.board.attachment_counters().image(), 2);
+    let mut state = AppState::from_snapshot(migrated).expect("state");
+    assert_eq!(ordinal(&state, id), 1);
+    for _ in 0..2 {
+        apply(
+            &mut store,
+            &mut state,
+            Action::Undo {
+                operation_id: ids.operation_id(),
+                scope: UndoScope::Editor { thought_id: id },
+                at: Timestamp::from_millis(4),
+            },
+        );
+        let thought = state.board.thought(id).expect("thought");
+        assert_eq!(thought.content, content);
+        assert_eq!(
+            thought
+                .annotations
+                .iter()
+                .map(|a| match a.kind {
+                    ContentAnnotationKind::Attachment { ordinal, .. } =>
+                        ordinal.expect("ordinal").get(),
+                    _ => 0,
+                })
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        apply(
+            &mut store,
+            &mut state,
+            Action::Redo {
+                operation_id: ids.operation_id(),
+                scope: UndoScope::Editor { thought_id: id },
+                at: Timestamp::from_millis(5),
+            },
+        );
+        assert_eq!(ordinal(&state, id), 1);
+    }
+    drop(store);
+    let mut store = fixture.open();
+    let restored = store.load_session(session).expect("reopen");
+    assert_eq!(restored.board.thoughts(), state.board.thoughts());
+    assert_eq!(
+        restored.board.attachment_counters(),
+        state.board.attachment_counters()
+    );
+    let mut state = AppState::from_snapshot(restored).expect("state");
+    let next = create(&mut store, &mut state, &mut ids, true);
+    assert_eq!(ordinal(&state, next), 3);
+}
+
+fn coalesced_legacy_edit(
+    store: &mut proqi::adapters::sqlite::SqliteStore,
+    state: &mut AppState,
+    ids: &mut FakeIdGenerator,
+) -> (ThoughtId, String) {
+    let id = ids.thought_id();
+    let path = "/offline/same.png";
+    let content = format!("{path}\n{path}");
+    apply(
+        store,
+        state,
+        Action::CreateThought {
+            thought_id: id,
+            operation_id: ids.operation_id(),
+            content: content.clone(),
+            annotations: vec![
+                annotation(0, path.len(), true),
+                annotation(path.len() + 1, content.len(), true),
+            ],
+            insertion_index: None,
+            at: Timestamp::from_millis(2),
+        },
+    );
+    let before_annotations = state
+        .board
+        .thought(id)
+        .expect("thought")
+        .annotations
+        .clone();
+    let mut after = before_annotations[1].clone();
+    after.start = 0;
+    after.end = path.len();
+    apply(
+        store,
+        state,
+        Action::EditThought {
+            thought_id: id,
+            revision_id: ids.revision_id(),
+            before_content: content.clone(),
+            after_content: path.to_owned(),
+            before_annotations,
+            after_annotations: vec![after],
+            before_cursor: TextPosition::new(0, 0),
+            after_cursor: TextPosition::new(0, 0),
+            at: Timestamp::from_millis(3),
+        },
+    );
+    (id, content)
+}
+
+pub(super) fn downgrade_to_legacy(fixture: &DatabaseFixture) {
+    let connection = rusqlite::Connection::open(&fixture.config.database_path).expect("database");
+    for (table, column, key) in [
+        ("thoughts", "annotations_json", "id"),
+        ("board_operations", "payload_json", "id"),
+        ("thought_revisions", "payload_json", "id"),
+        ("commit_receipts", "request_json", "external_id"),
+    ] {
+        let mut statement = connection
+            .prepare(&format!("SELECT {key}, {column} FROM {table}"))
+            .expect("query");
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, String>(1)?))
+            })
+            .expect("rows")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect");
+        for (id, encoded) in rows {
+            let mut value: serde_json::Value = serde_json::from_str(&encoded).expect("json");
+            strip_ordinals(&mut value);
+            connection
+                .execute(
+                    &format!("UPDATE {table} SET {column} = ?2 WHERE {key} = ?1"),
+                    rusqlite::params![id, value.to_string()],
+                )
+                .expect("legacy payload");
+        }
+    }
+    connection.execute_batch("ALTER TABLE sessions DROP COLUMN attachment_image_high; ALTER TABLE sessions DROP COLUMN attachment_file_high; DELETE FROM migration_history WHERE version = 14; UPDATE schema_meta SET schema_version = 13, storage_protocol = 12;").expect("legacy schema");
+}
+
+fn strip_ordinals(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            object.remove("ordinal");
+            for child in object.values_mut() {
+                strip_ordinals(child);
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                strip_ordinals(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[path = "attachment_numbering/capture.rs"]
+mod capture;
+
+#[path = "attachment_numbering/integrity.rs"]
+mod integrity;
+
+#[path = "attachment_numbering/structural.rs"]
+mod structural;
+
+#[path = "attachment_numbering/repeated_snapshot.rs"]
+mod repeated_snapshot;

--- a/tests/sqlite_store/attachment_numbering/capture.rs
+++ b/tests/sqlite_store/attachment_numbering/capture.rs
@@ -1,0 +1,116 @@
+//! Screenshot sequence allocation, atomic receipt rollback and lost acknowledgement replay.
+
+use super::{DatabaseFixture, create, ordinal, session_state, test_path};
+use proqi::{
+    adapters::memory::FakeIdGenerator,
+    application::{apply_capture, prepare_capture},
+    domain::Timestamp,
+    ports::{
+        environment::IdGenerator,
+        screenshot::{ScreenshotCandidate, ScreenshotFingerprint, ScreenshotImageType},
+        store::{CaptureCommitOutcome, OperationBatch, Store},
+    },
+};
+
+fn candidate(index: u8) -> ScreenshotCandidate {
+    ScreenshotCandidate {
+        path: test_path(&format!("capture Grüße {index}.png")),
+        fingerprint: ScreenshotFingerprint([index; 32]),
+        image_type: ScreenshotImageType::Png,
+    }
+}
+
+#[test]
+fn screenshot_sequence_shares_images_with_paste_and_keeps_file_sequence_independent() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("capture-numbering"));
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    for index in 1..=16 {
+        let commit = prepare_capture(
+            &state,
+            &candidate(index),
+            ids.thought_id(),
+            ids.operation_id(),
+            Timestamp::from_millis(3),
+        )
+        .expect("capture");
+        let outcome = store.commit_capture(&commit).expect("commit");
+        let thought = apply_capture(&mut state, &commit, &outcome)
+            .expect("apply")
+            .expect("created");
+        assert_eq!(ordinal(&state, thought), u64::from(index));
+        let replay = store.commit_capture(&commit).expect("replay");
+        assert!(matches!(replay, CaptureCommitOutcome::AlreadyCaptured(_)));
+        assert_eq!(
+            apply_capture(&mut state, &commit, &replay).expect("already applied"),
+            None
+        );
+    }
+    let file = create(&mut store, &mut state, &mut ids, false);
+    assert_eq!(ordinal(&state, file), 1);
+    let pasted = create(&mut store, &mut state, &mut ids, true);
+    assert_eq!(ordinal(&state, pasted), 17);
+    assert_eq!(
+        store
+            .load_session(state.board.session.id)
+            .expect("snapshot")
+            .board
+            .attachment_counters()
+            .image(),
+        17
+    );
+}
+
+#[test]
+fn failed_receipt_rolls_back_number_and_lost_acknowledgement_recovers_exact_proposal() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("capture-retry"));
+    let session = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let connection = rusqlite::Connection::open(&fixture.config.database_path).expect("database");
+    connection.execute_batch("CREATE TRIGGER fail_capture BEFORE INSERT ON screenshot_capture_receipts BEGIN SELECT RAISE(ABORT, 'capture receipt failure'); END;").expect("inject failure");
+    let commit = prepare_capture(
+        &state,
+        &candidate(1),
+        ids.thought_id(),
+        ids.operation_id(),
+        Timestamp::from_millis(3),
+    )
+    .expect("proposal");
+    assert!(store.commit_capture(&commit).is_err());
+    let failed = store.load_session(session).expect("rolled back");
+    assert!(failed.board.thoughts().is_empty());
+    assert_eq!(failed.board.attachment_counters().image(), 0);
+    connection
+        .execute_batch("DROP TRIGGER fail_capture;")
+        .expect("remove failure");
+    let _lost_acknowledgement = store.commit_capture(&commit).expect("durable retry");
+    let replay = store
+        .commit_capture(&commit)
+        .expect("retry after lost acknowledgement");
+    let thought = apply_capture(&mut state, &commit, &replay)
+        .expect("recover receipt")
+        .expect("apply once");
+    assert_eq!(ordinal(&state, thought), 1);
+    let next = prepare_capture(
+        &state,
+        &candidate(2),
+        ids.thought_id(),
+        ids.operation_id(),
+        Timestamp::from_millis(4),
+    )
+    .expect("next");
+    let outcome = store.commit_capture(&next).expect("next commit");
+    let thought = apply_capture(&mut state, &next, &outcome)
+        .expect("apply")
+        .expect("created");
+    assert_eq!(ordinal(&state, thought), 2);
+}

--- a/tests/sqlite_store/attachment_numbering/integrity.rs
+++ b/tests/sqlite_store/attachment_numbering/integrity.rs
@@ -1,0 +1,80 @@
+//! Durable allocation rejects stale writers and malformed stored identity.
+use super::*;
+use proqi::ports::store::StoreError;
+
+#[test]
+fn stale_creators_cannot_commit_duplicate_ordinals_and_reload_allocates_next() {
+    let fixture = DatabaseFixture::new();
+    let mut first = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("numbering-writers"));
+    let session = state.board.session.id;
+    first
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let mut second = fixture.open();
+    let mut contender =
+        AppState::from_snapshot(second.load_session(session).expect("snapshot")).expect("state");
+    let winner = create(&mut first, &mut state, &mut ids, true);
+    let effects = reduce(
+        &mut contender,
+        Action::CreateThought {
+            thought_id: ids.thought_id(),
+            operation_id: ids.operation_id(),
+            content: "/offline/second.png".to_owned(),
+            annotations: vec![annotation(0, "/offline/second.png".len(), true)],
+            insertion_index: None,
+            at: Timestamp::from_millis(3),
+        },
+    )
+    .expect("stale proposal");
+    let batch = effects[0].persistence_batch().expect("batch");
+    assert!(matches!(
+        second.commit(&batch),
+        Err(StoreError::Conflict(_))
+    ));
+    let mut reloaded =
+        AppState::from_snapshot(second.load_session(session).expect("reload")).expect("state");
+    assert_eq!(ordinal(&reloaded, winner), 1);
+    let next = create(&mut second, &mut reloaded, &mut ids, true);
+    assert_eq!(ordinal(&reloaded, next), 2);
+    assert_eq!(
+        first
+            .load_session(session)
+            .expect("durable")
+            .board
+            .live_thoughts()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn missing_zero_duplicate_and_underreported_ordinals_are_corrupt() {
+    for corruption in [
+        "UPDATE thoughts SET annotations_json = json_remove(annotations_json, '$[0].kind.ordinal')",
+        "UPDATE thoughts SET annotations_json = json_set(annotations_json, '$[0].kind.ordinal', 0)",
+        "UPDATE thoughts SET annotations_json = json_set(annotations_json, '$[0].kind.ordinal', 1)",
+        "UPDATE sessions SET attachment_image_high = 1",
+        "UPDATE board_operations SET payload_json = json_remove(payload_json, '$.forward.thought.annotations[0].kind.ordinal')",
+    ] {
+        let fixture = DatabaseFixture::new();
+        let mut store = fixture.open();
+        let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+        let mut state = session_state(&mut ids, &test_path("numbering-corrupt"));
+        let session = state.board.session.id;
+        store
+            .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+            .expect("session");
+        create(&mut store, &mut state, &mut ids, true);
+        create(&mut store, &mut state, &mut ids, true);
+        rusqlite::Connection::open(&fixture.config.database_path)
+            .expect("database")
+            .execute_batch(corruption)
+            .expect("corruption fixture");
+        assert!(
+            matches!(store.load_session(session), Err(StoreError::Corrupt(_))),
+            "{corruption}"
+        );
+    }
+}

--- a/tests/sqlite_store/attachment_numbering/repeated_snapshot.rs
+++ b/tests/sqlite_store/attachment_numbering/repeated_snapshot.rs
@@ -1,0 +1,152 @@
+//! Identical snapshots from different retained history steps are distinct occurrences.
+use super::*;
+
+fn split_then_reinsert(
+    store: &mut proqi::adapters::sqlite::SqliteStore,
+    state: &mut AppState,
+    ids: &mut FakeIdGenerator,
+) -> (ThoughtId, ThoughtId) {
+    let source = create(store, state, ids, true);
+    let before = state.board.thought(source).expect("source").clone();
+    let right = ids.thought_id();
+    apply(
+        store,
+        state,
+        Action::SplitThought {
+            thought_id: source,
+            new_thought_id: right,
+            operation_id: ids.operation_id(),
+            expected_content: before.content.clone(),
+            expected_annotations: before.annotations.clone(),
+            source_content: before.content.clone(),
+            source_annotations: before.annotations,
+            at_byte: 0,
+            at: Timestamp::from_millis(3),
+        },
+    );
+    apply(
+        store,
+        state,
+        Action::EditThought {
+            thought_id: source,
+            revision_id: ids.revision_id(),
+            before_content: String::new(),
+            before_annotations: Vec::new(),
+            after_content: before.content.clone(),
+            after_annotations: vec![annotation(0, before.content.len(), true)],
+            before_cursor: TextPosition::new(0, 0),
+            after_cursor: TextPosition::new(0, 0),
+            at: Timestamp::from_millis(4),
+        },
+    );
+    (source, right)
+}
+
+#[test]
+fn legacy_split_then_identical_reinsertion_migrates_and_replays_without_aliasing_live_anchors() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("repeated-snapshot"));
+    let session = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let (source, right) = split_then_reinsert(&mut store, &mut state, &mut ids);
+    assert_eq!((ordinal(&state, source), ordinal(&state, right)), (2, 1));
+    drop(store);
+    downgrade_to_legacy(&fixture);
+    let mut store = fixture.open();
+    let mut state =
+        AppState::from_snapshot(store.load_session(session).expect("migration")).expect("state");
+    assert_eq!((ordinal(&state, source), ordinal(&state, right)), (1, 2));
+    for undo in [true, false, true, false] {
+        let operation_id = ids.operation_id();
+        let scope = UndoScope::Editor { thought_id: source };
+        let at = Timestamp::from_millis(5);
+        let action = if undo {
+            Action::Undo {
+                operation_id,
+                scope,
+                at,
+            }
+        } else {
+            Action::Redo {
+                operation_id,
+                scope,
+                at,
+            }
+        };
+        apply(&mut store, &mut state, action);
+        assert_eq!(ordinal(&state, right), 2);
+        if undo {
+            assert!(
+                state
+                    .board
+                    .thought(source)
+                    .expect("source")
+                    .annotations
+                    .is_empty()
+            );
+        } else {
+            assert_eq!(ordinal(&state, source), 1);
+        }
+    }
+    drop(store);
+    let mut store = fixture.open();
+    let mut restored =
+        AppState::from_snapshot(store.load_session(session).expect("restart")).expect("state");
+    assert_eq!(restored.board.thoughts(), state.board.thoughts());
+    let next = create(&mut store, &mut restored, &mut ids, true);
+    assert_eq!(ordinal(&restored, next), 3);
+}
+
+#[test]
+fn legacy_migration_anchors_undone_split_before_dormant_identical_editor_redo() {
+    let fixture = DatabaseFixture::new();
+    let mut store = fixture.open();
+    let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+    let mut state = session_state(&mut ids, &test_path("undone-repeated-snapshot"));
+    let session = state.board.session.id;
+    store
+        .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+        .expect("session");
+    let (source, right) = split_then_reinsert(&mut store, &mut state, &mut ids);
+    for scope in [UndoScope::Editor { thought_id: source }, UndoScope::Board] {
+        apply(
+            &mut store,
+            &mut state,
+            Action::Undo {
+                operation_id: ids.operation_id(),
+                scope,
+                at: Timestamp::from_millis(5),
+            },
+        );
+    }
+    drop(store);
+    downgrade_to_legacy(&fixture);
+    let mut store = fixture.open();
+    let mut state =
+        AppState::from_snapshot(store.load_session(session).expect("migration")).expect("state");
+    assert_eq!(ordinal(&state, source), 1);
+    assert_eq!(state.board.attachment_counters().image(), 2);
+    for scope in [UndoScope::Board, UndoScope::Editor { thought_id: source }] {
+        apply(
+            &mut store,
+            &mut state,
+            Action::Redo {
+                operation_id: ids.operation_id(),
+                scope,
+                at: Timestamp::from_millis(6),
+            },
+        );
+    }
+    assert_eq!((ordinal(&state, source), ordinal(&state, right)), (2, 1));
+    drop(store);
+    let mut store = fixture.open();
+    let mut restored =
+        AppState::from_snapshot(store.load_session(session).expect("restart")).expect("state");
+    assert_eq!(restored.board.thoughts(), state.board.thoughts());
+    let next = create(&mut store, &mut restored, &mut ids, true);
+    assert_eq!(ordinal(&restored, next), 3);
+}

--- a/tests/sqlite_store/attachment_numbering/structural.rs
+++ b/tests/sqlite_store/attachment_numbering/structural.rs
@@ -1,0 +1,105 @@
+//! Movement lineage survives legacy synthesis and current undo history.
+use super::*;
+
+#[test]
+fn split_occurrences_keep_identity_through_restart_and_legacy_history_synthesis() {
+    for legacy in [false, true] {
+        let fixture = DatabaseFixture::new();
+        let mut store = fixture.open();
+        let mut ids = FakeIdGenerator::new(1_725_000_000_000);
+        let mut state = session_state(&mut ids, &test_path("numbering-split"));
+        let session = state.board.session.id;
+        store
+            .commit(&OperationBatch::CreateSession(state.board.session.clone()))
+            .expect("session");
+        let source = ids.thought_id();
+        let path = "/offline/same.png";
+        let content = format!("{path}\n{path}");
+        apply(
+            &mut store,
+            &mut state,
+            Action::CreateThought {
+                thought_id: source,
+                operation_id: ids.operation_id(),
+                content: content.clone(),
+                annotations: vec![
+                    annotation(0, path.len(), true),
+                    annotation(path.len() + 1, content.len(), true),
+                ],
+                insertion_index: None,
+                at: Timestamp::from_millis(2),
+            },
+        );
+        let annotations = state
+            .board
+            .thought(source)
+            .expect("source")
+            .annotations
+            .clone();
+        let right = ids.thought_id();
+        apply(
+            &mut store,
+            &mut state,
+            Action::SplitThought {
+                thought_id: source,
+                new_thought_id: right,
+                operation_id: ids.operation_id(),
+                expected_content: content.clone(),
+                expected_annotations: annotations.clone(),
+                source_content: content.clone(),
+                source_annotations: annotations,
+                at_byte: path.len() + 1,
+                at: Timestamp::from_millis(3),
+            },
+        );
+        assert_eq!((ordinal(&state, source), ordinal(&state, right)), (1, 2));
+        drop(store);
+        if legacy {
+            downgrade_to_legacy(&fixture);
+        }
+        let mut store = fixture.open();
+        let mut state =
+            AppState::from_snapshot(store.load_session(session).expect("snapshot")).expect("state");
+        assert_eq!((ordinal(&state, source), ordinal(&state, right)), (1, 2));
+        replay_split(&mut store, &mut state, &mut ids, source, right, &content);
+        let next = create(&mut store, &mut state, &mut ids, true);
+        assert_eq!(ordinal(&state, next), 3);
+    }
+}
+
+fn replay_split(
+    store: &mut proqi::adapters::sqlite::SqliteStore,
+    state: &mut AppState,
+    ids: &mut FakeIdGenerator,
+    source: ThoughtId,
+    right: ThoughtId,
+    content: &str,
+) {
+    for undo in [true, false, true, false] {
+        let operation_id = ids.operation_id();
+        let scope = UndoScope::Board;
+        let at = Timestamp::from_millis(4);
+        let action = if undo {
+            Action::Undo {
+                operation_id,
+                scope,
+                at,
+            }
+        } else {
+            Action::Redo {
+                operation_id,
+                scope,
+                at,
+            }
+        };
+        apply(store, state, action);
+        assert_eq!(ordinal(state, source), 1);
+        assert_eq!(ordinal(state, right), 2);
+        if undo {
+            assert_eq!(
+                state.board.thought(source).expect("source").content,
+                content
+            );
+        }
+    }
+}

--- a/tests/sqlite_store/clipboard_annotations.rs
+++ b/tests/sqlite_store/clipboard_annotations.rs
@@ -15,6 +15,7 @@ fn annotated_content() -> (String, ContentAnnotation) {
         start,
         end,
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "Grüße.png".to_owned(),
         },

--- a/tests/sqlite_store/migration_12.rs
+++ b/tests/sqlite_store/migration_12.rs
@@ -24,6 +24,7 @@ fn onboarding_completed_version(connection: &Connection) -> u32 {
 fn schema_eleven_requires_lease_authorized_backup_before_transformation_protocol_migration() {
     let fixture = DatabaseFixture::new();
     drop(fixture.open());
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     Connection::open(&fixture.config.database_path)
         .expect("schema eleven fixture")
         .execute_batch(
@@ -38,7 +39,7 @@ fn schema_eleven_requires_lease_authorized_backup_before_transformation_protocol
         SqliteStore::open(&refused),
         Err(StoreError::MigrationRequired {
             found: 11,
-            supported: 13
+            supported: SUPPORTED_SCHEMA_VERSION
         })
     ));
     let connection = Connection::open(&fixture.config.database_path).expect("unchanged fixture");

--- a/tests/sqlite_store/migration_13.rs
+++ b/tests/sqlite_store/migration_13.rs
@@ -93,7 +93,7 @@ fn physical_v12_route_migration_preserves_legacy_bytes_and_recovers_conservative
         SqliteStore::open(&refused),
         Err(StoreError::MigrationRequired {
             found: 12,
-            supported: 13
+            supported: SUPPORTED_SCHEMA_VERSION
         })
     ));
 
@@ -169,6 +169,7 @@ fn physical_v12_database() -> (DatabaseFixture, proqi::domain::SessionId) {
         .expect("mark sending");
     drop(store);
 
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     let connection = Connection::open(&fixture.config.database_path).expect("current database");
     connection
         .execute_batch(DOWNGRADE_TO_12)

--- a/tests/sqlite_store/onboarding_migration.rs
+++ b/tests/sqlite_store/onboarding_migration.rs
@@ -78,6 +78,7 @@ fn every_pre_onboarding_schema_migrates_with_current_onboarding_completed() {
     for version in 1..11 {
         let fixture = DatabaseFixture::new();
         drop(fixture.open());
+        super::attachment_numbering::downgrade_to_legacy(&fixture);
         let connection = Connection::open(&fixture.config.database_path).expect("legacy database");
         downgrade_to(&connection, version);
         drop(connection);

--- a/tests/sqlite_store/recovery.rs
+++ b/tests/sqlite_store/recovery.rs
@@ -127,6 +127,7 @@ fn migration_backup_succeeds_and_failure_preserves_source() {
 fn version_one_database_migrates_annotations_forward_without_reinterpretation() {
     let fixture = DatabaseFixture::new();
     drop(fixture.open());
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     let connection = Connection::open(&fixture.config.database_path).expect("version one DB");
     connection
         .execute_batch(
@@ -298,6 +299,7 @@ fn version_five_fixture() -> (
 }
 
 fn downgrade_collapsed_fixture(fixture: &DatabaseFixture) {
+    super::attachment_numbering::downgrade_to_legacy(fixture);
     let connection = Connection::open(&fixture.config.database_path).expect("version five DB");
     connection
         .execute(

--- a/tests/sqlite_store/screenshot.rs
+++ b/tests/sqlite_store/screenshot.rs
@@ -364,6 +364,7 @@ fn version_seven_receipts_migrate_without_ownership_foreign_keys() {
     store.commit_capture(&capture).expect("capture");
     drop(store);
 
+    super::attachment_numbering::downgrade_to_legacy(&fixture);
     let connection = Connection::open(&fixture.config.database_path).expect("version seven DB");
     connection
         .execute_batch(

--- a/tests/startup_concurrency.rs
+++ b/tests/startup_concurrency.rs
@@ -369,7 +369,9 @@ fn shared_schema_eleven_owner_blocks_migration_without_backup_then_release_recov
     Connection::open(&database)
         .expect("schema eleven fixture")
         .execute_batch(
-            "DELETE FROM migration_history WHERE version IN (12, 13);
+            "ALTER TABLE sessions DROP COLUMN attachment_image_high;
+             ALTER TABLE sessions DROP COLUMN attachment_file_high;
+             DELETE FROM migration_history WHERE version IN (12, 13, 14);
              UPDATE schema_meta SET schema_version = 11, storage_protocol = 10;",
         )
         .expect("downgrade transformation protocol stamp");

--- a/tests/ui_board/annotations.rs
+++ b/tests/ui_board/annotations.rs
@@ -1,5 +1,6 @@
 use super::*;
-use proptest::prelude::*;
+#[path = "annotations/navigation_property.rs"]
+mod navigation_property;
 #[path = "annotations/semantic.rs"]
 mod semantic;
 #[path = "annotations/support.rs"]
@@ -17,6 +18,7 @@ fn attachment_payload(path: &str, image: bool) -> PastePayload {
             start: 0,
             end: path.len(),
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image,
                 display_name: "screenshot.png".to_owned(),
             },
@@ -335,6 +337,7 @@ fn reverse_fold_navigation_uses_the_visible_space_before_an_inline_placeholder()
                 start,
                 end: start + path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "screenshot.png".to_owned(),
                 },
@@ -394,6 +397,7 @@ fn adjacent_folds_remain_independently_atomic() {
                 start: 0,
                 end: split,
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "first.png".to_owned(),
                 },
@@ -402,6 +406,7 @@ fn adjacent_folds_remain_independently_atomic() {
                 start: split,
                 end: split + second.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "second.png".to_owned(),
                 },
@@ -442,48 +447,6 @@ fn adjacent_folds_remain_independently_atomic() {
             end: proqi::domain::TextPosition::new(0, split),
         })
     );
-}
-
-proptest! {
-    #![proptest_config(ProptestConfig {
-        failure_persistence: None,
-        .. ProptestConfig::default()
-    })]
-
-    #[test]
-    fn collapsed_fold_navigation_never_leaves_a_cursor_inside_hidden_content(
-        forwards in proptest::collection::vec(any::<bool>(), 0..80),
-    ) {
-        let path = "/tmp/atomic-hidden-image.png";
-        let mut fixture = Fixture::new();
-        insert_accessible(&mut fixture, image_payload(path));
-        for forward in forwards {
-            fixture.input(crate::key_input(UiKey::Move {
-                movement: if forward {
-                    CursorMovement::GraphemeForward
-                } else {
-                    CursorMovement::GraphemeBack
-                },
-                extend_selection: false,
-            }));
-            let snapshot = fixture.app.editor_snapshot().expect("editor");
-            if let Some(selection) = snapshot.selection {
-                prop_assert_eq!(
-                    selection,
-                    proqi::ports::editor::TextSelection {
-                        start: proqi::domain::TextPosition::new(0, 0),
-                        end: proqi::domain::TextPosition::new(0, path.len()),
-                    }
-                );
-            } else {
-                prop_assert!(
-                    snapshot.cursor == proqi::domain::TextPosition::new(0, 0)
-                        || snapshot.cursor
-                            == proqi::domain::TextPosition::new(0, path.len())
-                );
-            }
-        }
-    }
 }
 
 #[test]

--- a/tests/ui_board/annotations/navigation_property.rs
+++ b/tests/ui_board/annotations/navigation_property.rs
@@ -1,0 +1,48 @@
+//! Arbitrary folded cursor movement preserves canonical attachment boundaries.
+
+use super::{image_payload, insert_accessible};
+use crate::Fixture;
+use proptest::prelude::*;
+use proqi::{ports::editor::CursorMovement, ui::UiKey};
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: None,
+        .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn collapsed_fold_navigation_never_leaves_a_cursor_inside_hidden_content(
+        forwards in proptest::collection::vec(any::<bool>(), 0..80),
+    ) {
+        let path = "/tmp/atomic-hidden-image.png";
+        let mut fixture = Fixture::new();
+        insert_accessible(&mut fixture, image_payload(path));
+        for forward in forwards {
+            fixture.input(crate::key_input(UiKey::Move {
+                movement: if forward {
+                    CursorMovement::GraphemeForward
+                } else {
+                    CursorMovement::GraphemeBack
+                },
+                extend_selection: false,
+            }));
+            let snapshot = fixture.app.editor_snapshot().expect("editor");
+            if let Some(selection) = snapshot.selection {
+                prop_assert_eq!(
+                    selection,
+                    proqi::ports::editor::TextSelection {
+                        start: proqi::domain::TextPosition::new(0, 0),
+                        end: proqi::domain::TextPosition::new(0, path.len()),
+                    }
+                );
+            } else {
+                prop_assert!(
+                    snapshot.cursor == proqi::domain::TextPosition::new(0, 0)
+                        || snapshot.cursor
+                            == proqi::domain::TextPosition::new(0, path.len())
+                );
+            }
+        }
+    }
+}

--- a/tests/ui_board/attachment_accessibility.rs
+++ b/tests/ui_board/attachment_accessibility.rs
@@ -385,6 +385,7 @@ fn attachment_payload(path: &str, image: bool) -> PastePayload {
             start: 0,
             end: path.len(),
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image,
                 display_name: path.rsplit('/').next().unwrap_or(path).to_owned(),
             },

--- a/tests/ui_board/attachment_accessibility/frame_presentation.rs
+++ b/tests/ui_board/attachment_accessibility/frame_presentation.rs
@@ -291,6 +291,7 @@ fn embedded_attachment(content: String, range: std::ops::Range<usize>) -> PasteP
             start: range.start,
             end: range.end,
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "fixture.png".to_owned(),
             },

--- a/tests/ui_board/clipboard.rs
+++ b/tests/ui_board/clipboard.rs
@@ -86,6 +86,7 @@ fn delayed_board_cut_success_keeps_an_intervening_edit() {
         start: 0,
         end: original.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "original.png".to_owned(),
         },

--- a/tests/ui_board/clipboard_annotations.rs
+++ b/tests/ui_board/clipboard_annotations.rs
@@ -13,6 +13,7 @@ fn attachment(content: &str, start: usize, end: usize, image: bool) -> ContentAn
         start,
         end,
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image,
             display_name: content[start..end].to_owned(),
         },
@@ -35,10 +36,13 @@ fn whole_thought_copy_shifts_every_annotation_across_canonical_separators() {
     let repeated = "/offline/same.txt";
     let second = format!("{repeated} and {repeated}");
     let second_start = repeated.len() + " and ".len();
-    let second_annotations = vec![
+    let mut second_annotations = vec![
         attachment(&second, 0, repeated.len(), false),
         attachment(&second, second_start, second_start + repeated.len(), false),
     ];
+    if let ContentAnnotationKind::Attachment { ordinal, .. } = &mut second_annotations[1].kind {
+        *ordinal = Some(2_u64.try_into().expect("second file"));
+    }
     fixture.input(UiInput::PasteAnnotated(
         PastePayload::annotated(second.clone(), second_annotations.clone())
             .expect("second payload"),

--- a/tests/ui_board/clipboard_races.rs
+++ b/tests/ui_board/clipboard_races.rs
@@ -15,6 +15,7 @@ fn delayed_editor_cut_cannot_delete_an_identical_annotated_neighbor() {
         start: 0,
         end: content.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "repeated.png".to_owned(),
         },
@@ -50,9 +51,25 @@ fn delayed_editor_cut_cannot_delete_an_identical_annotated_neighbor() {
 
     assert!(completion.is_empty());
     assert_eq!(fixture.app.state.board.live_thoughts().len(), 2);
-    for thought in fixture.app.state.board.live_thoughts() {
+    for (index, thought) in fixture
+        .app
+        .state
+        .board
+        .live_thoughts()
+        .into_iter()
+        .enumerate()
+    {
+        let mut expected = annotation.clone();
+        if let ContentAnnotationKind::Attachment { ordinal, .. } = &mut expected.kind {
+            *ordinal = Some(
+                u64::try_from(index + 1)
+                    .expect("index")
+                    .try_into()
+                    .expect("ordinal"),
+            );
+        }
         assert_eq!(thought.content, content);
-        assert_eq!(thought.annotations, vec![annotation.clone()]);
+        assert_eq!(thought.annotations, vec![expected]);
     }
     assert_eq!(
         fixture.app.status_text(),

--- a/tests/ui_board/compose.rs
+++ b/tests/ui_board/compose.rs
@@ -132,6 +132,7 @@ fn exact_and_annotated_paste_materialize_through_the_canonical_create() {
         start: 0,
         end: path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: false,
             display_name: "context file.txt".to_owned(),
         },

--- a/tests/ui_board/paste_reflow.rs
+++ b/tests/ui_board/paste_reflow.rs
@@ -139,6 +139,7 @@ fn protected_attachment_payload_pastes_exactly_with_truthful_status() {
             start: 0,
             end: path.len(),
             kind: ContentAnnotationKind::Attachment {
+                ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                 image: true,
                 display_name: "Some File.png".to_owned(),
             },

--- a/tests/ui_board/placeholder_space.rs
+++ b/tests/ui_board/placeholder_space.rs
@@ -23,8 +23,9 @@ fn substitution(kind: ContentAnnotationKind, start: usize, end: usize) -> Conten
     ContentAnnotation { start, end, kind }
 }
 
-fn attachment(image: bool) -> ContentAnnotationKind {
+fn attachment(image: bool, ordinal: u64) -> ContentAnnotationKind {
     ContentAnnotationKind::Attachment {
+        ordinal: Some(ordinal.try_into().expect("fixture ordinal")),
         image,
         display_name: if image { "image.png" } else { "context.txt" }.to_owned(),
     }
@@ -141,7 +142,7 @@ fn beginning_middle_end_and_reversed_placeholders_shift_exactly_once() {
     ] {
         let before = format!("{prefix}{value}{suffix}");
         let expected = format!("{prefix} {value}{suffix}");
-        let mut fixture = annotated(prefix, value, suffix, attachment(true));
+        let mut fixture = annotated(prefix, value, suffix, attachment(true, 1));
         if reverse {
             select_reverse(&mut fixture, suffix);
         } else {
@@ -155,8 +156,8 @@ fn beginning_middle_end_and_reversed_placeholders_shift_exactly_once() {
 #[test]
 fn every_substitution_kind_and_adjacent_placeholders_use_the_same_projection_rule() {
     let kinds = [
-        attachment(true),
-        attachment(false),
+        attachment(true, 1),
+        attachment(false, 1),
         ContentAnnotationKind::LargePaste {
             lines: 14,
             graphemes: 1_234,
@@ -179,8 +180,8 @@ fn every_substitution_kind_and_adjacent_placeholders_use_the_same_projection_rul
     let mut fixture = Fixture::with_annotated_thought(
         &content,
         vec![
-            substitution(attachment(true), 0, first.len()),
-            substitution(attachment(true), first.len(), content.len()),
+            substitution(attachment(true, 1), 0, first.len()),
+            substitution(attachment(true, 2), first.len(), content.len()),
         ],
     );
     select_reverse(&mut fixture, "");
@@ -193,7 +194,7 @@ fn every_substitution_kind_and_adjacent_placeholders_use_the_same_projection_rul
 #[test]
 fn repeated_space_keeps_the_placeholder_and_ordinary_followup_spaces() {
     let value = "/tmp/repeat.png";
-    let mut fixture = annotated("", value, "", attachment(true));
+    let mut fixture = annotated("", value, "", attachment(true, 1));
     select_forward(&mut fixture, "");
     let first = space_revision(&mut fixture);
     assert_eq!(first.after_content, format!(" {value}"));
@@ -224,7 +225,7 @@ fn repeated_space_keeps_the_placeholder_and_ordinary_followup_spaces() {
 #[test]
 fn delete_backspace_enter_replacement_and_paste_keep_existing_semantics() {
     for key in [UiKey::Delete, UiKey::Backspace] {
-        let mut fixture = annotated("a", "TOKEN", "z", attachment(false));
+        let mut fixture = annotated("a", "TOKEN", "z", attachment(false, 1));
         select_forward(&mut fixture, "a");
         fixture.input(crate::key_input(key));
         let effects = fixture
@@ -237,7 +238,7 @@ fn delete_backspace_enter_replacement_and_paste_keep_existing_semantics() {
         assert!(revision.after_annotations.is_empty());
     }
 
-    let mut entered = annotated("a", "TOKEN", "z", attachment(false));
+    let mut entered = annotated("a", "TOKEN", "z", attachment(false, 1));
     select_forward(&mut entered, "a");
     assert!(entered.effects(crate::key_input(UiKey::Enter)).is_empty());
     assert_eq!(
@@ -251,7 +252,7 @@ fn delete_backspace_enter_replacement_and_paste_keep_existing_semantics() {
         UiInput::Paste(" ".to_owned()),
         UiInput::Paste("first\r\nsecond".to_owned()),
     ] {
-        let mut fixture = annotated("a", "TOKEN", "z", attachment(false));
+        let mut fixture = annotated("a", "TOKEN", "z", attachment(false, 1));
         select_forward(&mut fixture, "a");
         let mut effects = fixture.effects(input);
         if effects.is_empty() {
@@ -276,7 +277,7 @@ fn delete_backspace_enter_replacement_and_paste_keep_existing_semantics() {
 
 #[test]
 fn partial_wide_multi_expanded_inline_and_plain_selections_are_not_eligible() {
-    let mut partial = annotated("", "TOKEN", "", attachment(false));
+    let mut partial = annotated("", "TOKEN", "", attachment(false, 1));
     partial.input(crate::key_input(UiKey::Enter));
     partial.input(move_key(CursorMovement::DocumentStart, false));
     partial.input(move_key(CursorMovement::GraphemeForward, true));
@@ -298,8 +299,8 @@ fn partial_wide_multi_expanded_inline_and_plain_selections_are_not_eligible() {
     let mut wide = Fixture::with_annotated_thought(
         "pONEmTWOs",
         vec![
-            substitution(attachment(false), 1, 1 + first.len()),
-            substitution(attachment(false), 5, 5 + second.len()),
+            substitution(attachment(false, 1), 1, 1 + first.len()),
+            substitution(attachment(false, 2), 5, 5 + second.len()),
         ],
     );
     wide.input(crate::key_input(UiKey::Enter));
@@ -308,7 +309,7 @@ fn partial_wide_multi_expanded_inline_and_plain_selections_are_not_eligible() {
     wide.input(crate::key_input(UiKey::UnmodifiedSpace));
     assert_eq!(wide.app.editor_snapshot().expect("editor").content, " ");
 
-    let mut expanded = annotated("", "TOKEN", "", attachment(false));
+    let mut expanded = annotated("", "TOKEN", "", attachment(false, 1));
     select_forward(&mut expanded, "");
     expanded.input(crate::key_input(UiKey::Enter));
     expanded.input(move_key(CursorMovement::DocumentStart, false));
@@ -336,7 +337,7 @@ fn partial_wide_multi_expanded_inline_and_plain_selections_are_not_eligible() {
 #[test]
 fn board_compose_and_search_retain_their_space_behavior() {
     let mut board =
-        Fixture::with_annotated_thought("TOKEN", vec![substitution(attachment(false), 0, 5)]);
+        Fixture::with_annotated_thought("TOKEN", vec![substitution(attachment(false, 1), 0, 5)]);
     assert!(
         board
             .effects(crate::key_input(UiKey::UnmodifiedSpace))
@@ -371,7 +372,7 @@ fn inaccessible_mouse_selection_survives_resize_and_shifts_without_recheck() {
     let insertion = fixture.effects(UiInput::PasteAnnotated(
         PastePayload::annotated(
             path.to_owned(),
-            vec![substitution(attachment(true), 0, path.len())],
+            vec![substitution(attachment(true, 1), 0, path.len())],
         )
         .expect("payload"),
     ));
@@ -421,7 +422,7 @@ fn inaccessible_mouse_selection_survives_resize_and_shifts_without_recheck() {
 #[test]
 fn failure_retry_undo_and_redo_keep_one_revision_and_exact_metadata() {
     let value = "/tmp/history.png";
-    let mut fixture = annotated("a", value, "z", attachment(true));
+    let mut fixture = annotated("a", value, "z", attachment(true, 1));
     select_forward(&mut fixture, "a");
     let revision = space_revision(&mut fixture);
     fixture
@@ -471,7 +472,7 @@ fn failure_retry_undo_and_redo_keep_one_revision_and_exact_metadata() {
 #[test]
 fn shifted_placeholder_has_a_reviewed_narrow_editor_snapshot() {
     let value = "/tmp/snapshot.png";
-    let mut fixture = annotated("before ", value, " after", attachment(true));
+    let mut fixture = annotated("before ", value, " after", attachment(true, 1));
     select_forward(&mut fixture, "before ");
     let _revision = space_revision(&mut fixture);
     let terminal = draw_theme(&mut fixture, 32, 7, ThemePreference::Dark);

--- a/tests/ui_board/placeholder_space/stress.rs
+++ b/tests/ui_board/placeholder_space/stress.rs
@@ -16,8 +16,8 @@ fn space_preserves_an_expanded_sibling_while_shifting_the_collapsed_target() {
     let mut fixture = Fixture::with_annotated_thought(
         &content,
         vec![
-            substitution(attachment(true), 0, expanded.len()),
-            substitution(attachment(false), second_start, content.len()),
+            substitution(attachment(true, 1), 0, expanded.len()),
+            substitution(attachment(false, 1), second_start, content.len()),
         ],
     );
     select_forward(&mut fixture, "");

--- a/tests/ui_board/sentence_deletion.rs
+++ b/tests/ui_board/sentence_deletion.rs
@@ -161,6 +161,7 @@ fn sentence_deletion_rebases_unrelated_fold_annotations_exactly() {
         start,
         end: start + path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: true,
             display_name: "image.png".to_owned(),
         },
@@ -200,6 +201,7 @@ fn sentence_with_a_fold_is_revealed_unchanged_then_deleted_on_repeat() {
                 start,
                 end: start + path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "image.png".to_owned(),
                 },
@@ -238,12 +240,19 @@ fn every_intersecting_fold_is_revealed_while_an_unrelated_fold_stays_collapsed()
     let content = "Use /tmp/a.png and /tmp/b.png now. Keep /tmp/c.png.";
     let annotations = ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"]
         .into_iter()
-        .map(|path| {
+        .enumerate()
+        .map(|(index, path)| {
             let start = content.find(path).expect("path");
             ContentAnnotation {
                 start,
                 end: start + path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(
+                        u64::try_from(index + 1)
+                            .expect("index")
+                            .try_into()
+                            .expect("fixture ordinal"),
+                    ),
                     image: true,
                     display_name: path.trim_start_matches("/tmp/").to_owned(),
                 },
@@ -276,12 +285,19 @@ fn selection_reveals_every_touched_fold_before_deleting_any_sentence() {
     let content = "Use /tmp/a.png now. Keep /tmp/b.png later.";
     let annotations = ["/tmp/a.png", "/tmp/b.png"]
         .into_iter()
-        .map(|path| {
+        .enumerate()
+        .map(|(index, path)| {
             let start = content.find(path).expect("path");
             ContentAnnotation {
                 start,
                 end: start + path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(
+                        u64::try_from(index + 1)
+                            .expect("index")
+                            .try_into()
+                            .expect("fixture ordinal"),
+                    ),
                     image: true,
                     display_name: path.trim_start_matches("/tmp/").to_owned(),
                 },

--- a/tests/ui_board/smart_lists.rs
+++ b/tests/ui_board/smart_lists.rs
@@ -150,6 +150,7 @@ fn selected_line_indentation_excludes_a_column_zero_endpoint_and_preserves_annot
         start: annotation_start,
         end: annotation_start + path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: false,
             display_name: "context.txt".to_owned(),
         },
@@ -259,6 +260,7 @@ fn paste_is_exact_and_smart_newlines_preserve_annotations_through_resize() {
         start: 0,
         end: path.len(),
         kind: ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: false,
             display_name: "context.txt".to_owned(),
         },

--- a/tests/ui_board/snapshots.rs
+++ b/tests/ui_board/snapshots.rs
@@ -13,6 +13,8 @@ use proqi::{
 use super::snapshot_support::snapshot_buffer;
 #[path = "snapshots/attachment_accessibility.rs"]
 mod attachment_accessibility_snapshots;
+#[path = "snapshots/attachment_numbering.rs"]
+mod attachment_numbering;
 #[path = "snapshots/herdr.rs"]
 mod herdr_snapshots;
 #[path = "snapshots/platform.rs"]
@@ -46,24 +48,7 @@ fn engaged_empty_compose_editor() {
 
 #[test]
 fn populated_board_with_folded_attachment() {
-    let mut fixture = Fixture::new();
-    fixture.input(UiInput::Paste("first prompt".to_owned()));
-    fixture.input(crate::key_input(UiKey::Escape));
-    fixture.input(UiInput::PasteAnnotated(
-        PastePayload::annotated(
-            "/private/tmp/Bild (18).png".to_owned(),
-            vec![ContentAnnotation {
-                start: 0,
-                end: "/private/tmp/Bild (18).png".len(),
-                kind: ContentAnnotationKind::Attachment {
-                    image: true,
-                    display_name: "Bild (18).png".to_owned(),
-                },
-            }],
-        )
-        .expect("valid attachment payload"),
-    ));
-    fixture.input(crate::key_input(UiKey::Escape));
+    let mut fixture = attachment_numbering::populated_attachment_fixture();
     insta::assert_snapshot!(snapshot(&mut fixture, 60, 12, ThemePreference::Dark));
 }
 
@@ -78,6 +63,7 @@ fn inaccessible_attachment_has_a_plain_warning_snapshot() {
                 start: 0,
                 end: path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "Grüße 第一.png".to_owned(),
                 },

--- a/tests/ui_board/snapshots/attachment_accessibility.rs
+++ b/tests/ui_board/snapshots/attachment_accessibility.rs
@@ -11,6 +11,7 @@ fn expanded_inaccessible_attachment_keeps_a_plain_warning_snapshot() {
                 start: 0,
                 end: path.len(),
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: true,
                     display_name: "missing.png".to_owned(),
                 },

--- a/tests/ui_board/snapshots/attachment_numbering.rs
+++ b/tests/ui_board/snapshots/attachment_numbering.rs
@@ -1,0 +1,77 @@
+//! Stable multi-digit labels after board movement, with an independent file sequence.
+
+use super::snapshot;
+use crate::{Fixture, key_input};
+use proqi::{
+    domain::{ContentAnnotation, ContentAnnotationKind},
+    ports::editor::CursorMovement,
+    ui::{PastePayload, ThemePreference, UiInput, UiKey},
+};
+
+fn paste(fixture: &mut Fixture, image: bool) {
+    let content = "/offline/Grüße asset.png".to_owned();
+    let annotation = ContentAnnotation {
+        start: 0,
+        end: content.len(),
+        kind: ContentAnnotationKind::Attachment {
+            ordinal: None,
+            image,
+            display_name: "asset.png".to_owned(),
+        },
+    };
+    fixture.input(UiInput::PasteAnnotated(
+        PastePayload::annotated(content, vec![annotation]).expect("payload"),
+    ));
+    fixture.input(key_input(UiKey::Escape));
+}
+
+#[test]
+fn shuffled_session_labels_keep_multidigit_image_identity_and_independent_files() {
+    let mut fixture = Fixture::new();
+    for _ in 0..14 {
+        paste(&mut fixture, true);
+    }
+    fixture.input(key_input(UiKey::PrimaryShiftMove {
+        movement: CursorMovement::VisualDown,
+    }));
+    assert!(matches!(
+        fixture.app.state.board.live_thoughts()[0].annotations[0].kind,
+        ContentAnnotationKind::Attachment { ordinal: Some(ordinal), .. } if ordinal.get() == 14
+    ));
+    paste(&mut fixture, false);
+    paste(&mut fixture, false);
+    for _ in 0..2 {
+        fixture.input(key_input(UiKey::Move {
+            movement: CursorMovement::VisualUp,
+            extend_selection: false,
+        }));
+    }
+    let rendered = snapshot(&mut fixture, 48, 20, ThemePreference::Dark);
+    assert!(rendered.contains("Image 13"), "{rendered}");
+    assert!(rendered.contains("File 1"));
+    assert!(rendered.contains("File 2"));
+    insta::assert_snapshot!(rendered);
+}
+
+pub(super) fn populated_attachment_fixture() -> Fixture {
+    let mut fixture = Fixture::new();
+    fixture.input(UiInput::Paste("first prompt".to_owned()));
+    fixture.input(crate::key_input(UiKey::Escape));
+    fixture.input(UiInput::PasteAnnotated(
+        PastePayload::annotated(
+            "/private/tmp/Bild (18).png".to_owned(),
+            vec![ContentAnnotation {
+                start: 0,
+                end: "/private/tmp/Bild (18).png".len(),
+                kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
+                    image: true,
+                    display_name: "Bild (18).png".to_owned(),
+                },
+            }],
+        )
+        .expect("valid attachment payload"),
+    ));
+    fixture.input(crate::key_input(UiKey::Escape));
+    fixture
+}

--- a/tests/ui_board/snapshots/snapshots/ui_board__snapshots__attachment_numbering__shuffled_session_labels_keep_multidigit_image_identity_and_independent_files.snap
+++ b/tests/ui_board/snapshots/snapshots/ui_board__snapshots__attachment_numbering__shuffled_session_labels_keep_multidigit_image_identity_and_independent_files.snap
@@ -1,0 +1,50 @@
+---
+source: tests/ui_board/snapshots/attachment_numbering.rs
+assertion_line: 53
+expression: rendered
+---
+SIZE 48x20
+
+TEXT
+00│  ──────────────────────────────────────────────│
+01│  [Image 9]│
+02│  ──────────────────────────────────────────────│
+03│  [Image 10]│
+04│  ──────────────────────────────────────────────│
+05│  [Image 11]│
+06│  ──────────────────────────────────────────────│
+07│  [Image 12]│
+08│  ──────────────────────────────────────────────│
+09│⋮ [Image 13]│
+10│  ──────────────────────────────────────────────│
+11│  [File 1]│
+12│  ──────────────────────────────────────────────│
+13│  [File 2]│
+14││
+15│                  + New thought│
+16││
+17│  proqi-ui-contract│
+18│  16 thoughts · board · saving│
+19│  n New   : Commands  ? Shortcuts│
+
+STYLE RUNS
+0: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 11-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+2: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+3: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-11 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 12-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-11 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 12-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+6: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+7: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-11 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 12-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+8: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+9: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-11 fg=Rgb(112, 214, 155) bg=Rgb(39, 40, 48) mod=BOLD | 12-47 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+10: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+11: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-9 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 10-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+12: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-47 fg=Rgb(42, 37, 32) bg=Rgb(15, 13, 10) mod=NONE
+13: 0-0 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-9 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=BOLD | 10-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+14: 0-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+15: 0-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-18 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 19-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+16: 0-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+17: 0-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+18: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-45 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 46-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+19: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 11-21 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 22-22 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 23-47 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE

--- a/tests/ui_board/transformations.rs
+++ b/tests/ui_board/transformations.rs
@@ -128,6 +128,7 @@ fn split_uses_annotations_rebased_by_the_edit_flushed_on_exit() {
                 start: 0,
                 end: 6,
                 kind: ContentAnnotationKind::Attachment {
+                    ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
                     image: false,
                     display_name: "fold.txt".to_owned(),
                 },

--- a/tests/ui_board/visual_row_selection.rs
+++ b/tests/ui_board/visual_row_selection.rs
@@ -195,6 +195,7 @@ fn collapsed_substitutions_are_atomic_and_expanded_folds_use_exact_content_rows(
     let content = "canonical folded payload";
     for annotation in [
         substitution(ContentAnnotationKind::Attachment {
+            ordinal: Some(1_u64.try_into().expect("fixture ordinal")),
             image: false,
             display_name: "payload.txt".to_owned(),
         }),


### PR DESCRIPTION
## Summary

Attachment labels restart in each thought today, so screenshots become hard to trace after a board is reorganized. Assign each new attachment occurrence a durable session-wide Image or File ordinal. Structural movement, editing, health changes, undo/redo, and restart preserve it; new copies and destination-session pastes allocate fresh numbers, and deleted numbers are never reused.

Schema 14 migrates live boards first, then retained history, using deterministic legacy matching and receipt-aware undo/redo bindings. Counters include dormant history. Canonical paths, annotation ranges, clipboard plain text, and submission content remain exact. Storage protocol 13, attachment-bearing control protocol 8, and typed clipboard schema 2 protect the new contract.

By contributing, you agree that your contribution is licensed under the
repository's [MIT License](https://github.com/oborchers/proqi/blob/main/LICENSE).
See [CONTRIBUTING.md](https://github.com/oborchers/proqi/blob/main/CONTRIBUTING.md)
for the repository's contribution rules.
Report vulnerabilities through
[SECURITY.md](https://github.com/oborchers/proqi/blob/main/SECURITY.md), never in
this pull request.

## Verification

- [x] `cargo xtask check` passes (1,594 tests; five skipped)
- [x] Nine focused numbering regressions cover allocation, migration, retries, corruption, and historical replay
- [x] PRODUCT, ARCHITECTURE, and prepared release notes describe the contract
- [x] No runtime state, secrets, or machine-specific paths are committed
- [x] One new representative snapshot was reviewed explicitly
- [x] Native read-only review completed in three passes; final pass has no findings
- [x] `cargo xtask test-pty` passes (77 tests)
- [x] `cargo xtask audit`, `cargo xtask package`, and `cargo xtask coverage` pass
- [x] Live Herdr exercise covered fifteen captures, mixed file paste, reordering, pointer and keyboard, undo/redo, health transitions, narrow/shallow resize, restart, persistence, and terminal restoration

The first serial PTY attempt stalled in the existing high-volume scroll fixture while other verification ran. Its owned children were stopped; the unchanged isolated rerun passed all 77 tests.
