### PR TITLE
Keep Herdr qualification issues actively tracked

### DIFF
--- a/.github/workflows/herdr-compatibility.yml
+++ b/.github/workflows/herdr-compatibility.yml
@@ -159,7 +159,7 @@ jobs:
           [[ "$SCHEMA_SHA256" =~ ^[0-9a-f]{64}$ ]]
           [[ "$SCHEMA_VERSION" =~ ^([0-9]+|unknown)$ ]]
           marker="<!-- herdr-compatibility:${TAG}:${SCHEMA_SHA256} -->"
-          query="repo:${GITHUB_REPOSITORY} is:issue in:body \"${marker}\""
+          query="repo:${GITHUB_REPOSITORY} is:issue is:open in:body \"${marker}\""
           existing="$(gh api --method GET search/issues -f q="$query" --jq '.total_count')"
           test "$existing" -ge 0
           if test "$existing" -gt 0; then

--- a/xtask/src/release_policy.rs
+++ b/xtask/src/release_policy.rs
@@ -54,7 +54,7 @@ const IMAGE_REQUIRED: [&str; 15] = [
 ];
 
 const HERDR_SENTINEL_PATH: &str = ".github/workflows/herdr-compatibility.yml";
-const HERDR_SENTINEL_REQUIRED: [&str; 15] = [
+const HERDR_SENTINEL_REQUIRED: [&str; 16] = [
     "schedule:",
     "workflow_dispatch:",
     "if: github.ref == 'refs/heads/main'",
@@ -69,6 +69,7 @@ const HERDR_SENTINEL_REQUIRED: [&str; 15] = [
     "timeout --kill-after=2s 10s",
     "cargo xtask herdr-compatibility",
     "search/issues",
+    "is:issue is:open in:body",
     "herdr-compatibility:${TAG}:${SCHEMA_SHA256}",
 ];
 
@@ -367,6 +368,12 @@ mod tests {
         let found = herdr_sentinel_findings(&unsafe_source);
         assert!(found.iter().any(|item| item.contains("contents: read")));
         assert!(found.iter().any(|item| item.contains("contents: write")));
+        let closed_issue_match = source.replace("is:issue is:open in:body", "is:issue in:body");
+        assert!(
+            herdr_sentinel_findings(&closed_issue_match)
+                .iter()
+                .any(|item| item.contains("is:issue is:open in:body"))
+        );
         let checkout_issue = source.replace(
             "steps:\n      - name: Create a deduplicated",
             "steps:\n      - uses: actions/checkout@pin\n      - name: Create a deduplicated",


### PR DESCRIPTION
## Summary

1. Restrict Herdr compatibility issue deduplication to open issues.
2. Require the open-issue qualifier in the xtask release-policy sentinel.
3. Add regression coverage that rejects an all-state deduplication query.

## Why

Protocol 22 remains provisionally supported and returns `issue_required=true`. PR #80 closed #74, but the previous sentinel search treated that closed issue as an active deduplication match. This prevented the sentinel from opening a current qualification issue.

With this change, a closed issue no longer hides outstanding provisional qualification work.

## Verification

1. `cargo test -p xtask scheduled_herdr_sentinel_is_narrowly_permissioned`
2. `cargo xtask check`, 1,671 tests passed, 5 configured skips, 85 reviewed snapshots, and all doctests passed.
3. A live read-only GitHub search confirmed that the old query finds closed issue #74 and the corrected query does not.