### PR TITLE
Show truthful macOS iCloud attachment states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,8 @@ dependencies = [
  "interprocess",
  "kqueue",
  "linkify",
+ "objc2",
+ "objc2-foundation",
  "png",
  "portable-pty",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ uuid.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 kqueue.workspace = true
+objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSArray", "NSDictionary", "NSError", "NSString", "NSURL", "NSValue"] }
 xattr.workspace = true
 
 [dev-dependencies]

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -364,17 +364,29 @@ never read or copied automatically.
 
 ### `AttachmentAccessibility`
 
-External attachment health crosses a terminal-independent read-only port. The
-filesystem adapter opens the exact absolute path without rewriting it, proves
-that it is a readable regular file, and returns typed missing, permission,
-unmounted, unreadable, or I/O failures. The bounded lane adds timeout and
-cancellation failures without waiting for a blocked filesystem call to return.
-Those reasons are content-free diagnostics only. Application and UI consumers
-reduce every completed failure to binary inaccessible health. Unknown and
+External attachment health crosses a terminal-independent read-only port. Its
+typed outcome is available, in iCloud, downloading, or a typed generic failure.
+The filesystem adapter opens the exact absolute path without rewriting it,
+proves that it is a readable regular file, and returns typed missing,
+permission, unmounted, unreadable, or I/O failures. The bounded lane adds
+timeout and cancellation failures without waiting for a blocked filesystem
+call to return. Those reasons are content-free diagnostics only. Unknown and
 checking state remain visually neutral without becoming accessibility proof.
 
+On macOS, the same killable attachment worker first reads the public Foundation
+URL resource values for ubiquitous identity, downloading activity, downloading
+status, and downloading error. Only a complete, correctly typed, error-free
+ubiquitous result can establish an iCloud presentation. `NotDownloaded` with an
+explicitly inactive download becomes in iCloud. An explicitly active download
+becomes downloading. `Downloaded` and `Current` still pass through the exact
+readability proof. Missing, wrong-typed, unknown, contradictory, or failed
+metadata falls through to the generic filesystem classification without an
+iCloud claim. Other platforms do not link Foundation and preserve the generic
+behavior. The adapter never calls a materialization or download API.
+
 Application state owns the transient exact-key cache, its explicit unknown,
-checking, accessible, and inaccessible states, and the scheduling policy.
+checking, available, in iCloud, downloading, and inaccessible states, and the
+scheduling policy.
 Keys include the thought, annotation index and range, presentation metadata,
 canonical path, and digest of the canonical content revision. Insertion and
 relink mutations invalidate affected work. Restoration schedules the focused
@@ -387,9 +399,9 @@ Submission captures exact source thoughts and attachment keys before waiting
 for durability. Once pending edits are durable, a fresh bounded preflight owns
 the accessibility lane ahead of background continuation. The locked sources
 must still match both their content digests and attachment keys when the check
-completes. Any inaccessible, timed-out, cancelled, incomplete, or stale result
-releases the source locks without preparing a journal attempt or invoking an
-agent gateway.
+completes. Any in iCloud, downloading, inaccessible, timed-out, cancelled,
+incomplete, or stale result releases the source locks without preparing a
+journal attempt or invoking an agent gateway.
 
 ### `ScreenshotWatcher`
 

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -373,16 +373,18 @@ timeout and cancellation failures without waiting for a blocked filesystem
 call to return. Those reasons are content-free diagnostics only. Unknown and
 checking state remain visually neutral without becoming accessibility proof.
 
-On macOS, the same killable attachment worker first reads the public Foundation
-URL resource values for ubiquitous identity, downloading activity, downloading
-status, and downloading error. Only a complete, correctly typed, error-free
-ubiquitous result can establish an iCloud presentation. `NotDownloaded` with an
-explicitly inactive download becomes in iCloud. An explicitly active download
-becomes downloading. `Downloaded` and `Current` still pass through the exact
-readability proof. Missing, wrong-typed, unknown, contradictory, or failed
-metadata falls through to the generic filesystem classification without an
-iCloud claim. Other platforms do not link Foundation and preserve the generic
-behavior. The adapter never calls a materialization or download API.
+On macOS, a private platform module in the same killable attachment worker
+reads the public Foundation URL resource values for ubiquitous identity,
+downloading activity, downloading status, and downloading error. The raw
+metadata types and translation policy remain confined to that module. Only a
+complete, correctly typed, error-free ubiquitous result can establish an
+iCloud presentation. `NotDownloaded` with an explicitly inactive download
+becomes in iCloud. An explicitly active download becomes downloading.
+`Downloaded` and `Current` still pass through the exact readability proof.
+Missing, wrong-typed, unknown, contradictory, or failed metadata falls through
+to the generic filesystem classification without an iCloud claim. Other
+platforms compile no cloud probe, do not link Foundation, and preserve the
+generic behavior. The adapter never calls a materialization or download API.
 
 Application state owns the transient exact-key cache, its explicit unknown,
 checking, available, in iCloud, downloading, and inaccessible states, and the

--- a/context/PRODUCT.md
+++ b/context/PRODUCT.md
@@ -572,11 +572,20 @@ Attachment annotations keep an external absolute path as canonical prompt
 content. Proqi presents a readable or not-yet-resolved attachment as
 `[Image N]` or `[File N]`. Unknown and checking health are not accessibility
 proof and remain fail-closed for actions that require a readable file, but they
-do not show a false warning. Only a completed failed check changes the same
-annotation to `[Image N · inaccessible]` or `[File N · inaccessible]` and uses
-the warning visual role. Missing files, permissions, unavailable volumes,
-filesystem failures, and bounded check timeouts remain diagnostic details
-rather than additional user-visible states.
+do not show a false warning. On macOS, public Foundation URL resource metadata
+can prove that an iCloud item has no local copy or is currently downloading.
+Those states append `· in iCloud` or `· downloading` to the same numeric label.
+Once the exact file becomes locally readable, its normal label returns. Proqi
+never requests or initiates an iCloud download.
+
+Only authoritative ubiquitous-item metadata can produce either iCloud state.
+A failed open or read never implies iCloud. Missing files, permissions,
+unavailable volumes, unreadable entries, ordinary filesystem failures, bounded
+check timeouts, and cancellation retain the generic `[Image N · inaccessible]`
+or `[File N · inaccessible]` presentation and the warning visual role. Absent
+or contradictory cloud metadata, other File Provider placeholders, and
+non-macOS platforms cannot produce an iCloud claim. They use the same generic
+presentation whenever exact local readability also fails.
 
 Health is transient and never changes prompt content. Proqi checks new
 annotations immediately, checks a restored board with the focused thought
@@ -587,9 +596,11 @@ fallback. Proqi does not poll or watch external attachment directories.
 
 Every adjacent-agent submission freshly verifies every attachment in the exact
 captured source set after edits are durable. The sources remain locked during
-that bounded preflight. If any check fails or times out, Proqi creates no
-submission attempt, sends nothing, removes nothing, and reports one aggregate
-error. There is no bypass action for an annotated inaccessible asset.
+that bounded preflight. In iCloud, downloading, inaccessible, timed-out, and
+cancelled results are all fail-closed. Proqi creates no submission attempt,
+sends nothing, removes nothing, and reports one aggregate error until every
+exact source is locally readable. There is no bypass action for an annotated
+unavailable asset.
 
 The path remains an external reference. A file can still disappear after the
 last successful check and before the receiving agent opens it. Proqi neither

--- a/src/adapters/attachment/accessibility.rs
+++ b/src/adapters/attachment/accessibility.rs
@@ -4,32 +4,96 @@ use std::{fs::File, io::Read as _, path::Path};
 
 use rustix::fs::{Mode, OFlags};
 
-use crate::ports::attachment_accessibility::{AttachmentAccessFailure, AttachmentAccessibility};
+use crate::ports::attachment_accessibility::{
+    AttachmentAccessFailure, AttachmentAccessibility, AttachmentAvailability,
+};
 
-/// System filesystem implementation of binary attachment accessibility.
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CloudDownloadStatus {
+    NotDownloaded,
+    Downloaded,
+    Current,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CloudMetadata {
+    ubiquitous: Option<bool>,
+    downloading: Option<bool>,
+    status: Option<CloudDownloadStatus>,
+    has_download_error: bool,
+}
+
+trait CloudMetadataProbe {
+    fn metadata(&self, path: &Path) -> Option<CloudMetadata>;
+}
+
+#[cfg(not(target_os = "macos"))]
+struct PlatformCloudMetadata;
+
+#[cfg(not(target_os = "macos"))]
+impl CloudMetadataProbe for PlatformCloudMetadata {
+    fn metadata(&self, _path: &Path) -> Option<CloudMetadata> {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+use macos::PlatformCloudMetadata;
+
+/// System filesystem implementation of typed attachment availability.
 #[derive(Default)]
 pub struct FileAttachmentAccessibility;
 
 impl AttachmentAccessibility for FileAttachmentAccessibility {
-    fn check(&mut self, path: &Path) -> Result<(), AttachmentAccessFailure> {
-        if !path.is_absolute() {
-            return Err(AttachmentAccessFailure::Unreadable);
-        }
-        let descriptor = rustix::fs::open(
-            path,
-            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK,
-            Mode::empty(),
-        )
-        .map_err(map_errno)?;
-        let mut file = File::from(descriptor);
-        let metadata = file.metadata().map_err(|error| map_io(&error))?;
-        if !metadata.is_file() {
-            return Err(AttachmentAccessFailure::Unreadable);
-        }
-        let mut probe = [0_u8; 1];
-        let _bytes = file.read(&mut probe).map_err(|error| map_io(&error))?;
-        Ok(())
+    fn check(&mut self, path: &Path) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
+        check_with_metadata(path, &PlatformCloudMetadata)
     }
+}
+
+fn check_with_metadata(
+    path: &Path,
+    cloud: &impl CloudMetadataProbe,
+) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
+    if !path.is_absolute() {
+        return Err(AttachmentAccessFailure::Unreadable);
+    }
+    if let Some(metadata) = cloud.metadata(path)
+        && metadata.ubiquitous == Some(true)
+        && !metadata.has_download_error
+    {
+        match (metadata.downloading, metadata.status) {
+            (
+                Some(true),
+                Some(CloudDownloadStatus::NotDownloaded | CloudDownloadStatus::Downloaded),
+            ) => return Ok(AttachmentAvailability::Downloading),
+            (Some(false), Some(CloudDownloadStatus::NotDownloaded)) => {
+                return Ok(AttachmentAvailability::InCloud);
+            }
+            _ => {}
+        }
+    }
+    prove_exact_readability(path)
+}
+
+fn prove_exact_readability(path: &Path) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
+    let descriptor = rustix::fs::open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(map_errno)?;
+    let mut file = File::from(descriptor);
+    let metadata = file.metadata().map_err(|error| map_io(&error))?;
+    if !metadata.is_file() {
+        return Err(AttachmentAccessFailure::Unreadable);
+    }
+    let mut probe = [0_u8; 1];
+    let _bytes = file.read(&mut probe).map_err(|error| map_io(&error))?;
+    Ok(AttachmentAvailability::Available)
 }
 
 fn map_errno(error: rustix::io::Errno) -> AttachmentAccessFailure {
@@ -59,10 +123,21 @@ fn map_io(error: &std::io::Error) -> AttachmentAccessFailure {
 #[cfg(test)]
 mod tests {
     use crate::ports::attachment_accessibility::{
-        AttachmentAccessFailure, AttachmentAccessibility as _,
+        AttachmentAccessFailure, AttachmentAccessibility as _, AttachmentAvailability,
     };
 
-    use super::FileAttachmentAccessibility;
+    use super::{
+        CloudDownloadStatus, CloudMetadata, CloudMetadataProbe, FileAttachmentAccessibility,
+        check_with_metadata,
+    };
+
+    struct FixedMetadata(Option<CloudMetadata>);
+
+    impl CloudMetadataProbe for FixedMetadata {
+        fn metadata(&self, _path: &std::path::Path) -> Option<CloudMetadata> {
+            self.0
+        }
+    }
 
     #[test]
     fn missing_directory_and_unicode_file_are_classified_without_rewriting_paths() {
@@ -70,7 +145,10 @@ mod tests {
         let unicode = temporary.path().join("Grüße 第一.txt");
         std::fs::write(&unicode, b"available").expect("unicode fixture");
         let mut accessibility = FileAttachmentAccessibility;
-        assert_eq!(accessibility.check(&unicode), Ok(()));
+        assert_eq!(
+            accessibility.check(&unicode),
+            Ok(AttachmentAvailability::Available)
+        );
         assert_eq!(
             accessibility.check(&temporary.path().join("missing.txt")),
             Err(AttachmentAccessFailure::Missing)
@@ -110,5 +188,110 @@ mod tests {
             super::map_errno(rustix::io::Errno::IO),
             AttachmentAccessFailure::Io
         );
+    }
+
+    #[test]
+    fn authoritative_ubiquitous_metadata_distinguishes_cloud_states() {
+        let missing = tempfile::tempdir()
+            .expect("temporary directory")
+            .path()
+            .join("evicted.txt");
+        let in_cloud = FixedMetadata(Some(CloudMetadata {
+            ubiquitous: Some(true),
+            downloading: Some(false),
+            status: Some(CloudDownloadStatus::NotDownloaded),
+            has_download_error: false,
+        }));
+        assert_eq!(
+            check_with_metadata(&missing, &in_cloud),
+            Ok(AttachmentAvailability::InCloud)
+        );
+
+        for status in [
+            CloudDownloadStatus::NotDownloaded,
+            CloudDownloadStatus::Downloaded,
+        ] {
+            let downloading = FixedMetadata(Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(status),
+                has_download_error: false,
+            }));
+            assert_eq!(
+                check_with_metadata(&missing, &downloading),
+                Ok(AttachmentAvailability::Downloading)
+            );
+        }
+    }
+
+    #[test]
+    fn downloaded_and_current_metadata_still_require_exact_readability() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let readable = temporary.path().join("local.txt");
+        std::fs::write(&readable, b"content").expect("readable fixture");
+        for status in [
+            CloudDownloadStatus::Downloaded,
+            CloudDownloadStatus::Current,
+        ] {
+            let metadata = FixedMetadata(Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: Some(false),
+                status: Some(status),
+                has_download_error: false,
+            }));
+            assert_eq!(
+                check_with_metadata(&readable, &metadata),
+                Ok(AttachmentAvailability::Available)
+            );
+            assert_eq!(
+                check_with_metadata(&temporary.path().join("missing.txt"), &metadata),
+                Err(AttachmentAccessFailure::Missing)
+            );
+        }
+    }
+
+    #[test]
+    fn unavailable_contradictory_or_failed_metadata_never_claims_icloud() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let missing = temporary.path().join("missing.txt");
+        let cases = [
+            None,
+            Some(CloudMetadata {
+                ubiquitous: Some(false),
+                downloading: Some(true),
+                status: Some(CloudDownloadStatus::NotDownloaded),
+                has_download_error: false,
+            }),
+            Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: None,
+                status: Some(CloudDownloadStatus::NotDownloaded),
+                has_download_error: false,
+            }),
+            Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: Some(false),
+                status: Some(CloudDownloadStatus::Unknown),
+                has_download_error: false,
+            }),
+            Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(CloudDownloadStatus::Current),
+                has_download_error: false,
+            }),
+            Some(CloudMetadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(CloudDownloadStatus::NotDownloaded),
+                has_download_error: true,
+            }),
+        ];
+        for metadata in cases {
+            assert_eq!(
+                check_with_metadata(&missing, &FixedMetadata(metadata)),
+                Err(AttachmentAccessFailure::Missing)
+            );
+        }
     }
 }

--- a/src/adapters/attachment/accessibility.rs
+++ b/src/adapters/attachment/accessibility.rs
@@ -11,72 +11,30 @@ use crate::ports::attachment_accessibility::{
 #[cfg(target_os = "macos")]
 mod macos;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CloudDownloadStatus {
-    NotDownloaded,
-    Downloaded,
-    Current,
-    Unknown,
-}
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct CloudMetadata {
-    ubiquitous: Option<bool>,
-    downloading: Option<bool>,
-    status: Option<CloudDownloadStatus>,
-    has_download_error: bool,
-}
-
-trait CloudMetadataProbe {
-    fn metadata(&self, path: &Path) -> Option<CloudMetadata>;
-}
-
-#[cfg(not(target_os = "macos"))]
-struct PlatformCloudMetadata;
-
-#[cfg(not(target_os = "macos"))]
-impl CloudMetadataProbe for PlatformCloudMetadata {
-    fn metadata(&self, _path: &Path) -> Option<CloudMetadata> {
-        None
-    }
-}
-
-#[cfg(target_os = "macos")]
-use macos::PlatformCloudMetadata;
-
 /// System filesystem implementation of typed attachment availability.
 #[derive(Default)]
 pub struct FileAttachmentAccessibility;
 
 impl AttachmentAccessibility for FileAttachmentAccessibility {
     fn check(&mut self, path: &Path) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
-        check_with_metadata(path, &PlatformCloudMetadata)
+        if !path.is_absolute() {
+            return Err(AttachmentAccessFailure::Unreadable);
+        }
+
+        #[cfg(target_os = "macos")]
+        let platform_availability = macos::availability(path);
+        #[cfg(not(target_os = "macos"))]
+        let platform_availability = None;
+
+        finish_with_platform_availability(path, platform_availability)
     }
 }
 
-fn check_with_metadata(
+fn finish_with_platform_availability(
     path: &Path,
-    cloud: &impl CloudMetadataProbe,
+    platform_availability: Option<AttachmentAvailability>,
 ) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
-    if !path.is_absolute() {
-        return Err(AttachmentAccessFailure::Unreadable);
-    }
-    if let Some(metadata) = cloud.metadata(path)
-        && metadata.ubiquitous == Some(true)
-        && !metadata.has_download_error
-    {
-        match (metadata.downloading, metadata.status) {
-            (
-                Some(true),
-                Some(CloudDownloadStatus::NotDownloaded | CloudDownloadStatus::Downloaded),
-            ) => return Ok(AttachmentAvailability::Downloading),
-            (Some(false), Some(CloudDownloadStatus::NotDownloaded)) => {
-                return Ok(AttachmentAvailability::InCloud);
-            }
-            _ => {}
-        }
-    }
-    prove_exact_readability(path)
+    platform_availability.map_or_else(|| prove_exact_readability(path), Ok)
 }
 
 fn prove_exact_readability(path: &Path) -> Result<AttachmentAvailability, AttachmentAccessFailure> {
@@ -126,18 +84,7 @@ mod tests {
         AttachmentAccessFailure, AttachmentAccessibility as _, AttachmentAvailability,
     };
 
-    use super::{
-        CloudDownloadStatus, CloudMetadata, CloudMetadataProbe, FileAttachmentAccessibility,
-        check_with_metadata,
-    };
-
-    struct FixedMetadata(Option<CloudMetadata>);
-
-    impl CloudMetadataProbe for FixedMetadata {
-        fn metadata(&self, _path: &std::path::Path) -> Option<CloudMetadata> {
-            self.0
-        }
-    }
+    use super::FileAttachmentAccessibility;
 
     #[test]
     fn missing_directory_and_unicode_file_are_classified_without_rewriting_paths() {
@@ -190,108 +137,20 @@ mod tests {
         );
     }
 
+    #[cfg(not(target_os = "macos"))]
     #[test]
-    fn authoritative_ubiquitous_metadata_distinguishes_cloud_states() {
-        let missing = tempfile::tempdir()
-            .expect("temporary directory")
-            .path()
-            .join("evicted.txt");
-        let in_cloud = FixedMetadata(Some(CloudMetadata {
-            ubiquitous: Some(true),
-            downloading: Some(false),
-            status: Some(CloudDownloadStatus::NotDownloaded),
-            has_download_error: false,
-        }));
-        assert_eq!(
-            check_with_metadata(&missing, &in_cloud),
-            Ok(AttachmentAvailability::InCloud)
-        );
-
-        for status in [
-            CloudDownloadStatus::NotDownloaded,
-            CloudDownloadStatus::Downloaded,
-        ] {
-            let downloading = FixedMetadata(Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: Some(true),
-                status: Some(status),
-                has_download_error: false,
-            }));
-            assert_eq!(
-                check_with_metadata(&missing, &downloading),
-                Ok(AttachmentAvailability::Downloading)
-            );
-        }
-    }
-
-    #[test]
-    fn downloaded_and_current_metadata_still_require_exact_readability() {
+    fn non_macos_uses_only_exact_generic_readability() {
         let temporary = tempfile::tempdir().expect("temporary directory");
         let readable = temporary.path().join("local.txt");
         std::fs::write(&readable, b"content").expect("readable fixture");
-        for status in [
-            CloudDownloadStatus::Downloaded,
-            CloudDownloadStatus::Current,
-        ] {
-            let metadata = FixedMetadata(Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: Some(false),
-                status: Some(status),
-                has_download_error: false,
-            }));
-            assert_eq!(
-                check_with_metadata(&readable, &metadata),
-                Ok(AttachmentAvailability::Available)
-            );
-            assert_eq!(
-                check_with_metadata(&temporary.path().join("missing.txt"), &metadata),
-                Err(AttachmentAccessFailure::Missing)
-            );
-        }
-    }
-
-    #[test]
-    fn unavailable_contradictory_or_failed_metadata_never_claims_icloud() {
-        let temporary = tempfile::tempdir().expect("temporary directory");
-        let missing = temporary.path().join("missing.txt");
-        let cases = [
-            None,
-            Some(CloudMetadata {
-                ubiquitous: Some(false),
-                downloading: Some(true),
-                status: Some(CloudDownloadStatus::NotDownloaded),
-                has_download_error: false,
-            }),
-            Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: None,
-                status: Some(CloudDownloadStatus::NotDownloaded),
-                has_download_error: false,
-            }),
-            Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: Some(false),
-                status: Some(CloudDownloadStatus::Unknown),
-                has_download_error: false,
-            }),
-            Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: Some(true),
-                status: Some(CloudDownloadStatus::Current),
-                has_download_error: false,
-            }),
-            Some(CloudMetadata {
-                ubiquitous: Some(true),
-                downloading: Some(true),
-                status: Some(CloudDownloadStatus::NotDownloaded),
-                has_download_error: true,
-            }),
-        ];
-        for metadata in cases {
-            assert_eq!(
-                check_with_metadata(&missing, &FixedMetadata(metadata)),
-                Err(AttachmentAccessFailure::Missing)
-            );
-        }
+        let mut accessibility = FileAttachmentAccessibility;
+        assert_eq!(
+            accessibility.check(&readable),
+            Ok(AttachmentAvailability::Available)
+        );
+        assert_eq!(
+            accessibility.check(&temporary.path().join("missing.txt")),
+            Err(AttachmentAccessFailure::Missing)
+        );
     }
 }

--- a/src/adapters/attachment/accessibility/macos.rs
+++ b/src/adapters/attachment/accessibility/macos.rs
@@ -7,16 +7,36 @@ use objc2_foundation::{
     NSArray, NSDictionary, NSNumber, NSString, NSURL, NSURLResourceKey, ns_string,
 };
 
-use super::{CloudDownloadStatus, CloudMetadata, CloudMetadataProbe};
+use crate::ports::attachment_accessibility::AttachmentAvailability;
 
 const STATUS_NOT_DOWNLOADED: &str = "NSURLUbiquitousItemDownloadingStatusNotDownloaded";
 const STATUS_DOWNLOADED: &str = "NSURLUbiquitousItemDownloadingStatusDownloaded";
 const STATUS_CURRENT: &str = "NSURLUbiquitousItemDownloadingStatusCurrent";
 
-pub(super) struct PlatformCloudMetadata;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DownloadStatus {
+    NotDownloaded,
+    Downloaded,
+    Current,
+    Unknown,
+}
 
-impl CloudMetadataProbe for PlatformCloudMetadata {
-    fn metadata(&self, path: &Path) -> Option<CloudMetadata> {
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct Metadata {
+    ubiquitous: Option<bool>,
+    downloading: Option<bool>,
+    status: Option<DownloadStatus>,
+    has_download_error: bool,
+}
+
+trait MetadataProbe {
+    fn metadata(&self, path: &Path) -> Option<Metadata>;
+}
+
+struct FoundationMetadata;
+
+impl MetadataProbe for FoundationMetadata {
+    fn metadata(&self, path: &Path) -> Option<Metadata> {
         let url = NSURL::from_file_path(path)?;
         let ubiquitous_key = ns_string!("NSURLIsUbiquitousItemKey");
         let downloading_key = ns_string!("NSURLUbiquitousItemIsDownloadingKey");
@@ -24,12 +44,36 @@ impl CloudMetadataProbe for PlatformCloudMetadata {
         let error_key = ns_string!("NSURLUbiquitousItemDownloadingErrorKey");
         let keys = NSArray::from_slice(&[ubiquitous_key, downloading_key, status_key, error_key]);
         let values = url.resourceValuesForKeys_error(&keys).ok()?;
-        Some(CloudMetadata {
+        Some(Metadata {
             ubiquitous: bool_value(&values, ubiquitous_key),
             downloading: bool_value(&values, downloading_key),
             status: status_value(&values, status_key),
             has_download_error: values.objectForKey(error_key).is_some(),
         })
+    }
+}
+
+pub(super) fn availability(path: &Path) -> Option<AttachmentAvailability> {
+    availability_with_metadata(path, &FoundationMetadata)
+}
+
+fn availability_with_metadata(
+    path: &Path,
+    metadata: &impl MetadataProbe,
+) -> Option<AttachmentAvailability> {
+    classify(metadata.metadata(path)?)
+}
+
+fn classify(metadata: Metadata) -> Option<AttachmentAvailability> {
+    if metadata.ubiquitous != Some(true) || metadata.has_download_error {
+        return None;
+    }
+    match (metadata.downloading, metadata.status) {
+        (Some(true), Some(DownloadStatus::NotDownloaded | DownloadStatus::Downloaded)) => {
+            Some(AttachmentAvailability::Downloading)
+        }
+        (Some(false), Some(DownloadStatus::NotDownloaded)) => Some(AttachmentAvailability::InCloud),
+        _ => None,
     }
 }
 
@@ -47,18 +91,128 @@ fn bool_value(
 fn status_value(
     values: &NSDictionary<NSURLResourceKey, AnyObject>,
     key: &NSURLResourceKey,
-) -> Option<CloudDownloadStatus> {
+) -> Option<DownloadStatus> {
     let value = values.objectForKey(key)?.downcast::<NSString>().ok()?;
     Some(match value.to_string().as_str() {
-        STATUS_NOT_DOWNLOADED => CloudDownloadStatus::NotDownloaded,
-        STATUS_DOWNLOADED => CloudDownloadStatus::Downloaded,
-        STATUS_CURRENT => CloudDownloadStatus::Current,
-        _ => CloudDownloadStatus::Unknown,
+        STATUS_NOT_DOWNLOADED => DownloadStatus::NotDownloaded,
+        STATUS_DOWNLOADED => DownloadStatus::Downloaded,
+        STATUS_CURRENT => DownloadStatus::Current,
+        _ => DownloadStatus::Unknown,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::ports::attachment_accessibility::{AttachmentAccessFailure, AttachmentAvailability};
+
+    use super::super::finish_with_platform_availability;
+    use super::{DownloadStatus, Metadata, MetadataProbe, availability_with_metadata};
+
+    struct FixedMetadata(Option<Metadata>);
+
+    impl MetadataProbe for FixedMetadata {
+        fn metadata(&self, _path: &std::path::Path) -> Option<Metadata> {
+            self.0
+        }
+    }
+
+    #[test]
+    fn authoritative_ubiquitous_metadata_distinguishes_cloud_states() {
+        let path = std::path::Path::new("/private/evicted.txt");
+        let in_cloud = FixedMetadata(Some(Metadata {
+            ubiquitous: Some(true),
+            downloading: Some(false),
+            status: Some(DownloadStatus::NotDownloaded),
+            has_download_error: false,
+        }));
+        assert_eq!(
+            availability_with_metadata(path, &in_cloud),
+            Some(AttachmentAvailability::InCloud)
+        );
+
+        for status in [DownloadStatus::NotDownloaded, DownloadStatus::Downloaded] {
+            let downloading = FixedMetadata(Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(status),
+                has_download_error: false,
+            }));
+            assert_eq!(
+                availability_with_metadata(path, &downloading),
+                Some(AttachmentAvailability::Downloading)
+            );
+        }
+    }
+
+    #[test]
+    fn downloaded_and_current_metadata_fall_through_to_exact_readability() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let readable = temporary.path().join("local.txt");
+        let missing = temporary.path().join("missing.txt");
+        std::fs::write(&readable, b"content").expect("readable fixture");
+        for status in [DownloadStatus::Downloaded, DownloadStatus::Current] {
+            let metadata = FixedMetadata(Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: Some(false),
+                status: Some(status),
+                has_download_error: false,
+            }));
+            assert_eq!(availability_with_metadata(&readable, &metadata), None);
+            assert_eq!(
+                finish_with_platform_availability(&readable, None),
+                Ok(AttachmentAvailability::Available)
+            );
+            assert_eq!(
+                finish_with_platform_availability(&missing, None),
+                Err(AttachmentAccessFailure::Missing)
+            );
+        }
+    }
+
+    #[test]
+    fn unavailable_contradictory_or_failed_metadata_never_claims_icloud() {
+        let path = std::path::Path::new("/private/missing.txt");
+        let cases = [
+            None,
+            Some(Metadata {
+                ubiquitous: Some(false),
+                downloading: Some(true),
+                status: Some(DownloadStatus::NotDownloaded),
+                has_download_error: false,
+            }),
+            Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: None,
+                status: Some(DownloadStatus::NotDownloaded),
+                has_download_error: false,
+            }),
+            Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: Some(false),
+                status: Some(DownloadStatus::Unknown),
+                has_download_error: false,
+            }),
+            Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(DownloadStatus::Current),
+                has_download_error: false,
+            }),
+            Some(Metadata {
+                ubiquitous: Some(true),
+                downloading: Some(true),
+                status: Some(DownloadStatus::NotDownloaded),
+                has_download_error: true,
+            }),
+        ];
+        for metadata in cases {
+            assert_eq!(
+                availability_with_metadata(path, &FixedMetadata(metadata)),
+                None
+            );
+        }
+    }
+
     #[test]
     fn metadata_probe_has_no_materialization_selector() {
         let source = include_str!("macos.rs");

--- a/src/adapters/attachment/accessibility/macos.rs
+++ b/src/adapters/attachment/accessibility/macos.rs
@@ -1,0 +1,68 @@
+//! Safe Foundation URL-resource metadata probe for macOS ubiquitous items.
+
+use std::path::Path;
+
+use objc2::runtime::AnyObject;
+use objc2_foundation::{
+    NSArray, NSDictionary, NSNumber, NSString, NSURL, NSURLResourceKey, ns_string,
+};
+
+use super::{CloudDownloadStatus, CloudMetadata, CloudMetadataProbe};
+
+const STATUS_NOT_DOWNLOADED: &str = "NSURLUbiquitousItemDownloadingStatusNotDownloaded";
+const STATUS_DOWNLOADED: &str = "NSURLUbiquitousItemDownloadingStatusDownloaded";
+const STATUS_CURRENT: &str = "NSURLUbiquitousItemDownloadingStatusCurrent";
+
+pub(super) struct PlatformCloudMetadata;
+
+impl CloudMetadataProbe for PlatformCloudMetadata {
+    fn metadata(&self, path: &Path) -> Option<CloudMetadata> {
+        let url = NSURL::from_file_path(path)?;
+        let ubiquitous_key = ns_string!("NSURLIsUbiquitousItemKey");
+        let downloading_key = ns_string!("NSURLUbiquitousItemIsDownloadingKey");
+        let status_key = ns_string!("NSURLUbiquitousItemDownloadingStatusKey");
+        let error_key = ns_string!("NSURLUbiquitousItemDownloadingErrorKey");
+        let keys = NSArray::from_slice(&[ubiquitous_key, downloading_key, status_key, error_key]);
+        let values = url.resourceValuesForKeys_error(&keys).ok()?;
+        Some(CloudMetadata {
+            ubiquitous: bool_value(&values, ubiquitous_key),
+            downloading: bool_value(&values, downloading_key),
+            status: status_value(&values, status_key),
+            has_download_error: values.objectForKey(error_key).is_some(),
+        })
+    }
+}
+
+fn bool_value(
+    values: &NSDictionary<NSURLResourceKey, AnyObject>,
+    key: &NSURLResourceKey,
+) -> Option<bool> {
+    values
+        .objectForKey(key)?
+        .downcast::<NSNumber>()
+        .ok()
+        .map(|value| value.as_bool())
+}
+
+fn status_value(
+    values: &NSDictionary<NSURLResourceKey, AnyObject>,
+    key: &NSURLResourceKey,
+) -> Option<CloudDownloadStatus> {
+    let value = values.objectForKey(key)?.downcast::<NSString>().ok()?;
+    Some(match value.to_string().as_str() {
+        STATUS_NOT_DOWNLOADED => CloudDownloadStatus::NotDownloaded,
+        STATUS_DOWNLOADED => CloudDownloadStatus::Downloaded,
+        STATUS_CURRENT => CloudDownloadStatus::Current,
+        _ => CloudDownloadStatus::Unknown,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn metadata_probe_has_no_materialization_selector() {
+        let source = include_str!("macos.rs");
+        let materialization_selector = ["startDownloading", "UbiquitousItem"].concat();
+        assert!(!source.contains(&materialization_selector));
+    }
+}

--- a/src/adapters/attachment/worker.rs
+++ b/src/adapters/attachment/worker.rs
@@ -8,24 +8,39 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::ports::attachment_accessibility::{AttachmentAccessFailure, AttachmentAccessibility};
+use crate::ports::attachment_accessibility::{
+    AttachmentAccessFailure, AttachmentAccessibility, AttachmentAvailability,
+};
 
 use super::FileAttachmentAccessibility;
 
-const PROTOCOL_VERSION: u8 = 1;
+const PROTOCOL_VERSION: u8 = 2;
 const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+const MAX_RESPONSE_BYTES: usize = 16 * 1024;
 const MAX_BATCH_PATHS: usize = 32;
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct WorkerRequest {
     version: u8,
     paths: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct WorkerResponse {
     version: u8,
-    failures: Vec<Option<String>>,
+    outcomes: Vec<WorkerOutcome>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "state", content = "reason", rename_all = "snake_case")]
+enum WorkerOutcome {
+    Available,
+    InCloud,
+    Downloading,
+    Inaccessible(String),
 }
 
 pub(crate) fn encode_request(paths: Vec<String>) -> Result<Vec<u8>, serde_json::Error> {
@@ -35,22 +50,37 @@ pub(crate) fn encode_request(paths: Vec<String>) -> Result<Vec<u8>, serde_json::
     })
 }
 
+fn decode_request(bytes: &[u8]) -> Result<WorkerRequest, ()> {
+    let request: WorkerRequest = serde_json::from_slice(bytes).map_err(|_| ())?;
+    if request.version != PROTOCOL_VERSION || request.paths.len() > MAX_BATCH_PATHS {
+        return Err(());
+    }
+    Ok(request)
+}
+
 pub(crate) fn decode_response(
     bytes: &[u8],
     expected: usize,
-) -> Result<Vec<Result<(), AttachmentAccessFailure>>, ()> {
+) -> Result<Vec<Result<AttachmentAvailability, AttachmentAccessFailure>>, ()> {
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        return Err(());
+    }
     let response: WorkerResponse = serde_json::from_slice(bytes).map_err(|_| ())?;
-    if response.version != PROTOCOL_VERSION || response.failures.len() != expected {
+    if response.version != PROTOCOL_VERSION || response.outcomes.len() != expected {
         return Err(());
     }
     response
-        .failures
+        .outcomes
         .into_iter()
-        .map(|failure| match failure {
-            None => Ok(Ok(())),
-            Some(code) => AttachmentAccessFailure::from_diagnostic_code(&code)
-                .map(Err)
-                .ok_or(()),
+        .map(|outcome| match outcome {
+            WorkerOutcome::Available => Ok(Ok(AttachmentAvailability::Available)),
+            WorkerOutcome::InCloud => Ok(Ok(AttachmentAvailability::InCloud)),
+            WorkerOutcome::Downloading => Ok(Ok(AttachmentAvailability::Downloading)),
+            WorkerOutcome::Inaccessible(code) => {
+                AttachmentAccessFailure::from_diagnostic_code(&code)
+                    .map(Err)
+                    .ok_or(())
+            }
         })
         .collect()
 }
@@ -71,24 +101,21 @@ fn execute_stdio() -> Result<(), ()> {
     if u64::try_from(input.len()).map_err(|_| ())? > MAX_REQUEST_BYTES {
         return Err(());
     }
-    let request: WorkerRequest = serde_json::from_slice(&input).map_err(|_| ())?;
-    if request.version != PROTOCOL_VERSION || request.paths.len() > MAX_BATCH_PATHS {
-        return Err(());
-    }
+    let request = decode_request(&input)?;
     let mut checker = FileAttachmentAccessibility;
-    let failures = request
+    let outcomes = request
         .paths
         .iter()
-        .map(|path| {
-            checker
-                .check(Path::new(path))
-                .err()
-                .map(|failure| failure.diagnostic_code().to_owned())
+        .map(|path| match checker.check(Path::new(path)) {
+            Ok(AttachmentAvailability::Available) => WorkerOutcome::Available,
+            Ok(AttachmentAvailability::InCloud) => WorkerOutcome::InCloud,
+            Ok(AttachmentAvailability::Downloading) => WorkerOutcome::Downloading,
+            Err(failure) => WorkerOutcome::Inaccessible(failure.diagnostic_code().to_owned()),
         })
         .collect();
     let output = serde_json::to_vec(&WorkerResponse {
         version: PROTOCOL_VERSION,
-        failures,
+        outcomes,
     })
     .map_err(|_| ())?;
     std::io::stdout().write_all(&output).map_err(|_| ())
@@ -96,7 +123,9 @@ fn execute_stdio() -> Result<(), ()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_response, encode_request};
+    use crate::ports::attachment_accessibility::{AttachmentAccessFailure, AttachmentAvailability};
+
+    use super::{MAX_RESPONSE_BYTES, decode_request, decode_response, encode_request};
 
     #[test]
     fn protocol_round_trips_unicode_paths_and_rejects_wrong_counts() {
@@ -107,7 +136,57 @@ mod tests {
                 .expect("UTF-8 JSON")
                 .contains("Grüße")
         );
-        assert!(decode_response(br#"{"version":1,"failures":[null]}"#, 1).is_ok());
-        assert!(decode_response(br#"{"version":1,"failures":[]}"#, 1).is_err());
+        assert_eq!(
+            decode_response(br#"{"version":2,"outcomes":[{"state":"available"}]}"#, 1),
+            Ok(vec![Ok(AttachmentAvailability::Available)])
+        );
+        assert!(decode_response(br#"{"version":2,"outcomes":[]}"#, 1).is_err());
+    }
+
+    #[test]
+    fn protocol_decodes_every_availability_and_failure_state() {
+        let response = br#"{"version":2,"outcomes":[{"state":"available"},{"state":"in_cloud"},{"state":"downloading"},{"state":"inaccessible","reason":"missing"},{"state":"inaccessible","reason":"permission_denied"},{"state":"inaccessible","reason":"unmounted"},{"state":"inaccessible","reason":"unreadable"},{"state":"inaccessible","reason":"io"},{"state":"inaccessible","reason":"timed_out"},{"state":"inaccessible","reason":"cancelled"}]}"#;
+        assert_eq!(
+            decode_response(response, 10),
+            Ok(vec![
+                Ok(AttachmentAvailability::Available),
+                Ok(AttachmentAvailability::InCloud),
+                Ok(AttachmentAvailability::Downloading),
+                Err(AttachmentAccessFailure::Missing),
+                Err(AttachmentAccessFailure::PermissionDenied),
+                Err(AttachmentAccessFailure::Unmounted),
+                Err(AttachmentAccessFailure::Unreadable),
+                Err(AttachmentAccessFailure::Io),
+                Err(AttachmentAccessFailure::TimedOut),
+                Err(AttachmentAccessFailure::Cancelled),
+            ])
+        );
+    }
+
+    #[test]
+    fn protocol_rejects_unknown_wrong_incomplete_and_oversized_responses() {
+        for invalid in [
+            br#"{"version":1,"outcomes":[{"state":"available"}]}"#.as_slice(),
+            br#"{"version":2,"outcomes":[{"state":"unknown"}]}"#.as_slice(),
+            br#"{"version":2,"outcomes":[{"state":"inaccessible","reason":"other"}]}"#.as_slice(),
+            br#"{"version":2,"outcomes":[{"state":"available","extra":true}]}"#.as_slice(),
+            br#"{"version":2,"outcomes":[{"state":"available"}],"extra":true}"#.as_slice(),
+            br#"{"version":2,"outcomes":["#.as_slice(),
+        ] {
+            assert!(decode_response(invalid, 1).is_err());
+        }
+        assert!(decode_response(&vec![b' '; MAX_RESPONSE_BYTES + 1], 0).is_err());
+    }
+
+    #[test]
+    fn request_envelope_rejects_wrong_versions_and_unknown_fields() {
+        assert!(decode_request(br#"{"version":1,"paths":[]}"#).is_err());
+        assert!(decode_request(br#"{"version":2,"paths":[],"unexpected":true}"#).is_err());
+        let oversized_count = serde_json::to_vec(&serde_json::json!({
+            "version": 2,
+            "paths": vec!["/tmp/item"; 33],
+        }))
+        .expect("request fixture");
+        assert!(decode_request(&oversized_count).is_err());
     }
 }

--- a/src/adapters/diagnostics.rs
+++ b/src/adapters/diagnostics.rs
@@ -104,6 +104,11 @@ pub enum SafeEvent<'a> {
         /// Typed content-free adapter failure.
         reason: &'a str,
     },
+    /// One attachment has a public-metadata cloud availability state.
+    AttachmentCloudState {
+        /// Stable content-free availability code.
+        state: &'a str,
+    },
     /// One invocation source returned retained but incomplete results.
     InvocationIncomplete {
         /// Typed reason containing only stable codes and aggregate counts.
@@ -262,9 +267,8 @@ pub fn record(event: SafeEvent<'_>) {
         SafeEvent::UpdateCheckFailed { mode, code } => {
             tracing::warn!(event = "update_check_failed", mode, code);
         }
-        SafeEvent::AttachmentInaccessible { reason } => {
-            tracing::warn!(event = "attachment_inaccessible", reason);
-        }
+        SafeEvent::AttachmentInaccessible { reason } => record_attachment_failure(reason),
+        SafeEvent::AttachmentCloudState { state } => record_attachment_cloud_state(state),
         SafeEvent::InvocationIncomplete { reason } => invocation::record(reason),
         SafeEvent::Submission {
             submission_id,
@@ -293,6 +297,14 @@ pub fn record(event: SafeEvent<'_>) {
             outcome
         ),
     }
+}
+
+fn record_attachment_failure(reason: &str) {
+    tracing::warn!(event = "attachment_inaccessible", reason);
+}
+
+fn record_attachment_cloud_state(state: &str) {
+    tracing::info!(event = "attachment_cloud_state", state);
 }
 
 /// Record one content-free input lease reset without widening the public event vocabulary.

--- a/src/adapters/terminal/accessibility_lane.rs
+++ b/src/adapters/terminal/accessibility_lane.rs
@@ -13,8 +13,8 @@ use crate::{
         process::{CancellationFlag, SystemProcessRunner},
     },
     ports::attachment_accessibility::{
-        AttachmentAccessFailure, AttachmentCheckBatch, AttachmentCheckBatchResult,
-        AttachmentCheckResult,
+        AttachmentAccessFailure, AttachmentAvailability, AttachmentCheckBatch,
+        AttachmentCheckBatchResult, AttachmentCheckResult,
     },
     ports::environment::{ProcessError, ProcessRequest, ProcessRunner},
 };
@@ -118,7 +118,7 @@ fn accessibility_loop(
 ) {
     while let Ok(batch) = requests.recv() {
         let check_results = executor.execute(&batch);
-        record_failures(&check_results);
+        record_health(&check_results);
         let completion = AttachmentCheckBatchResult {
             id: batch.id,
             purpose: batch.purpose,
@@ -179,14 +179,22 @@ fn process_failure(error: &ProcessError) -> AttachmentAccessFailure {
     }
 }
 
-fn record_failures(results: &[AttachmentCheckResult]) {
+fn record_health(results: &[AttachmentCheckResult]) {
     for result in results {
-        if let Err(reason) = result.result {
-            crate::adapters::diagnostics::record(
+        match result.result {
+            Err(reason) => crate::adapters::diagnostics::record(
                 crate::adapters::diagnostics::SafeEvent::AttachmentInaccessible {
                     reason: reason.diagnostic_code(),
                 },
-            );
+            ),
+            Ok(state @ (AttachmentAvailability::InCloud | AttachmentAvailability::Downloading)) => {
+                crate::adapters::diagnostics::record(
+                    crate::adapters::diagnostics::SafeEvent::AttachmentCloudState {
+                        state: state.diagnostic_code(),
+                    },
+                );
+            }
+            Ok(AttachmentAvailability::Available) => {}
         }
     }
 }
@@ -205,12 +213,13 @@ mod tests {
     use crate::{
         adapters::terminal::supervisor::ShutdownDeadline,
         ports::attachment_accessibility::{
-            AttachmentAccessFailure, AttachmentCheckBatch, AttachmentCheckKey,
-            AttachmentCheckPurpose, AttachmentCheckResult,
+            AttachmentAccessFailure, AttachmentAvailability, AttachmentCheckBatch,
+            AttachmentCheckKey, AttachmentCheckPurpose, AttachmentCheckResult,
         },
+        ports::environment::ProcessError,
     };
 
-    use super::{AccessibilityLane, BatchExecutor};
+    use super::{AccessibilityLane, BatchExecutor, process_failure};
 
     struct SequenceExecutor {
         outcomes: VecDeque<AttachmentAccessFailure>,
@@ -218,7 +227,10 @@ mod tests {
 
     impl BatchExecutor for SequenceExecutor {
         fn execute(&mut self, batch: &AttachmentCheckBatch) -> Vec<AttachmentCheckResult> {
-            let result = self.outcomes.pop_front().map_or(Ok(()), Err);
+            let result = self
+                .outcomes
+                .pop_front()
+                .map_or(Ok(AttachmentAvailability::Available), Err);
             batch
                 .checks
                 .iter()
@@ -259,6 +271,26 @@ mod tests {
         );
         lane.stop(ShutdownDeadline::after(Duration::from_millis(150)))
             .expect("recovered lane stops within its bound");
+    }
+
+    #[test]
+    fn process_timeout_cancellation_and_failures_stay_distinct_or_generic() {
+        assert_eq!(
+            process_failure(&ProcessError::TimedOut),
+            AttachmentAccessFailure::TimedOut
+        );
+        assert_eq!(
+            process_failure(&ProcessError::Cancelled),
+            AttachmentAccessFailure::Cancelled
+        );
+        assert_eq!(
+            process_failure(&ProcessError::Io("content-free fixture".to_owned())),
+            AttachmentAccessFailure::Io
+        );
+        assert_eq!(
+            process_failure(&ProcessError::OutputLimit),
+            AttachmentAccessFailure::Io
+        );
     }
 
     fn batch(id: u64, timeout: Duration) -> AttachmentCheckBatch {

--- a/src/application/attachments.rs
+++ b/src/application/attachments.rs
@@ -1,6 +1,7 @@
 //! Transient attachment health, bounded scheduling, and submission preflight policy.
 
 mod keys;
+mod presentation;
 #[cfg(test)]
 mod tests;
 
@@ -12,8 +13,9 @@ use std::{
 use crate::{
     domain::{SessionBoard, SubmissionId, ThoughtId},
     ports::attachment_accessibility::{
-        AttachmentAccessFailure, AttachmentCheckBatch, AttachmentCheckBatchResult,
-        AttachmentCheckKey, AttachmentCheckPurpose, AttachmentCheckResult,
+        AttachmentAccessFailure, AttachmentAvailability, AttachmentCheckBatch,
+        AttachmentCheckBatchResult, AttachmentCheckKey, AttachmentCheckPurpose,
+        AttachmentCheckResult,
     },
 };
 
@@ -21,6 +23,7 @@ use super::Effect;
 
 pub use keys::attachment_keys;
 use keys::attachment_keys_by_thought;
+pub use presentation::AttachmentPresentationState;
 
 const BACKGROUND_BATCH_SIZE: usize = 16;
 const PREFLIGHT_BATCH_SIZE: usize = 32;
@@ -32,7 +35,9 @@ const INACTIVE_REFRESH_AFTER: Duration = Duration::from_secs(5 * 60);
 enum AttachmentHealth {
     Unknown,
     Checking,
-    Accessible,
+    Available,
+    InCloud,
+    Downloading,
     Inaccessible(AttachmentAccessFailure),
 }
 
@@ -292,19 +297,6 @@ impl AttachmentAccessibilityState {
         (effects, preflight, refresh)
     }
 
-    /// Confirmed user-visible failure for one current attachment annotation.
-    #[must_use]
-    pub fn inaccessible(&self, thought_id: ThoughtId, annotation_index: usize) -> bool {
-        self.known
-            .get(&thought_id)
-            .and_then(|keys| {
-                keys.iter()
-                    .find(|key| key.annotation_index == annotation_index)
-            })
-            .and_then(|key| self.health.get(key))
-            .is_some_and(|health| matches!(health, AttachmentHealth::Inaccessible(_)))
-    }
-
     /// Exact current keys for source capture and fresh preflight.
     #[must_use]
     pub fn keys_for(&self, thought_ids: &[ThoughtId]) -> Option<Vec<AttachmentCheckKey>> {
@@ -326,7 +318,7 @@ impl AttachmentAccessibilityState {
                 .get(key)
                 .copied()
                 .unwrap_or(Err(AttachmentAccessFailure::Io));
-            if result.is_err() {
+            if result != Ok(AttachmentAvailability::Available) {
                 failures += 1;
             }
             let target = self.current_result_key(key);
@@ -362,7 +354,7 @@ impl AttachmentAccessibilityState {
             .known
             .values()
             .flatten()
-            .filter(|key| !matches!(self.health.get(*key), Some(AttachmentHealth::Accessible)))
+            .filter(|key| !matches!(self.health.get(*key), Some(AttachmentHealth::Available)))
             .count();
         let outcome = AttachmentRefreshOutcome {
             total,

--- a/src/application/attachments/keys.rs
+++ b/src/application/attachments/keys.rs
@@ -11,14 +11,30 @@ use crate::{
 
 use super::{AttachmentAccessibilityState, AttachmentHealth};
 
-impl From<Result<(), crate::ports::attachment_accessibility::AttachmentAccessFailure>>
-    for AttachmentHealth
+impl
+    From<
+        Result<
+            crate::ports::attachment_accessibility::AttachmentAvailability,
+            crate::ports::attachment_accessibility::AttachmentAccessFailure,
+        >,
+    > for AttachmentHealth
 {
     fn from(
-        result: Result<(), crate::ports::attachment_accessibility::AttachmentAccessFailure>,
+        result: Result<
+            crate::ports::attachment_accessibility::AttachmentAvailability,
+            crate::ports::attachment_accessibility::AttachmentAccessFailure,
+        >,
     ) -> Self {
         match result {
-            Ok(()) => Self::Accessible,
+            Ok(crate::ports::attachment_accessibility::AttachmentAvailability::Available) => {
+                Self::Available
+            }
+            Ok(crate::ports::attachment_accessibility::AttachmentAvailability::InCloud) => {
+                Self::InCloud
+            }
+            Ok(crate::ports::attachment_accessibility::AttachmentAvailability::Downloading) => {
+                Self::Downloading
+            }
             Err(failure) => Self::Inaccessible(failure),
         }
     }
@@ -84,7 +100,12 @@ impl AttachmentAccessibilityState {
         for key in keys {
             if !matches!(
                 self.health.get(key),
-                Some(AttachmentHealth::Accessible | AttachmentHealth::Inaccessible(_))
+                Some(
+                    AttachmentHealth::Available
+                        | AttachmentHealth::InCloud
+                        | AttachmentHealth::Downloading
+                        | AttachmentHealth::Inaccessible(_)
+                )
             ) {
                 self.health.insert(key.clone(), AttachmentHealth::Checking);
             }
@@ -98,8 +119,7 @@ impl AttachmentAccessibilityState {
         };
         for key in keys {
             if paths.contains(&key.canonical_path) {
-                self.health
-                    .insert(key.clone(), AttachmentHealth::Accessible);
+                self.health.insert(key.clone(), AttachmentHealth::Available);
             }
         }
     }
@@ -110,15 +130,19 @@ impl AttachmentAccessibilityState {
             return;
         };
         for key in keys {
-            self.health
-                .insert(key.clone(), AttachmentHealth::Accessible);
+            self.health.insert(key.clone(), AttachmentHealth::Available);
         }
     }
 
     pub(super) fn has_result(&self, key: &AttachmentCheckKey) -> bool {
         matches!(
             self.health.get(key),
-            Some(AttachmentHealth::Accessible | AttachmentHealth::Inaccessible(_))
+            Some(
+                AttachmentHealth::Available
+                    | AttachmentHealth::InCloud
+                    | AttachmentHealth::Downloading
+                    | AttachmentHealth::Inaccessible(_)
+            )
         )
     }
 

--- a/src/application/attachments/presentation.rs
+++ b/src/application/attachments/presentation.rs
@@ -1,0 +1,52 @@
+use crate::domain::ThoughtId;
+
+use super::{AttachmentAccessibilityState, AttachmentHealth};
+
+/// User-visible transient state derived from one exact attachment health entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AttachmentPresentationState {
+    /// Normal presentation, including neutral unknown and checking health.
+    Available,
+    /// Public macOS metadata proves the item remains in iCloud without a local copy.
+    InCloud,
+    /// Public macOS metadata proves the item is currently downloading.
+    Downloading,
+    /// Exact readability failed without authoritative iCloud availability metadata.
+    Inaccessible,
+}
+
+impl AttachmentAccessibilityState {
+    /// Return the presentation state for one current attachment annotation.
+    #[must_use]
+    pub fn presentation_state(
+        &self,
+        thought_id: ThoughtId,
+        annotation_index: usize,
+    ) -> AttachmentPresentationState {
+        self.known
+            .get(&thought_id)
+            .and_then(|keys| {
+                keys.iter()
+                    .find(|key| key.annotation_index == annotation_index)
+            })
+            .and_then(|key| self.health.get(key))
+            .map_or(
+                AttachmentPresentationState::Available,
+                |health| match health {
+                    AttachmentHealth::Unknown
+                    | AttachmentHealth::Checking
+                    | AttachmentHealth::Available => AttachmentPresentationState::Available,
+                    AttachmentHealth::InCloud => AttachmentPresentationState::InCloud,
+                    AttachmentHealth::Downloading => AttachmentPresentationState::Downloading,
+                    AttachmentHealth::Inaccessible(_) => AttachmentPresentationState::Inaccessible,
+                },
+            )
+    }
+
+    /// Whether one current annotation has generic inaccessible presentation.
+    #[must_use]
+    pub fn inaccessible(&self, thought_id: ThoughtId, annotation_index: usize) -> bool {
+        self.presentation_state(thought_id, annotation_index)
+            == AttachmentPresentationState::Inaccessible
+    }
+}

--- a/src/application/attachments/tests.rs
+++ b/src/application/attachments/tests.rs
@@ -8,8 +8,8 @@ use crate::{
     },
     ports::{
         attachment_accessibility::{
-            AttachmentAccessFailure, AttachmentCheckBatch, AttachmentCheckBatchResult,
-            AttachmentCheckPurpose, AttachmentCheckResult,
+            AttachmentAccessFailure, AttachmentAvailability, AttachmentCheckBatch,
+            AttachmentCheckBatchResult, AttachmentCheckPurpose, AttachmentCheckResult,
         },
         environment::IdGenerator as _,
     },
@@ -18,6 +18,7 @@ use crate::{
 use super::{AttachmentAccessibilityState, AttachmentRefreshCause};
 use crate::application::test_support::TestIds;
 
+mod health_states;
 mod reconciliation;
 
 #[test]
@@ -394,25 +395,6 @@ fn focus_transition_reprioritizes_unknown_work_once() {
     assert!(state.prioritize_focus(ids[39]).is_empty());
 }
 
-#[test]
-fn every_typed_failure_has_the_same_binary_health() {
-    for failure in [
-        AttachmentAccessFailure::Missing,
-        AttachmentAccessFailure::PermissionDenied,
-        AttachmentAccessFailure::Unmounted,
-        AttachmentAccessFailure::Unreadable,
-        AttachmentAccessFailure::Io,
-        AttachmentAccessFailure::TimedOut,
-        AttachmentAccessFailure::Cancelled,
-    ] {
-        let (board, ids) = board_with_attachments(1);
-        let mut state = AttachmentAccessibilityState::default();
-        let batch = one_batch(state.start(&board, Some(ids[0]), Duration::ZERO));
-        assert!(state.complete(failed(batch, failure)).0.is_empty());
-        assert!(state.inaccessible(ids[0], 0), "failure: {failure:?}");
-    }
-}
-
 fn board_with_attachments(count: usize) -> (SessionBoard, Vec<crate::domain::ThoughtId>) {
     let mut ids = TestIds::new(1_725_000_000_000);
     let now = Timestamp::from_millis(1_725_000_000_000);
@@ -469,6 +451,24 @@ fn failed(
     completion(batch, |_| Err(failure))
 }
 
+fn availability(
+    batch: AttachmentCheckBatch,
+    state: AttachmentAvailability,
+) -> AttachmentCheckBatchResult {
+    AttachmentCheckBatchResult {
+        id: batch.id,
+        purpose: batch.purpose,
+        results: batch
+            .checks
+            .into_iter()
+            .map(|key| AttachmentCheckResult {
+                key,
+                result: Ok(state),
+            })
+            .collect(),
+    }
+}
+
 fn completion(
     batch: AttachmentCheckBatch,
     result: impl Fn(
@@ -482,7 +482,7 @@ fn completion(
             .checks
             .into_iter()
             .map(|key| AttachmentCheckResult {
-                result: result(&key),
+                result: result(&key).map(|()| AttachmentAvailability::Available),
                 key,
             })
             .collect(),

--- a/src/application/attachments/tests/health_states.rs
+++ b/src/application/attachments/tests/health_states.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+use crate::{
+    application::attachments::{AttachmentPresentationState, AttachmentRefreshCause},
+    ports::attachment_accessibility::{AttachmentAccessFailure, AttachmentAvailability},
+};
+
+use super::{
+    AttachmentAccessibilityState, availability, board_with_attachments, failed, one_batch,
+};
+
+#[test]
+fn refresh_converges_available_to_icloud_to_downloading_to_available() {
+    let (board, ids) = board_with_attachments(1);
+    let mut state = AttachmentAccessibilityState::default();
+    let initial = one_batch(state.start(&board, Some(ids[0]), Duration::ZERO));
+    state.complete(availability(initial, AttachmentAvailability::Available));
+    assert_eq!(
+        state.presentation_state(ids[0], 0),
+        AttachmentPresentationState::Available
+    );
+
+    for (availability_state, presentation_state) in [
+        (
+            AttachmentAvailability::InCloud,
+            AttachmentPresentationState::InCloud,
+        ),
+        (
+            AttachmentAvailability::Downloading,
+            AttachmentPresentationState::Downloading,
+        ),
+        (
+            AttachmentAvailability::Available,
+            AttachmentPresentationState::Available,
+        ),
+    ] {
+        let refresh = one_batch(
+            state
+                .refresh_all(&board, Some(ids[0]), AttachmentRefreshCause::Quiet)
+                .0,
+        );
+        state.complete(availability(refresh, availability_state));
+        assert_eq!(state.presentation_state(ids[0], 0), presentation_state);
+    }
+}
+
+#[test]
+fn every_typed_failure_has_generic_inaccessible_health() {
+    for failure in [
+        AttachmentAccessFailure::Missing,
+        AttachmentAccessFailure::PermissionDenied,
+        AttachmentAccessFailure::Unmounted,
+        AttachmentAccessFailure::Unreadable,
+        AttachmentAccessFailure::Io,
+        AttachmentAccessFailure::TimedOut,
+        AttachmentAccessFailure::Cancelled,
+    ] {
+        let (board, ids) = board_with_attachments(1);
+        let mut state = AttachmentAccessibilityState::default();
+        let batch = one_batch(state.start(&board, Some(ids[0]), Duration::ZERO));
+        assert!(state.complete(failed(batch, failure)).0.is_empty());
+        assert_eq!(
+            state.presentation_state(ids[0], 0),
+            AttachmentPresentationState::Inaccessible,
+            "failure: {failure:?}"
+        );
+    }
+}
+
+#[test]
+fn manual_refresh_counts_cloud_states_as_unavailable() {
+    for cloud_state in [
+        AttachmentAvailability::InCloud,
+        AttachmentAvailability::Downloading,
+    ] {
+        let (board, ids) = board_with_attachments(1);
+        let mut state = AttachmentAccessibilityState::default();
+        let initial = one_batch(state.start(&board, Some(ids[0]), Duration::ZERO));
+        state.complete(availability(initial, AttachmentAvailability::Available));
+        let refresh = one_batch(
+            state
+                .refresh_all(&board, Some(ids[0]), AttachmentRefreshCause::Manual)
+                .0,
+        );
+        let (_, _, outcome) = state.complete(availability(refresh, cloud_state));
+        assert_eq!(outcome.expect("manual outcome").inaccessible, 1);
+    }
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -26,8 +26,8 @@ pub use action::Action;
 pub(crate) use action::{OwnedThoughtCreation, OwnedThoughtEdit};
 pub use admission::{PendingMutationIntent, PendingMutationIntents};
 pub use attachments::{
-    AttachmentAccessibilityState, AttachmentPreflightOutcome, AttachmentRefreshCause,
-    AttachmentRefreshOutcome, attachment_keys,
+    AttachmentAccessibilityState, AttachmentPreflightOutcome, AttachmentPresentationState,
+    AttachmentRefreshCause, AttachmentRefreshOutcome, attachment_keys,
 };
 pub use capture::{apply_capture, prepare_capture};
 pub(crate) use control::{ControlReplay, match_control_replay};

--- a/src/ports/attachment_accessibility.rs
+++ b/src/ports/attachment_accessibility.rs
@@ -61,6 +61,29 @@ pub enum AttachmentAccessFailure {
     Cancelled,
 }
 
+/// Proven transient availability of one exact external attachment path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AttachmentAvailability {
+    /// The exact path currently names a locally readable regular file.
+    Available,
+    /// macOS public metadata proves the ubiquitous item is not downloaded.
+    InCloud,
+    /// macOS public metadata proves the ubiquitous item is downloading.
+    Downloading,
+}
+
+impl AttachmentAvailability {
+    /// Stable content-free worker and diagnostic spelling.
+    #[must_use]
+    pub const fn diagnostic_code(self) -> &'static str {
+        match self {
+            Self::Available => "available",
+            Self::InCloud => "in_cloud",
+            Self::Downloading => "downloading",
+        }
+    }
+}
+
 impl AttachmentAccessFailure {
     /// Stable content-free diagnostic spelling.
     #[must_use]
@@ -119,8 +142,8 @@ pub struct AttachmentCheckBatch {
 pub struct AttachmentCheckResult {
     /// Exact requested identity, used to reject stale results.
     pub key: AttachmentCheckKey,
-    /// Accessible on success, otherwise one diagnostic-only failure reason.
-    pub result: Result<(), AttachmentAccessFailure>,
+    /// Proven availability or one diagnostic-only generic failure reason.
+    pub result: Result<AttachmentAvailability, AttachmentAccessFailure>,
 }
 
 /// Ordered completion for one batch.
@@ -136,11 +159,11 @@ pub struct AttachmentCheckBatchResult {
 
 /// Filesystem-independent capability used by the bounded accessibility lane.
 pub trait AttachmentAccessibility: Send {
-    /// Prove that one exact path currently names a readable regular file.
+    /// Classify one exact path without initiating cloud materialization.
     ///
     /// # Errors
     ///
-    /// Returns a typed diagnostic reason. Every failure is user-visible only as
-    /// binary inaccessible health.
-    fn check(&mut self, path: &Path) -> Result<(), AttachmentAccessFailure>;
+    /// Returns a typed diagnostic reason. Every failure has the same generic
+    /// inaccessible presentation.
+    fn check(&mut self, path: &Path) -> Result<AttachmentAvailability, AttachmentAccessFailure>;
 }

--- a/src/ui/annotations.rs
+++ b/src/ui/annotations.rs
@@ -1,5 +1,6 @@
 //! Exact paste payloads and folded board presentation.
 
+use crate::application::AttachmentPresentationState;
 use crate::domain::{
     AnnotationBehavior, ContentAnnotation, ContentAnnotationKind, InlineStyleKind,
 };
@@ -12,7 +13,6 @@ pub(in crate::ui) use reflow::PasteReflow;
 
 const LARGE_PASTE_LINES: usize = 12;
 const LARGE_PASTE_GRAPHEMES: usize = 1_200;
-const INACCESSIBLE_SUFFIX: &str = " [inaccessible]";
 
 /// Exact inserted text with optional durable presentation provenance.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -157,7 +157,7 @@ pub(super) struct PresentedSubstitution {
     pub(super) canonical_start: usize,
     pub(super) canonical_end: usize,
     pub(super) collapsed: bool,
-    pub(super) inaccessible: bool,
+    pub(super) health: AttachmentPresentationState,
 }
 
 /// Closed semantic style applied to a projected visible byte range.
@@ -204,18 +204,22 @@ pub(super) fn project_with_health(
     content: &str,
     annotations: &[ContentAnnotation],
     expanded: &[usize],
-    mut inaccessible: impl FnMut(usize) -> bool,
+    mut health: impl FnMut(usize) -> AttachmentPresentationState,
 ) -> Result<Presentation, ProjectionError> {
     let mut projection = ProjectionBuilder::default();
     for (annotation_index, annotation) in annotations.iter().enumerate() {
-        let is_inaccessible = matches!(annotation.kind, ContentAnnotationKind::Attachment { .. })
-            && inaccessible(annotation_index);
+        let attachment_health =
+            if matches!(annotation.kind, ContentAnnotationKind::Attachment { .. }) {
+                health(annotation_index)
+            } else {
+                AttachmentPresentationState::Available
+            };
         projection.push_annotation(
             content,
             annotation_index,
             annotation,
             expanded.contains(&annotation_index),
-            is_inaccessible,
+            attachment_health,
         )?;
     }
     projection.finish(content)
@@ -238,7 +242,7 @@ impl ProjectionBuilder {
         annotation_index: usize,
         annotation: &ContentAnnotation,
         expanded: bool,
-        inaccessible: bool,
+        health: AttachmentPresentationState,
     ) -> Result<(), ProjectionError> {
         let prefix = content
             .get(self.cursor..annotation.start)
@@ -250,10 +254,10 @@ impl ProjectionBuilder {
                 self.push_inline(content, annotation, start, kind)?;
             }
             AnnotationBehavior::Substitution if expanded => {
-                self.push_expanded(content, annotation_index, annotation, start, inaccessible)?;
+                self.push_expanded(content, annotation_index, annotation, start, health)?;
             }
             AnnotationBehavior::Substitution => {
-                self.push_collapsed(annotation_index, annotation, start, inaccessible);
+                self.push_collapsed(annotation_index, annotation, start, health);
             }
         }
         self.cursor = annotation.end;
@@ -287,7 +291,7 @@ impl ProjectionBuilder {
         annotation_index: usize,
         annotation: &ContentAnnotation,
         start: usize,
-        inaccessible: bool,
+        health: AttachmentPresentationState,
     ) -> Result<(), ProjectionError> {
         match &annotation.kind {
             ContentAnnotationKind::Attachment { image: true, .. } => self.image += 1,
@@ -299,9 +303,7 @@ impl ProjectionBuilder {
             .ok_or(ProjectionError::InvalidAnnotationRange)?;
         self.output.push_str(exact);
         let content_end = self.output.len();
-        if inaccessible {
-            self.output.push_str(INACCESSIBLE_SUFFIX);
-        }
+        push_expanded_health_suffix(&mut self.output, health);
         self.substitutions.push(substitution(
             annotation_index,
             start,
@@ -309,9 +311,9 @@ impl ProjectionBuilder {
             content_end,
             annotation,
             false,
-            inaccessible,
+            health,
         ));
-        if inaccessible {
+        if health != AttachmentPresentationState::Available {
             self.styles.push(PresentedStyle {
                 start,
                 end: self.output.len(),
@@ -326,14 +328,14 @@ impl ProjectionBuilder {
         annotation_index: usize,
         annotation: &ContentAnnotation,
         start: usize,
-        inaccessible: bool,
+        health: AttachmentPresentationState,
     ) {
         push_collapsed_label(
             &mut self.output,
             &annotation.kind,
             &mut self.image,
             &mut self.file,
-            inaccessible,
+            health,
         );
         self.substitutions.push(substitution(
             annotation_index,
@@ -342,15 +344,15 @@ impl ProjectionBuilder {
             self.output.len(),
             annotation,
             true,
-            inaccessible,
+            health,
         ));
         self.styles.push(PresentedStyle {
             start,
             end: self.output.len(),
-            kind: if inaccessible {
-                PresentedStyleKind::Warning
-            } else {
+            kind: if health == AttachmentPresentationState::Available {
                 PresentedStyleKind::Annotation
+            } else {
+                PresentedStyleKind::Warning
             },
         });
     }
@@ -373,7 +375,7 @@ fn push_collapsed_label(
     kind: &ContentAnnotationKind,
     image_count: &mut usize,
     file_count: &mut usize,
-    inaccessible: bool,
+    health: AttachmentPresentationState,
 ) {
     match kind {
         ContentAnnotationKind::Attachment { image, .. } => {
@@ -388,9 +390,7 @@ fn push_collapsed_label(
             output.push_str(label);
             output.push(' ');
             output.push_str(&number.to_string());
-            if inaccessible {
-                output.push_str(" · inaccessible");
-            }
+            push_collapsed_health_suffix(output, health);
             output.push(']');
         }
         ContentAnnotationKind::LargePaste { lines, graphemes } => {
@@ -414,7 +414,7 @@ fn substitution(
     content_end: usize,
     annotation: &ContentAnnotation,
     collapsed: bool,
-    inaccessible: bool,
+    health: AttachmentPresentationState,
 ) -> PresentedSubstitution {
     PresentedSubstitution {
         annotation_index,
@@ -424,7 +424,25 @@ fn substitution(
         canonical_start: annotation.start,
         canonical_end: annotation.end,
         collapsed,
-        inaccessible,
+        health,
+    }
+}
+
+fn push_collapsed_health_suffix(output: &mut String, health: AttachmentPresentationState) {
+    match health {
+        AttachmentPresentationState::Available => {}
+        AttachmentPresentationState::InCloud => output.push_str(" · in iCloud"),
+        AttachmentPresentationState::Downloading => output.push_str(" · downloading"),
+        AttachmentPresentationState::Inaccessible => output.push_str(" · inaccessible"),
+    }
+}
+
+fn push_expanded_health_suffix(output: &mut String, health: AttachmentPresentationState) {
+    match health {
+        AttachmentPresentationState::Available => {}
+        AttachmentPresentationState::InCloud => output.push_str(" [in iCloud]"),
+        AttachmentPresentationState::Downloading => output.push_str(" [downloading]"),
+        AttachmentPresentationState::Inaccessible => output.push_str(" [inaccessible]"),
     }
 }
 

--- a/src/ui/annotations/tests.rs
+++ b/src/ui/annotations/tests.rs
@@ -225,7 +225,7 @@ fn invocation_reference_projects_without_placeholder_brackets() {
             },
         }],
         &[],
-        |_| false,
+        |_| crate::application::AttachmentPresentationState::Available,
     )
     .expect("valid invocation projection");
 
@@ -251,7 +251,7 @@ fn shortcut_emphasis_preserves_text_and_is_never_a_substitution() {
         content,
         &[ContentAnnotation::shortcut(start, end)],
         &[],
-        |_| false,
+        |_| crate::application::AttachmentPresentationState::Available,
     )
     .expect("valid shortcut projection");
 
@@ -271,7 +271,9 @@ fn shortcut_emphasis_preserves_text_and_is_never_a_substitution() {
 fn malformed_projection_fails_instead_of_discarding_metadata() {
     let malformed = ContentAnnotation::shortcut(1, 2);
     assert_eq!(
-        super::project_with_health("é", &[malformed], &[], |_| false),
+        super::project_with_health("é", &[malformed], &[], |_| {
+            crate::application::AttachmentPresentationState::Available
+        }),
         Err(super::ProjectionError::InvalidAnnotationRange)
     );
 }

--- a/src/ui/app/attachments.rs
+++ b/src/ui/app/attachments.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use crate::{
     application::{
-        AttachmentPreflightOutcome, AttachmentRefreshCause, AttachmentRefreshOutcome, Effect,
-        attachment_keys,
+        AttachmentPreflightOutcome, AttachmentPresentationState, AttachmentRefreshCause,
+        AttachmentRefreshOutcome, Effect, attachment_keys,
     },
     domain::ThoughtId,
     ports::attachment_accessibility::AttachmentCheckBatchResult,
@@ -105,8 +105,19 @@ impl BoardApp {
         effects
     }
 
-    /// Binary render state for one current annotation.
+    /// Visible render state for one current annotation.
     #[must_use]
+    pub(in crate::ui) fn attachment_presentation_state(
+        &self,
+        thought_id: ThoughtId,
+        annotation_index: usize,
+    ) -> AttachmentPresentationState {
+        self.state
+            .attachments
+            .presentation_state(thought_id, annotation_index)
+    }
+
+    #[cfg(test)]
     pub(in crate::ui) fn attachment_inaccessible(
         &self,
         thought_id: ThoughtId,

--- a/src/ui/app/view.rs
+++ b/src/ui/app/view.rs
@@ -98,7 +98,9 @@ impl BoardApp {
                     &content,
                     &annotations,
                     &self.expanded_fold_indices(thought.id),
-                    |annotation_index| self.attachment_inaccessible(thought.id, annotation_index),
+                    |annotation_index| {
+                        self.attachment_presentation_state(thought.id, annotation_index)
+                    },
                 )
                 .unwrap_or_else(|_| {
                     crate::ui::annotations::Presentation::canonical(content.clone())

--- a/tests/attachment_check_worker.rs
+++ b/tests/attachment_check_worker.rs
@@ -13,7 +13,7 @@ fn hidden_worker_checks_unicode_and_missing_paths_without_runtime_state() {
     fs::write(&accessible, b"proof").expect("accessible fixture");
     let missing = temporary.path().join("missing.txt");
     let request = serde_json::to_vec(&serde_json::json!({
-        "version": 1,
+        "version": 2,
         "paths": [accessible, missing],
     }))
     .expect("worker request");
@@ -37,8 +37,9 @@ fn hidden_worker_checks_unicode_and_missing_paths_without_runtime_state() {
     assert!(output.status.success(), "stderr: {:?}", output.stderr);
     let response: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("response JSON");
-    assert_eq!(response["version"], 1);
-    assert_eq!(response["failures"][0], serde_json::Value::Null);
-    assert_eq!(response["failures"][1], "missing");
+    assert_eq!(response["version"], 2);
+    assert_eq!(response["outcomes"][0]["state"], "available");
+    assert_eq!(response["outcomes"][1]["state"], "inaccessible");
+    assert_eq!(response["outcomes"][1]["reason"], "missing");
     assert!(!temporary.path().join("worker-state").exists());
 }

--- a/tests/ui_board/annotations/support.rs
+++ b/tests/ui_board/annotations/support.rs
@@ -1,5 +1,7 @@
 use super::*;
-use proqi::ports::attachment_accessibility::{AttachmentCheckBatchResult, AttachmentCheckResult};
+use proqi::ports::attachment_accessibility::{
+    AttachmentAvailability, AttachmentCheckBatchResult, AttachmentCheckResult,
+};
 
 pub(super) fn insert_accessible(fixture: &mut Fixture, payload: PastePayload) {
     let effects = fixture.effects(UiInput::PasteAnnotated(payload));
@@ -20,7 +22,7 @@ pub(super) fn insert_accessible(fixture: &mut Fixture, payload: PastePayload) {
                 .into_iter()
                 .map(|key| AttachmentCheckResult {
                     key,
-                    result: Ok(()),
+                    result: Ok(AttachmentAvailability::Available),
                 })
                 .collect(),
         });

--- a/tests/ui_board/attachment_accessibility.rs
+++ b/tests/ui_board/attachment_accessibility.rs
@@ -3,12 +3,14 @@ use super::*;
 use proqi::{
     domain::Direction,
     ports::attachment_accessibility::{
-        AttachmentAccessFailure, AttachmentCheckBatch, AttachmentCheckBatchResult,
-        AttachmentCheckResult,
+        AttachmentAccessFailure, AttachmentAvailability, AttachmentCheckBatch,
+        AttachmentCheckBatchResult, AttachmentCheckResult,
     },
 };
 use ratatui_core::style::Modifier;
 
+#[path = "attachment_accessibility/cloud_states.rs"]
+mod cloud_states;
 #[path = "attachment_accessibility/flicker_regressions.rs"]
 mod flicker_regressions;
 #[path = "attachment_accessibility/frame_presentation.rs"]
@@ -413,7 +415,28 @@ pub(super) fn complete(
         results: batch
             .checks
             .into_iter()
-            .map(|key| AttachmentCheckResult { key, result })
+            .map(|key| AttachmentCheckResult {
+                key,
+                result: result.map(|()| AttachmentAvailability::Available),
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn complete_availability(
+    batch: AttachmentCheckBatch,
+    state: AttachmentAvailability,
+) -> AttachmentCheckBatchResult {
+    AttachmentCheckBatchResult {
+        id: batch.id,
+        purpose: batch.purpose,
+        results: batch
+            .checks
+            .into_iter()
+            .map(|key| AttachmentCheckResult {
+                key,
+                result: Ok(state),
+            })
             .collect(),
     }
 }

--- a/tests/ui_board/attachment_accessibility/cloud_states.rs
+++ b/tests/ui_board/attachment_accessibility/cloud_states.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+#[test]
+fn icloud_and_downloading_use_exact_composable_labels_in_both_fold_states() {
+    for (state, suffix) in [
+        (AttachmentAvailability::InCloud, "in iCloud"),
+        (AttachmentAvailability::Downloading, "downloading"),
+    ] {
+        for (image, noun) in [(true, "Image"), (false, "File")] {
+            let mut fixture = Fixture::new();
+            let path = "/private/var/folders/TemporaryItems/Grüße 第一.png";
+            let effects = fixture.effects(UiInput::PasteAnnotated(attachment_payload(path, image)));
+            let batch = attachment_batch(&effects);
+            fixture
+                .app
+                .complete_attachment_checks(complete_availability(batch, state));
+
+            let collapsed = text(draw(&mut fixture, 31, 8).backend().buffer());
+            assert!(collapsed.contains(&format!("[{noun} 1 · {suffix}]")));
+            assert!(!collapsed.contains("TemporaryItems"));
+
+            let layout = fixture.app.prepare_frame(Rect::new(0, 0, 31, 8));
+            let area = layout.thoughts[0].text_area;
+            fixture.pointer(area.x + 2, area.y, PointerKind::Down(PointerButton::Left));
+            fixture.input(crate::key_input(UiKey::Enter));
+            let expanded = text(draw(&mut fixture, 80, 8).backend().buffer());
+            assert!(expanded.contains(&format!("[{suffix}]")));
+            assert_eq!(
+                fixture.app.state.board.live_thoughts()[0].content,
+                path,
+                "presentation must preserve the exact canonical path"
+            );
+        }
+    }
+}
+
+#[test]
+fn cloud_states_refuse_preflight_until_the_same_attachment_is_available() {
+    for state in [
+        AttachmentAvailability::InCloud,
+        AttachmentAvailability::Downloading,
+    ] {
+        let mut fixture = submission_fixture();
+        let first = execute_palette(&mut fixture, "submit all and keep");
+        let first = attachment_batch(&first);
+        let refused = fixture
+            .app
+            .complete_attachment_checks(complete_availability(first, state));
+        assert!(refused.is_empty(), "cloud state must not create a journal");
+        assert_eq!(
+            fixture.app.status_text(),
+            Some("Proqi cannot access 1 attachment")
+        );
+        assert_eq!(fixture.app.state.board.live_thoughts().len(), 2);
+        assert!(
+            fixture
+                .app
+                .state
+                .board
+                .live_thoughts()
+                .iter()
+                .all(|thought| !fixture.app.state.thought_locked(thought.id))
+        );
+
+        let retry = execute_palette(&mut fixture, "submit all and keep");
+        let retry = attachment_batch(&retry);
+        let prepared = fixture
+            .app
+            .complete_attachment_checks(complete_availability(
+                retry,
+                AttachmentAvailability::Available,
+            ));
+        assert!(matches!(
+            prepared.as_slice(),
+            [Effect::PrepareSubmission(_)]
+        ));
+    }
+}

--- a/tests/ui_board/attachment_accessibility/frame_presentation.rs
+++ b/tests/ui_board/attachment_accessibility/frame_presentation.rs
@@ -71,7 +71,7 @@ fn collapsed_overflow_and_next_separator_use_health_aware_natural_rows() {
     let path = "/tmp/missing.png";
     let content = format!("one\ntwo\n{path}");
     let effects = fixture.effects(UiInput::PasteAnnotated(embedded_attachment(
-        content,
+        content.clone(),
         8..8 + path.len(),
     )));
     fixture.app.complete_attachment_checks(complete(
@@ -114,7 +114,7 @@ fn health_transitions_resize_reflow_and_preserve_scroll_selection() {
     let prefix = "Grüße 界\nbeta\n";
     let content = format!("{prefix}{path}\nomega\nlast");
     let effects = fixture.effects(UiInput::PasteAnnotated(embedded_attachment(
-        content,
+        content.clone(),
         prefix.len()..prefix.len() + path.len(),
     )));
     fixture
@@ -146,6 +146,20 @@ fn health_transitions_resize_reflow_and_preserve_scroll_selection() {
     assert!(before.first_row_offset > 0);
     assert!(fixture.app.thought_selected(thought_id));
 
+    for (state, label) in [
+        (AttachmentAvailability::InCloud, "in iCloud"),
+        (AttachmentAvailability::Downloading, "downloading"),
+    ] {
+        assert_cloud_transition_preserves_state(
+            &mut fixture,
+            narrow,
+            thought_id,
+            &content,
+            state,
+            label,
+        );
+    }
+
     complete_refresh(&mut fixture, Err(AttachmentAccessFailure::Missing));
     let failed = draw(&mut fixture, narrow.width, narrow.height);
     let failed_layout = fixture.app.prepare_frame(narrow);
@@ -168,6 +182,42 @@ fn health_transitions_resize_reflow_and_preserve_scroll_selection() {
     assert_eq!(recovered_layout.first_index, 0);
     assert!(recovered_layout.thought(thought_id).is_some());
     assert!(fixture.app.thought_selected(thought_id));
+}
+
+fn assert_cloud_transition_preserves_state(
+    fixture: &mut Fixture,
+    area: Rect,
+    thought_id: proqi::domain::ThoughtId,
+    content: &str,
+    state: AttachmentAvailability,
+    label: &str,
+) {
+    complete_refresh_availability(fixture, state);
+    let _cloud = draw(fixture, area.width, area.height);
+    let expected = if label == "in iCloud" {
+        proqi::application::AttachmentPresentationState::InCloud
+    } else {
+        proqi::application::AttachmentPresentationState::Downloading
+    };
+    assert_eq!(
+        fixture
+            .app
+            .state
+            .attachments
+            .presentation_state(thought_id, 0),
+        expected
+    );
+    assert!(fixture.app.thought_selected(thought_id));
+    assert_eq!(
+        fixture
+            .app
+            .state
+            .board
+            .thought(thought_id)
+            .expect("thought")
+            .content,
+        content
+    );
 }
 
 #[test]
@@ -318,6 +368,13 @@ fn complete_refresh(fixture: &mut Fixture, result: Result<(), AttachmentAccessFa
     fixture
         .app
         .complete_attachment_checks(complete(batch, result));
+}
+
+fn complete_refresh_availability(fixture: &mut Fixture, state: AttachmentAvailability) {
+    let batch = attachment_batch(&fixture.app.refresh_attachments(false));
+    fixture
+        .app
+        .complete_attachment_checks(complete_availability(batch, state));
 }
 
 fn assert_top_thought_row(fixture: &mut Fixture, area: Rect, expected: &str) {

--- a/tests/ui_board/snapshots/attachment_accessibility.rs
+++ b/tests/ui_board/snapshots/attachment_accessibility.rs
@@ -1,4 +1,69 @@
 use super::*;
+use proqi::ports::attachment_accessibility::AttachmentAvailability;
+
+#[test]
+fn cloud_attachment_states_have_plain_warning_snapshots() {
+    let mut fixture = Fixture::new();
+    let image = "/private/TemporaryItems/cloud.png";
+    let file = "/private/TemporaryItems/downloading.txt";
+    let content = format!("{image}\n{file}");
+    let file_start = image.len() + 1;
+    let effects = fixture.effects(UiInput::PasteAnnotated(
+        PastePayload::annotated(
+            content,
+            vec![
+                ContentAnnotation {
+                    start: 0,
+                    end: image.len(),
+                    kind: ContentAnnotationKind::Attachment {
+                        image: true,
+                        display_name: "cloud.png".to_owned(),
+                    },
+                },
+                ContentAnnotation {
+                    start: file_start,
+                    end: file_start + file.len(),
+                    kind: ContentAnnotationKind::Attachment {
+                        image: false,
+                        display_name: "downloading.txt".to_owned(),
+                    },
+                },
+            ],
+        )
+        .expect("valid attachment payload"),
+    ));
+    let batch = effects
+        .iter()
+        .find_map(|effect| match effect {
+            Effect::CheckAttachments(batch) => Some(batch.clone()),
+            _ => None,
+        })
+        .expect("insertion check");
+    fixture
+        .app
+        .complete_attachment_checks(AttachmentCheckBatchResult {
+            id: batch.id,
+            purpose: batch.purpose,
+            results: batch
+                .checks
+                .into_iter()
+                .enumerate()
+                .map(|(index, key)| AttachmentCheckResult {
+                    key,
+                    result: Ok(if index == 0 {
+                        AttachmentAvailability::InCloud
+                    } else {
+                        AttachmentAvailability::Downloading
+                    }),
+                })
+                .collect(),
+        });
+    fixture.input(crate::key_input(UiKey::Escape));
+
+    insta::with_settings!({ snapshot_path => "." }, {
+        insta::assert_snapshot!(snapshot(&mut fixture, 60, 8, ThemePreference::Dark));
+    });
+}
 
 #[test]
 fn expanded_inaccessible_attachment_keeps_a_plain_warning_snapshot() {

--- a/tests/ui_board/snapshots/ui_board__snapshots__attachment_accessibility_snapshots__cloud_attachment_states_have_plain_warning_snapshots.snap
+++ b/tests/ui_board/snapshots/ui_board__snapshots__attachment_accessibility_snapshots__cloud_attachment_states_have_plain_warning_snapshots.snap
@@ -1,0 +1,26 @@
+---
+source: tests/ui_board/snapshots/attachment_accessibility.rs
+assertion_line: 64
+expression: "snapshot(&mut fixture, 60, 8, ThemePreference::Dark)"
+---
+SIZE 60x8
+
+TEXT
+00││
+01│⋮ [Image 1 · in iCloud]│
+02│  [File 1 · downloading]│
+03││
+04││
+05│  proqi-ui-contract│
+06│  1 thought · board · saving│
+07│  n New   y Copy  x Cut  d/Del  Space Select u Undo│
+
+STYLE RUNS
+0: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+1: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-22 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 23-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+2: 0-0 fg=Rgb(250, 250, 248) bg=Rgb(45, 106, 79) mod=BOLD | 1-1 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE | 2-23 fg=Rgb(204, 160, 58) bg=Rgb(39, 40, 48) mod=BOLD | 24-59 fg=Rgb(232, 228, 223) bg=Rgb(39, 40, 48) mod=NONE
+3: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+4: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+5: 0-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+6: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-57 fg=Rgb(176, 169, 160) bg=Rgb(15, 13, 10) mod=NONE | 58-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE
+7: 0-1 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 2-2 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 3-9 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 10-10 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 11-17 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 18-18 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 19-24 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 25-29 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 30-31 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 32-36 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 37-44 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE | 45-45 fg=Rgb(112, 214, 155) bg=Rgb(15, 13, 10) mod=NONE | 46-59 fg=Rgb(232, 228, 223) bg=Rgb(15, 13, 10) mod=NONE


### PR DESCRIPTION
## Summary

- Add typed Available, In iCloud, Downloading, and generic Inaccessible attachment health.
- Confine Apple metadata retrieval and translation to the macOS adapter. Other platforms link no Foundation dependency and retain their existing exact-readability behavior.
- Classify iCloud states only when public Foundation URL resource metadata proves ubiquitous identity and download state. Failed reads and contradictory or unavailable metadata remain generic inaccessible.
- Keep every filesystem and cloud metadata probe inside bounded killable worker protocol v2. Submission remains fail closed and never initiates materialization.
- Derive collapsed and expanded labels from the existing per-frame presentation, preserving canonical content, paths, ranges, numbering, and warning styling.
- Document the platform boundary and the no automatic download contract.

By contributing, you agree that your contribution is licensed under the
repository's [MIT License](https://github.com/oborchers/proqi/blob/main/LICENSE).
See [CONTRIBUTING.md](https://github.com/oborchers/proqi/blob/main/CONTRIBUTING.md)
for the repository's contribution rules.
Report vulnerabilities through
[SECURITY.md](https://github.com/oborchers/proqi/blob/main/SECURITY.md), never in
this pull request.

## Verification

- [x] `cargo xtask check` passes
- [x] Focused tests cover the changed behavior
- [x] Documentation is updated when contracts change
- [x] No runtime state, secrets, or machine-specific paths are committed
- [x] Snapshot and golden-file changes were reviewed explicitly
- [x] `cargo xtask audit` passes
- [x] `cargo xtask package` passes
- [x] `cargo xtask test-pty` passes
- [x] `cargo xtask coverage` passes
- [x] Codex review is clean

## Live qualification

The topic binary was exercised with readable, missing, permission-denied, Unicode, disappearance, restoration, refresh, submission refusal, restart, narrow and shallow geometry, keyboard, and mouse paths.

A user-controlled iCloud image was observed transitioning from locally readable to `in iCloud` and back to locally readable after Finder initiated materialization. Proqi only observed and refreshed the state. The downloading phase completed too quickly to capture live and remains covered by deterministic macOS metadata tests.

All ticket-owned panes and files were removed, and the workspace was restored to its original geometry.
