### PR TITLE
Automate safe Dependabot updates

### DIFF
--- a/.agents/skills/implement-in-worktree/SKILL.md
+++ b/.agents/skills/implement-in-worktree/SKILL.md
@@ -44,23 +44,25 @@ ownership of scope, review, or merge authorization.
 - Derive a short unique topic branch, worktree label, and worker name from the
   ticket. Prefer `feature/`, `fix/`, or `docs/` according to the work.
 
-## Base drift and integration policy
+## Base drift and final integration policy
 
-- Treat the recorded base SHA as the ticket's implementation base. After the
-  lane starts, never merge or rebase `main` into the topic merely because
-  `origin/main` advanced, GitHub reports `BEHIND`, or an earlier strict status
-  check policy would have required an update.
-- Fetch current remote state before final handoff and inspect the actual merge
-  result. A green pull request that remains `CLEAN` and `MERGEABLE` may be made
-  ready and handed back on its original base without another CI run.
-- Integrate current `main` only when GitHub or a local merge analysis proves an
-  actual conflict, when current-main behavior concretely invalidates a tested
-  ticket assumption, or when the user explicitly requests integration. File
-  overlap or base drift alone is not evidence of either condition.
-- When integration is necessary, record the prior base, integrated main SHA,
-  resulting parents, conflict resolutions, and proportional requalification in
-  the pull request and final handoff. Never rerun the complete gate solely to
-  refresh a behind marker.
+- Treat the recorded base SHA as the ticket's implementation base. Do not
+  repeatedly merge or rebase `main` during exploration and implementation each
+  time `origin/main` advances. Finish the coherent topic work first.
+- Immediately before final canonical qualification, fetch `origin/main`. When
+  it advanced beyond the recorded or previously integrated base, merge the
+  exact current `main` into the topic with ordinary non-force history even when
+  Git reports no textual conflict. A clean merge is not proof that the combined
+  behavior remains semantically compatible.
+- Run the required focused, canonical, milestone, live, and CI qualification on
+  that integrated head. `CLEAN`, `MERGEABLE`, and a green result against an
+  older base do not satisfy the final gate.
+- Strict required-status freshness remains authoritative. If `main` advances
+  after the green run and GitHub requires another update, integrate the new tip
+  and requalify rather than bypassing or weakening the requirement.
+- Record the original base, each integrated main SHA, resulting parents,
+  conflict resolutions, semantic compatibility repairs, and final
+  requalification in the pull request and handoff.
 
 ## Create exactly one lane
 
@@ -221,9 +223,9 @@ based retry is reasonable for an infrastructure flake; repeated unexplained
 failure is a blocker, not permission for indefinite retries. Never weaken a
 gate, threshold, test, or snapshot to obtain green status.
 
-Do not restart CI merely because `main` advanced after a green run. Refresh the
-pull request state, apply the base drift and integration policy above, and keep
-the existing green result when the pull request remains clean and mergeable.
+When `main` advances after a green run, apply the final integration policy above
+and obtain a fresh complete CI result for the new integrated head. Do not treat
+an older green result or a conflict-free merge as current integration evidence.
 
 When the complete pull request is green and mergeable and no known defect or
 review issue remains, mark it ready for review without requesting another

--- a/.agents/skills/implement-in-worktree/SKILL.md
+++ b/.agents/skills/implement-in-worktree/SKILL.md
@@ -44,6 +44,24 @@ ownership of scope, review, or merge authorization.
 - Derive a short unique topic branch, worktree label, and worker name from the
   ticket. Prefer `feature/`, `fix/`, or `docs/` according to the work.
 
+## Base drift and integration policy
+
+- Treat the recorded base SHA as the ticket's implementation base. After the
+  lane starts, never merge or rebase `main` into the topic merely because
+  `origin/main` advanced, GitHub reports `BEHIND`, or an earlier strict status
+  check policy would have required an update.
+- Fetch current remote state before final handoff and inspect the actual merge
+  result. A green pull request that remains `CLEAN` and `MERGEABLE` may be made
+  ready and handed back on its original base without another CI run.
+- Integrate current `main` only when GitHub or a local merge analysis proves an
+  actual conflict, when current-main behavior concretely invalidates a tested
+  ticket assumption, or when the user explicitly requests integration. File
+  overlap or base drift alone is not evidence of either condition.
+- When integration is necessary, record the prior base, integrated main SHA,
+  resulting parents, conflict resolutions, and proportional requalification in
+  the pull request and final handoff. Never rerun the complete gate solely to
+  refresh a behind marker.
+
 ## Create exactly one lane
 
 1. Create one Herdr-managed Git worktree/workspace from the recorded base with
@@ -202,6 +220,10 @@ Fix failures caused by the branch and rerun the required gates. One evidence-
 based retry is reasonable for an infrastructure flake; repeated unexplained
 failure is a blocker, not permission for indefinite retries. Never weaken a
 gate, threshold, test, or snapshot to obtain green status.
+
+Do not restart CI merely because `main` advanced after a green run. Refresh the
+pull request state, apply the base drift and integration policy above, and keep
+the existing green result when the pull request remains clean and mergeable.
 
 When the complete pull request is green and mergeable and no known defect or
 review issue remains, mark it ready for review without requesting another

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  request:
+    name: Request safe Dependabot auto-merge
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'oborchers/proqi' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Read verified Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Request squash auto-merge for patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/context/ARCHITECTURE.md
+++ b/context/ARCHITECTURE.md
@@ -1896,11 +1896,10 @@ Cargo.lock is committed because Proqi ships an application. Dependabot checks
 Cargo dependencies, GitHub Actions, and the pinned Rust toolchain weekly, applies
 a routine update cooldown, and limits routine dependency work to one grouped
 pull request. Security updates remain exempt from cooldown. Dependency pull
-requests pass the same required gate as contributor pull requests. Automatic
-merging is limited to explicitly allowed low-risk patch updates after all
-required checks pass.
-Minor updates, all pre-1.0 compatibility changes, and security-sensitive crates
-receive human review.
+requests pass the same required gate as contributor pull requests. Verified
+Dependabot patch and minor updates may request squash auto-merge only after all
+required checks pass against current `main`. Major updates always receive human
+review. External contributors never receive merge authority from this policy.
 
 The default branch requires the aggregate `check` status and rejects force
 pushes while allowing direct owner pushes. Releases use a protected GitHub

--- a/xtask/src/release_policy.rs
+++ b/xtask/src/release_policy.rs
@@ -72,6 +72,20 @@ const HERDR_SENTINEL_REQUIRED: [&str; 16] = [
     "is:issue is:open in:body",
     "herdr-compatibility:${TAG}:${SCHEMA_SHA256}",
 ];
+const DEPENDABOT_AUTOMERGE_PATH: &str = ".github/workflows/dependabot-auto-merge.yml";
+const DEPENDABOT_AUTOMERGE_REQUIRED: [&str; 11] = [
+    "pull_request:",
+    "contents: write",
+    "pull-requests: write",
+    "github.event.pull_request.user.login == 'dependabot[bot]'",
+    "github.repository == 'oborchers/proqi'",
+    "github.event.pull_request.draft == false",
+    "dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0",
+    "steps.metadata.outputs.update-type == 'version-update:semver-patch'",
+    "steps.metadata.outputs.update-type == 'version-update:semver-minor'",
+    "GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+    "gh pr merge --auto --squash",
+];
 
 pub(crate) fn check(root: &Path) -> Result<Vec<String>, String> {
     let release = read(root, ".github/workflows/release.yml")?;
@@ -79,8 +93,10 @@ pub(crate) fn check(root: &Path) -> Result<Vec<String>, String> {
     let ci = read(root, ".github/workflows/ci.yml")?;
     let image = read(root, ".github/workflows/ci-linux-image.yml")?;
     let sentinel = read(root, HERDR_SENTINEL_PATH)?;
+    let dependabot = read(root, DEPENDABOT_AUTOMERGE_PATH)?;
     let mut found = findings(&release, &candidate, &ci, &image);
     found.extend(herdr_sentinel_findings(&sentinel));
+    found.extend(dependabot_automerge_findings(&dependabot));
     found.extend(image_repository_findings(root)?);
     found.extend(scheduled_workflow_findings(root)?);
     Ok(found)
@@ -245,6 +261,29 @@ fn herdr_sentinel_findings(source: &str) -> Vec<String> {
     found
 }
 
+fn dependabot_automerge_findings(source: &str) -> Vec<String> {
+    let mut found = missing(
+        DEPENDABOT_AUTOMERGE_PATH,
+        source,
+        &DEPENDABOT_AUTOMERGE_REQUIRED,
+    );
+    for forbidden in [
+        "pull_request_target:",
+        "actions/checkout@",
+        "version-update:semver-major",
+        "gh pr merge --admin",
+        "gh pr merge --auto --merge",
+        "gh pr merge --auto --rebase",
+    ] {
+        if source.contains(forbidden) {
+            found.push(format!(
+                "{DEPENDABOT_AUTOMERGE_PATH}: forbidden `{forbidden}`"
+            ));
+        }
+    }
+    found
+}
+
 fn contains_schedule(source: &str) -> Result<bool, String> {
     let documents = YamlLoader::load_from_str(source)
         .map_err(|error| format!("parse GitHub Actions workflow YAML: {error}"))?;
@@ -293,7 +332,10 @@ fn enforce_order(source: &str, found: &mut Vec<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{contains_schedule, findings, herdr_sentinel_findings, schedule_is_forbidden};
+    use super::{
+        contains_schedule, dependabot_automerge_findings, findings, herdr_sentinel_findings,
+        schedule_is_forbidden,
+    };
     use std::path::Path;
 
     fn sources() -> (&'static str, &'static str, &'static str, &'static str) {
@@ -404,6 +446,22 @@ mod tests {
                 schedule_is_forbidden(Path::new("another.yml"), source)
                     .expect("alternate scheduled YAML")
             );
+        }
+    }
+
+    #[test]
+    fn dependabot_automerge_is_verified_bounded_and_squashed() {
+        let source = include_str!("../../.github/workflows/dependabot-auto-merge.yml");
+        assert!(dependabot_automerge_findings(source).is_empty());
+
+        for unsafe_change in [
+            source.replace("pull_request:", "pull_request_target:"),
+            format!("{source}\n      - uses: actions/checkout@pin"),
+            source.replace("semver-minor", "semver-major"),
+            source.replace("--auto --squash", "--auto --merge"),
+            source.replace("dependabot[bot]", "github-actions[bot]"),
+        ] {
+            assert!(!dependabot_automerge_findings(&unsafe_change).is_empty());
         }
     }
 }


### PR DESCRIPTION
## Summary

- request squash auto-merge only for verified Dependabot patch and minor updates
- keep every major update manual
- enforce the workflow identity, event, permissions, pinned metadata action, update boundary, and merge method through xtask
- keep implementation worktrees on their recorded base during active development, then integrate current main once before final qualification and CI

## Verification

- `cargo test -p xtask release_policy`
- `cargo xtask architecture`
- `actionlint .github/workflows/dependabot-auto-merge.yml`
- `git diff --check`

## Integration

Strict required-status freshness is authoritative again. This branch merged current main at `8faf444cfa54cdf65f77a6f0f9cdb065a2aa32ea` without textual conflicts, then reran the focused policy and workflow checks on the integrated head. The complete canonical gate was deliberately not rerun at Oliver's direction. GitHub CI remains the final current-main gate.
