### PR TITLE
Fix visual-row end boundary affinity

### DIFF
--- a/src/adapters/editor/mod.rs
+++ b/src/adapters/editor/mod.rs
@@ -13,11 +13,11 @@ use ropey::Rope;
 use crate::domain::TextPosition;
 use crate::ports::editor::{
     CellRange, CursorMovement, EditCommand, EditOutcome, Editor, EditorFactory, EditorSnapshot,
-    FAST_NAVIGATION_ROWS, TextChangeSet, TextSelection, TextViewport,
+    FAST_NAVIGATION_ROWS, TextChangeSet, TextSelection, TextViewport, VisualCursorAffinity,
 };
 use crate::ports::text_layout::{
     WrappedRow, byte_at_cell, byte_for_position, cell_column_at_byte, logical_lines,
-    position_for_byte, wrap_rows, wrapped_row_index,
+    position_for_byte, wrap_rows, wrapped_row_index_with_affinity,
 };
 use text::{next_boundary, previous_boundary, word_back, word_forward};
 
@@ -35,6 +35,7 @@ impl EditorFactory for RopeEditorFactory {
 struct State {
     text: Rope,
     cursor_byte: usize,
+    cursor_affinity: VisualCursorAffinity,
     selection_anchor_byte: Option<usize>,
 }
 
@@ -43,6 +44,7 @@ impl State {
         Self {
             text: Rope::new(),
             cursor_byte: 0,
+            cursor_affinity: VisualCursorAffinity::default(),
             selection_anchor_byte: None,
         }
     }
@@ -81,6 +83,7 @@ impl RopeEditor {
             state: State {
                 text: Rope::from_str(text),
                 cursor_byte: 0,
+                cursor_affinity: VisualCursorAffinity::default(),
                 selection_anchor_byte: None,
             },
             ..Self::default()
@@ -103,7 +106,12 @@ impl RopeEditor {
         })
     }
 
-    fn set_cursor_byte(&mut self, byte: usize, extend_selection: bool) {
+    fn set_cursor_byte_with_affinity(
+        &mut self,
+        byte: usize,
+        affinity: VisualCursorAffinity,
+        extend_selection: bool,
+    ) {
         if extend_selection {
             self.state
                 .selection_anchor_byte
@@ -112,30 +120,45 @@ impl RopeEditor {
             self.state.selection_anchor_byte = None;
         }
         self.state.cursor_byte = byte.min(self.state.text.len_bytes());
+        self.state.cursor_affinity = affinity;
         self.ensure_cursor_visible();
     }
 
     fn move_cursor(&mut self, movement: CursorMovement, extend_selection: bool) {
         let content = self.content();
-        let target = match movement {
+        let (target, affinity) = match movement {
             CursorMovement::GraphemeBack => {
-                previous_boundary(&content, self.state.cursor_byte).unwrap_or(0)
+                let byte = previous_boundary(&content, self.state.cursor_byte).unwrap_or(0);
+                (byte, VisualCursorAffinity::default())
             }
             CursorMovement::GraphemeForward => {
-                next_boundary(&content, self.state.cursor_byte).unwrap_or(content.len())
+                let byte = next_boundary(&content, self.state.cursor_byte).unwrap_or(content.len());
+                (byte, VisualCursorAffinity::default())
             }
-            CursorMovement::WordBack => word_back(&content, self.state.cursor_byte),
-            CursorMovement::WordForward => word_forward(&content, self.state.cursor_byte),
+            CursorMovement::WordBack => (
+                word_back(&content, self.state.cursor_byte),
+                VisualCursorAffinity::default(),
+            ),
+            CursorMovement::WordForward => (
+                word_forward(&content, self.state.cursor_byte),
+                VisualCursorAffinity::default(),
+            ),
             CursorMovement::LineStart => {
                 let lines = logical_lines(&content);
-                lines[position_for_byte(&content, self.state.cursor_byte).line].start
+                (
+                    lines[position_for_byte(&content, self.state.cursor_byte).line].start,
+                    VisualCursorAffinity::default(),
+                )
             }
             CursorMovement::LineEnd => {
                 let lines = logical_lines(&content);
-                lines[position_for_byte(&content, self.state.cursor_byte).line].content_end
+                (
+                    lines[position_for_byte(&content, self.state.cursor_byte).line].content_end,
+                    VisualCursorAffinity::default(),
+                )
             }
-            CursorMovement::DocumentStart => 0,
-            CursorMovement::DocumentEnd => content.len(),
+            CursorMovement::DocumentStart => (0, VisualCursorAffinity::default()),
+            CursorMovement::DocumentEnd => (content.len(), VisualCursorAffinity::default()),
             CursorMovement::VisualUp => self.vertical_target(-1),
             CursorMovement::VisualDown => self.vertical_target(1),
             CursorMovement::VisualJumpUp => {
@@ -154,19 +177,33 @@ impl RopeEditor {
         ) {
             self.preferred_column = None;
         }
-        self.set_cursor_byte(target, extend_selection);
+        self.set_cursor_byte_with_affinity(target, affinity, extend_selection);
     }
 
-    fn vertical_target(&mut self, rows: isize) -> usize {
+    fn vertical_target(&mut self, rows: isize) -> (usize, VisualCursorAffinity) {
         let wrapped = self.wrapped_lines();
-        let current_index = wrapped_row_index(&wrapped, self.state.cursor_byte);
+        let current_index = wrapped_row_index_with_affinity(
+            &wrapped,
+            self.state.cursor_byte,
+            self.state.cursor_affinity,
+        );
         let current = &wrapped[current_index];
         let current_column = cell_column_at_byte(&self.content(), current, self.state.cursor_byte);
         let preferred = *self.preferred_column.get_or_insert(current_column);
         let target_index = current_index
             .saturating_add_signed(rows)
             .min(wrapped.len().saturating_sub(1));
-        byte_at_cell(&self.content(), &wrapped[target_index], preferred)
+        let target = byte_at_cell(&self.content(), &wrapped[target_index], preferred);
+        let affinity = if wrapped[target_index].end_byte == target
+            && wrapped
+                .get(target_index + 1)
+                .is_some_and(|next| next.start_byte == target)
+        {
+            VisualCursorAffinity::PreviousRow
+        } else {
+            VisualCursorAffinity::default()
+        };
+        (target, affinity)
     }
 
     fn wrapped_lines(&self) -> Vec<WrappedRow> {
@@ -175,7 +212,11 @@ impl RopeEditor {
 
     fn ensure_cursor_visible(&mut self) {
         let wrapped = self.wrapped_lines();
-        let cursor_row = wrapped_row_index(&wrapped, self.state.cursor_byte);
+        let cursor_row = wrapped_row_index_with_affinity(
+            &wrapped,
+            self.state.cursor_byte,
+            self.state.cursor_affinity,
+        );
         let height = usize::from(self.viewport.height);
         if cursor_row < self.scroll_row {
             self.scroll_row = cursor_row;
@@ -197,6 +238,41 @@ impl RopeEditor {
 
     fn apply_sentence_deletion(&mut self, list_indent_width: u8) -> TextChangeSet {
         self.mutate_many(|editor| editor.delete_sentence(list_indent_width))
+    }
+
+    fn apply_cursor_position(
+        &mut self,
+        position: TextPosition,
+        affinity: VisualCursorAffinity,
+        extend_selection: bool,
+    ) -> TextChangeSet {
+        self.pointer_selection = None;
+        self.preferred_column = None;
+        let byte = byte_for_position(&self.content(), position);
+        self.set_cursor_byte_with_affinity(byte, affinity, extend_selection);
+        TextChangeSet::unchanged(self.state.text.len_bytes())
+    }
+
+    fn apply_select_all(&mut self) -> TextChangeSet {
+        self.pointer_selection = None;
+        self.preferred_column = None;
+        self.state.selection_anchor_byte = Some(0);
+        self.state.cursor_byte = self.state.text.len_bytes();
+        self.state.cursor_affinity = VisualCursorAffinity::default();
+        self.ensure_cursor_visible();
+        TextChangeSet::unchanged(self.state.text.len_bytes())
+    }
+
+    fn apply_pointer_start(
+        &mut self,
+        position: TextPosition,
+        granularity: crate::ports::editor::SelectionGranularity,
+        extend_selection: bool,
+    ) -> TextChangeSet {
+        self.preferred_column = None;
+        self.state.cursor_affinity = VisualCursorAffinity::default();
+        self.begin_pointer_selection(position, granularity, extend_selection);
+        TextChangeSet::unchanged(self.state.text.len_bytes())
     }
 
     fn outcome(&self, changes: TextChangeSet) -> EditOutcome {
@@ -243,14 +319,7 @@ impl Editor for RopeEditor {
                 self.move_cursor(movement, extend_selection);
                 TextChangeSet::unchanged(self.state.text.len_bytes())
             }
-            EditCommand::SelectAll => {
-                self.pointer_selection = None;
-                self.preferred_column = None;
-                self.state.selection_anchor_byte = Some(0);
-                self.state.cursor_byte = self.state.text.len_bytes();
-                self.ensure_cursor_visible();
-                TextChangeSet::unchanged(self.state.text.len_bytes())
-            }
+            EditCommand::SelectAll => self.apply_select_all(),
             EditCommand::ClearSelection => {
                 self.pointer_selection = None;
                 self.preferred_column = None;
@@ -260,22 +329,21 @@ impl Editor for RopeEditor {
             EditCommand::SetCursor {
                 position,
                 extend_selection,
-            } => {
-                self.pointer_selection = None;
-                self.preferred_column = None;
-                let byte = byte_for_position(&self.content(), position);
-                self.set_cursor_byte(byte, extend_selection);
-                TextChangeSet::unchanged(self.state.text.len_bytes())
-            }
+            } => self.apply_cursor_position(
+                position,
+                VisualCursorAffinity::default(),
+                extend_selection,
+            ),
+            EditCommand::SetVisualCursor {
+                position,
+                affinity,
+                extend_selection,
+            } => self.apply_cursor_position(position, affinity, extend_selection),
             EditCommand::PointerStart {
                 position,
                 granularity,
                 extend_selection,
-            } => {
-                self.preferred_column = None;
-                self.begin_pointer_selection(position, granularity, extend_selection);
-                TextChangeSet::unchanged(self.state.text.len_bytes())
-            }
+            } => self.apply_pointer_start(position, granularity, extend_selection),
             EditCommand::PointerDrag { position } => {
                 self.extend_pointer_selection(position);
                 TextChangeSet::unchanged(self.state.text.len_bytes())
@@ -309,6 +377,7 @@ impl Editor for RopeEditor {
         let selected_bytes = self.selection_bytes();
         EditorSnapshot {
             cursor: position_for_byte(&content, self.state.cursor_byte),
+            cursor_affinity: self.state.cursor_affinity,
             selection: self.selection(&content),
             viewport: self.viewport,
             scroll_row: self.scroll_row,
@@ -338,6 +407,7 @@ impl Editor for RopeEditor {
         self.state = State {
             text: Rope::from_str(&text),
             cursor_byte: byte,
+            cursor_affinity: VisualCursorAffinity::default(),
             selection_anchor_byte: None,
         };
         self.undo.clear();

--- a/src/adapters/editor/mutation.rs
+++ b/src/adapters/editor/mutation.rs
@@ -54,7 +54,6 @@ impl RopeEditor {
     ) -> TextChangeSet {
         self.preferred_column = None;
         self.pointer_selection = None;
-        self.ensure_cursor_visible();
         let Some(changes) = changes.filter(|changes| !changes.is_empty()) else {
             if before_content != self.content() {
                 self.state = before_state;
@@ -62,6 +61,8 @@ impl RopeEditor {
             }
             return TextChangeSet::unchanged(before_content.len());
         };
+        self.state.cursor_affinity = crate::ports::editor::VisualCursorAffinity::default();
+        self.ensure_cursor_visible();
         self.undo.push(HistoryEntry {
             before: before_state,
             after: self.state.clone(),
@@ -127,6 +128,7 @@ impl RopeEditor {
         self.state.text = ropey::Rope::from_str(&after);
         self.state.cursor_byte = cursor;
         self.state.selection_anchor_byte = anchor;
+        self.state.cursor_affinity = crate::ports::editor::VisualCursorAffinity::default();
         Some(changes)
     }
 
@@ -234,6 +236,7 @@ impl RopeEditor {
         self.state.text.insert(start_char, replacement);
         self.state.cursor_byte = start + replacement.len();
         self.state.selection_anchor_byte = None;
+        self.state.cursor_affinity = crate::ports::editor::VisualCursorAffinity::default();
         AppliedRange {
             old: start..end,
             new: start..start + replacement.len(),

--- a/src/adapters/terminal/input.rs
+++ b/src/adapters/terminal/input.rs
@@ -1,7 +1,9 @@
 //! Crossterm event normalization and lossless input delivery.
 
 use std::{
-    fmt, io,
+    fmt, fs, io,
+    io::Write as _,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -76,15 +78,25 @@ pub(super) struct InputLane {
     pub(super) receiver: Receiver<InputMessage>,
     stop: Arc<AtomicBool>,
     latest_sequence: Arc<AtomicU64>,
+    test_acceptance_path: Option<PathBuf>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl InputLane {
     pub(super) fn spawn() -> Self {
-        Self::spawn_with_source(Box::new(CrosstermEventSource))
+        Self::spawn_with_state_root(Box::new(CrosstermEventSource), None)
     }
 
+    pub(super) fn spawn_with_test_acceptance(state_root: Option<&Path>) -> Self {
+        Self::spawn_with_state_root(Box::new(CrosstermEventSource), state_root)
+    }
+
+    #[cfg(test)]
     fn spawn_with_source(source: Box<dyn EventSource>) -> Self {
+        Self::spawn_with_state_root(source, None)
+    }
+
+    fn spawn_with_state_root(source: Box<dyn EventSource>, state_root: Option<&Path>) -> Self {
         let (sender, receiver) = sync_channel(64);
         let stop = Arc::new(AtomicBool::new(false));
         let latest_sequence = Arc::new(AtomicU64::new(0));
@@ -97,6 +109,8 @@ impl InputLane {
             receiver,
             stop,
             latest_sequence,
+            test_acceptance_path: std::env::var_os("PROQI_TEST_INPUT_ACCEPTANCE")
+                .and_then(|_| state_root.map(|root| root.join("runtime/input-accepted"))),
             handle: Some(handle),
         }
     }
@@ -117,6 +131,21 @@ impl InputLane {
 
     pub(super) fn latest_sequence(&self) -> u64 {
         self.latest_sequence.load(Ordering::Acquire)
+    }
+
+    pub(super) fn record_test_acceptance(&self, sequence: u64, mode: &str) {
+        let Some(path) = &self.test_acceptance_path else {
+            return;
+        };
+        let result = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .and_then(|mut output| writeln!(output, "{sequence} mode={mode}"));
+        debug_assert!(
+            result.is_ok(),
+            "test input-acceptance probe must be writable"
+        );
     }
 }
 

--- a/src/adapters/terminal/runner.rs
+++ b/src/adapters/terminal/runner.rs
@@ -173,6 +173,7 @@ pub(crate) fn run(resources: TerminalResources) -> Result<SessionId, TerminalErr
         session_lease.info().clone(),
         terminal_host_label,
         executable,
+        state_root.as_deref(),
     );
     let mut pane_heartbeat = None;
     let shutdown = super::supervisor::ShutdownCoordinator::default();

--- a/src/adapters/terminal/runner/composition.rs
+++ b/src/adapters/terminal/runner/composition.rs
@@ -107,12 +107,13 @@ pub(super) fn spawn_lanes(
     instance: InstanceInfo,
     terminal_host: String,
     executable: PathBuf,
+    state_root: Option<&std::path::Path>,
 ) -> OwnedLanes {
     let cancellation = crate::adapters::process::CancellationFlag::default();
     OwnedLanes {
         accessibility: AccessibilityLane::spawn(executable, cancellation.clone()),
         control,
-        input: InputLane::spawn(),
+        input: InputLane::spawn_with_test_acceptance(state_root),
         persistence: PersistenceLane::spawn_with_runtime(
             store,
             coordinator.clone(),

--- a/src/adapters/terminal/runner/input_admission.rs
+++ b/src/adapters/terminal/runner/input_admission.rs
@@ -65,12 +65,22 @@ pub(super) fn apply(
     }
     schedule_attachment_focus_refresh(&event, Instant::now(), &mut deadlines.attachment);
     app.note_screenshot_activity(&event, lanes.monotonic.now());
-    if event.is_deliberate_interaction() {
+    let deliberate = event.is_deliberate_interaction();
+    if deliberate {
         let effects = app.note_attachment_interaction(lanes.monotonic.now());
         enqueue_effects(app, lanes, effects, pending)?;
     }
     let effects = app.handle(event, ids, &clock);
-    enqueue_effects(app, lanes, effects, pending)
+    enqueue_effects(app, lanes, effects, pending)?;
+    if deliberate {
+        let mode = match app.interaction_mode() {
+            crate::application::InteractionMode::Board => "board",
+            crate::application::InteractionMode::Compose => "compose",
+            crate::application::InteractionMode::Edit { .. } => "edit",
+        };
+        lanes.input.record_test_acceptance(sequence, mode);
+    }
+    Ok(())
 }
 
 fn schedule_attachment_focus_refresh(

--- a/src/ports/editor.rs
+++ b/src/ports/editor.rs
@@ -143,6 +143,15 @@ pub enum EditCommand {
         /// Whether to extend the selection from its anchor.
         extend_selection: bool,
     },
+    /// Place the cursor at a wrapped-row boundary with explicit visual affinity.
+    SetVisualCursor {
+        /// Requested canonical position, clamped to valid content.
+        position: TextPosition,
+        /// Wrapped row that owns a position shared by two visual rows.
+        affinity: VisualCursorAffinity,
+        /// Whether to extend the selection from its anchor.
+        extend_selection: bool,
+    },
     /// Begin a pointer selection at a viewport cell.
     PointerStart {
         /// Canonical logical position under the pointer.
@@ -195,6 +204,16 @@ pub struct CellRange {
     pub end: usize,
 }
 
+/// Visual ownership of a canonical cursor at a shared soft-wrap boundary.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum VisualCursorAffinity {
+    /// Render the cursor at the end of the preceding wrapped row.
+    PreviousRow,
+    /// Render the cursor at the start of the following wrapped row.
+    #[default]
+    NextRow,
+}
+
 /// Serializable application-facing view of transient editor state.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EditorSnapshot {
@@ -202,6 +221,8 @@ pub struct EditorSnapshot {
     pub content: String,
     /// Logical cursor position.
     pub cursor: TextPosition,
+    /// Visual ownership when the logical cursor is shared by two wrapped rows.
+    pub cursor_affinity: VisualCursorAffinity,
     /// Normalized active selection, if any.
     pub selection: Option<TextSelection>,
     /// Current viewport.

--- a/src/ports/text_layout.rs
+++ b/src/ports/text_layout.rs
@@ -4,7 +4,7 @@ use crate::domain::TextPosition;
 use unicode_segmentation::UnicodeSegmentation as _;
 use unicode_width::UnicodeWidthStr as _;
 
-use super::editor::VisualLine;
+use super::editor::{VisualCursorAffinity, VisualLine};
 
 const TAB_WIDTH: usize = 4;
 
@@ -218,6 +218,23 @@ pub(crate) fn wrapped_row_index(rows: &[WrappedRow], byte: usize) -> usize {
         })
         .or_else(|| rows.iter().rposition(|row| row.start_byte <= byte))
         .unwrap_or(0)
+}
+
+pub(crate) fn wrapped_row_index_with_affinity(
+    rows: &[WrappedRow],
+    byte: usize,
+    affinity: VisualCursorAffinity,
+) -> usize {
+    let index = wrapped_row_index(rows, byte);
+    if affinity == VisualCursorAffinity::PreviousRow
+        && index > 0
+        && rows[index].start_byte == byte
+        && rows[index - 1].end_byte == byte
+    {
+        index - 1
+    } else {
+        index
+    }
 }
 
 pub(crate) fn byte_for_position(content: &str, position: TextPosition) -> usize {

--- a/src/ui/app/folds.rs
+++ b/src/ui/app/folds.rs
@@ -14,7 +14,7 @@ impl BoardApp {
     pub(super) fn move_to_visual_row_edge(&mut self, edge: VisualRowEdge, extend_selection: bool) {
         let mut frame = self.build_frame_presentation();
         self.attach_editor_presentation(&mut frame);
-        let Some(position) = frame
+        let Some(target) = frame
             .editor()
             .map(|editor| editor.visual_row_edge(edge, extend_selection))
         else {
@@ -23,8 +23,9 @@ impl BoardApp {
         let Some((_, editor)) = &mut self.editor else {
             return;
         };
-        let _outcome = editor.apply(EditCommand::SetCursor {
-            position,
+        let _outcome = editor.apply(EditCommand::SetVisualCursor {
+            position: target.position,
+            affinity: target.affinity,
             extend_selection,
         });
         self.edit_boundary = None;

--- a/src/ui/app/view.rs
+++ b/src/ui/app/view.rs
@@ -208,6 +208,7 @@ impl BoardApp {
                 | EditCommand::SelectAll
                 | EditCommand::ClearSelection
                 | EditCommand::SetCursor { .. }
+                | EditCommand::SetVisualCursor { .. }
                 | EditCommand::PointerStart { .. }
                 | EditCommand::PointerDrag { .. }
                 | EditCommand::PointerEnd

--- a/src/ui/layout/scroll/tests.rs
+++ b/src/ui/layout/scroll/tests.rs
@@ -259,6 +259,7 @@ fn active_editor_rows_replace_stale_durable_content_during_measurement() {
     let editor = EditorSnapshot {
         content,
         cursor: crate::domain::TextPosition::default(),
+        cursor_affinity: crate::ports::editor::VisualCursorAffinity::default(),
         selection: None,
         viewport: TextViewport::new(20, 8),
         scroll_row: 0,

--- a/src/ui/layout/tests.rs
+++ b/src/ui/layout/tests.rs
@@ -75,6 +75,7 @@ fn empty_layout_distinguishes_passive_prompt_from_engaged_compose() {
     let snapshot = EditorSnapshot {
         content: String::new(),
         cursor: crate::domain::TextPosition::default(),
+        cursor_affinity: crate::ports::editor::VisualCursorAffinity::default(),
         selection: None,
         viewport: TextViewport::new(18, 1),
         scroll_row: 0,
@@ -152,6 +153,7 @@ fn editing_ignores_a_stale_collapsed_cap_and_uses_the_available_viewport() {
     let snapshot = EditorSnapshot {
         content: content.clone(),
         cursor: crate::domain::TextPosition::default(),
+        cursor_affinity: crate::ports::editor::VisualCursorAffinity::default(),
         selection: None,
         viewport: TextViewport::new(width, 1),
         scroll_row: 0,

--- a/src/ui/projection.rs
+++ b/src/ui/projection.rs
@@ -1,14 +1,18 @@
 //! Canonical-to-visible mapping for folded editor ranges.
 
+#[cfg(test)]
+#[path = "projection/tests.rs"]
+mod tests;
+
 use super::annotations::{Presentation, PresentedStyle, PresentedSubstitution};
 use crate::{
     application::AppState,
     domain::{TextPosition, ThoughtId, ThoughtPresentation},
     ports::{
-        editor::{CellRange, EditorSnapshot, TextSelection},
+        editor::{CellRange, EditorSnapshot, TextSelection, VisualCursorAffinity},
         text_layout::{
             WrappedRow, byte_at_cell, byte_for_position, cell_column_at_byte, position_for_byte,
-            wrap_rows, wrapped_row_index,
+            wrap_rows, wrapped_row_index_with_affinity,
         },
     },
     ui::VisualRowEdge,
@@ -100,6 +104,12 @@ pub(super) enum BoardCellTarget {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct VisualRowTarget {
+    pub(super) position: TextPosition,
+    pub(super) affinity: VisualCursorAffinity,
+}
+
 pub(super) fn board_cell_target(
     canonical: &str,
     presentation: &Presentation,
@@ -131,21 +141,44 @@ impl EditorPresentation {
         &self,
         edge: VisualRowEdge,
         advance_across_rows: bool,
-    ) -> TextPosition {
+    ) -> VisualRowTarget {
         let row_index = if advance_across_rows {
-            directional_row_index(&self.rows, self.cursor_display_byte, edge)
+            directional_row_index(
+                &self.rows,
+                self.cursor_display_byte,
+                self.snapshot.cursor_affinity,
+                edge,
+            )
         } else {
-            wrapped_row_index(&self.rows, self.cursor_display_byte)
+            wrapped_row_index_with_affinity(
+                &self.rows,
+                self.cursor_display_byte,
+                self.snapshot.cursor_affinity,
+            )
         };
         let row = &self.rows[row_index];
         let display_byte = match edge {
             VisualRowEdge::Start => row.start_byte,
             VisualRowEdge::End => row.end_byte,
         };
-        position_for_byte(
+        let position = position_for_byte(
             &self.canonical_content,
             unproject_boundary(display_byte, &self.substitutions, edge),
-        )
+        );
+        let shared_end = edge == VisualRowEdge::End
+            && row.start_byte < row.end_byte
+            && self
+                .rows
+                .get(row_index + 1)
+                .is_some_and(|next| next.start_byte == row.end_byte);
+        VisualRowTarget {
+            position,
+            affinity: if shared_end {
+                VisualCursorAffinity::PreviousRow
+            } else {
+                VisualCursorAffinity::NextRow
+            },
+        }
     }
 
     pub(super) fn cell_target(&self, row: u16, column: u16) -> BoardCellTarget {
@@ -186,18 +219,27 @@ impl EditorPresentation {
 
     pub(super) fn cursor_viewport_cell(&self) -> Option<(usize, usize)> {
         let cursor = self.cursor_display_byte;
-        let row = wrapped_row_index(&self.rows, cursor);
+        let row =
+            wrapped_row_index_with_affinity(&self.rows, cursor, self.snapshot.cursor_affinity);
         let viewport_row = row.checked_sub(self.snapshot.scroll_row)?;
         let wrapped = self.rows.get(row)?;
-        Some((
-            cell_column_at_byte(&self.snapshot.content, wrapped, cursor),
-            viewport_row,
-        ))
+        let column = cell_column_at_byte(&self.snapshot.content, wrapped, cursor);
+        let column = if self.snapshot.cursor_affinity == VisualCursorAffinity::PreviousRow {
+            column.min(usize::from(self.snapshot.viewport.width).saturating_sub(1))
+        } else {
+            column
+        };
+        Some((column, viewport_row))
     }
 }
 
-fn directional_row_index(rows: &[WrappedRow], cursor: usize, edge: VisualRowEdge) -> usize {
-    let index = wrapped_row_index(rows, cursor);
+fn directional_row_index(
+    rows: &[WrappedRow],
+    cursor: usize,
+    affinity: VisualCursorAffinity,
+    edge: VisualRowEdge,
+) -> usize {
+    let index = wrapped_row_index_with_affinity(rows, cursor, affinity);
     let row = &rows[index];
     match edge {
         VisualRowEdge::Start if cursor == row.start_byte && index > 0 => index - 1,
@@ -228,6 +270,7 @@ pub(super) fn editor_presentation(
     let snapshot = EditorSnapshot {
         content: presentation.content,
         cursor,
+        cursor_affinity: canonical.cursor_affinity,
         selection,
         viewport: canonical.viewport,
         scroll_row,
@@ -339,7 +382,7 @@ fn apply_selection(content: &str, rows: &mut [WrappedRow], selection: Option<Tex
 }
 
 fn visible_scroll(canonical: &EditorSnapshot, rows: &[WrappedRow], cursor: usize) -> usize {
-    let cursor_row = wrapped_row_index(rows, cursor);
+    let cursor_row = wrapped_row_index_with_affinity(rows, cursor, canonical.cursor_affinity);
     let height = usize::from(canonical.viewport.height).max(1);
     let mut scroll = canonical.scroll_row.min(rows.len().saturating_sub(height));
     if cursor_row < scroll {

--- a/src/ui/projection/tests.rs
+++ b/src/ui/projection/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     adapters::editor::RopeEditor,
     domain::TextPosition,
     ports::editor::{EditCommand, Editor as _, TextViewport, VisualCursorAffinity},
-    ui::annotations::Presentation,
+    ui::{VisualRowEdge, annotations::Presentation},
 };
 
 use super::editor_presentation;
@@ -11,6 +11,68 @@ fn cursor_cell(editor: &RopeEditor) -> Option<(usize, usize)> {
     let snapshot = editor.snapshot();
     editor_presentation(&snapshot, Presentation::canonical(snapshot.content.clone()))
         .cursor_viewport_cell()
+}
+
+fn move_to_visual_edge(editor: &mut RopeEditor, edge: VisualRowEdge) {
+    let snapshot = editor.snapshot();
+    let target = editor_presentation(&snapshot, Presentation::canonical(snapshot.content.clone()))
+        .visual_row_edge(edge, false);
+    let _moved = editor.apply(EditCommand::SetVisualCursor {
+        position: target.position,
+        affinity: target.affinity,
+        extend_selection: false,
+    });
+}
+
+#[test]
+fn semantic_edges_converge_on_the_requested_exact_width_row() {
+    let mut editor = RopeEditor::new(&"x".repeat(56));
+    editor.set_viewport(TextViewport::new(14, 3));
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: TextPosition::new(0, 15),
+        affinity: VisualCursorAffinity::NextRow,
+        extend_selection: false,
+    });
+
+    move_to_visual_edge(&mut editor, VisualRowEdge::Start);
+    assert_eq!(editor.snapshot().cursor, TextPosition::new(0, 14));
+    assert_eq!(cursor_cell(&editor), Some((0, 1)));
+    move_to_visual_edge(&mut editor, VisualRowEdge::Start);
+    assert_eq!(cursor_cell(&editor), Some((0, 1)));
+
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: TextPosition::new(0, 15),
+        affinity: VisualCursorAffinity::NextRow,
+        extend_selection: false,
+    });
+    move_to_visual_edge(&mut editor, VisualRowEdge::End);
+    let at_end = editor.snapshot();
+    assert_eq!(at_end.cursor, TextPosition::new(0, 28));
+    assert_eq!(at_end.cursor_affinity, VisualCursorAffinity::PreviousRow);
+    assert_eq!(cursor_cell(&editor), Some((13, 1)));
+    move_to_visual_edge(&mut editor, VisualRowEdge::End);
+    assert_eq!(editor.snapshot(), at_end);
+    assert_eq!(cursor_cell(&editor), Some((13, 1)));
+}
+
+#[test]
+fn semantic_end_preserves_the_exact_width_synthetic_final_row() {
+    let mut editor = RopeEditor::new(&"x".repeat(28));
+    editor.set_viewport(TextViewport::new(14, 3));
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: TextPosition::new(0, 28),
+        affinity: VisualCursorAffinity::NextRow,
+        extend_selection: false,
+    });
+
+    move_to_visual_edge(&mut editor, VisualRowEdge::End);
+    let at_end = editor.snapshot();
+    assert_eq!(at_end.cursor, TextPosition::new(0, 28));
+    assert_eq!(at_end.cursor_affinity, VisualCursorAffinity::NextRow);
+    assert_eq!(cursor_cell(&editor), Some((0, 2)));
+    move_to_visual_edge(&mut editor, VisualRowEdge::End);
+    assert_eq!(editor.snapshot(), at_end);
+    assert_eq!(cursor_cell(&editor), Some((0, 2)));
 }
 
 #[test]

--- a/src/ui/projection/tests.rs
+++ b/src/ui/projection/tests.rs
@@ -1,0 +1,47 @@
+use crate::{
+    adapters::editor::RopeEditor,
+    domain::TextPosition,
+    ports::editor::{EditCommand, Editor as _, TextViewport, VisualCursorAffinity},
+    ui::annotations::Presentation,
+};
+
+use super::editor_presentation;
+
+fn cursor_cell(editor: &RopeEditor) -> Option<(usize, usize)> {
+    let snapshot = editor.snapshot();
+    editor_presentation(&snapshot, Presentation::canonical(snapshot.content.clone()))
+        .cursor_viewport_cell()
+}
+
+#[test]
+fn mutation_undo_and_noop_preserve_rendered_visual_affinity() {
+    let mut editor = RopeEditor::new("abcdefgh");
+    editor.set_viewport(TextViewport::new(4, 3));
+    let boundary = TextPosition::new(0, 4);
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: boundary,
+        affinity: VisualCursorAffinity::PreviousRow,
+        extend_selection: false,
+    });
+    assert_eq!(cursor_cell(&editor), Some((3, 0)));
+
+    let _inserted = editor.apply(EditCommand::InsertChar('!'));
+    let undone = editor.apply(EditCommand::Undo).snapshot;
+    assert_eq!(undone.cursor, boundary);
+    assert_eq!(undone.cursor_affinity, VisualCursorAffinity::PreviousRow);
+    assert_eq!(cursor_cell(&editor), Some((3, 0)));
+
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: TextPosition::new(0, 8),
+        affinity: VisualCursorAffinity::PreviousRow,
+        extend_selection: false,
+    });
+    let before_noop = cursor_cell(&editor);
+    let deleted = editor.apply(EditCommand::DeleteForward);
+    assert!(deleted.changes.is_empty());
+    assert_eq!(
+        deleted.snapshot.cursor_affinity,
+        VisualCursorAffinity::PreviousRow
+    );
+    assert_eq!(cursor_cell(&editor), before_noop);
+}

--- a/tests/editor_contract/navigation.rs
+++ b/tests/editor_contract/navigation.rs
@@ -1,7 +1,10 @@
 use proqi::{
     adapters::editor::RopeEditor,
     domain::TextPosition,
-    ports::editor::{CursorMovement, EditCommand, Editor, FAST_NAVIGATION_ROWS, TextViewport},
+    ports::editor::{
+        CursorMovement, EditCommand, Editor, FAST_NAVIGATION_ROWS, TextViewport,
+        VisualCursorAffinity,
+    },
 };
 
 fn move_cursor(editor: &mut impl Editor, movement: CursorMovement, extend_selection: bool) {
@@ -135,4 +138,34 @@ fn pointer_reposition_replaces_a_stale_vertical_preferred_column() {
     move_cursor(&mut editor, CursorMovement::VisualJumpDown, false);
 
     assert_eq!(editor.snapshot().cursor, TextPosition::new(7, 4));
+}
+
+#[test]
+fn mutation_history_and_noop_keep_visual_boundary_affinity_truthful() {
+    let mut editor = RopeEditor::new("abcdefgh");
+    editor.set_viewport(TextViewport::new(4, 3));
+    let boundary = TextPosition::new(0, 4);
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: boundary,
+        affinity: VisualCursorAffinity::PreviousRow,
+        extend_selection: false,
+    });
+
+    let inserted = editor.apply(EditCommand::InsertChar('!'));
+    assert!(!inserted.changes.is_empty());
+    let undone = editor.apply(EditCommand::Undo).snapshot;
+    assert_eq!(undone.cursor, boundary);
+    assert_eq!(undone.cursor_affinity, VisualCursorAffinity::PreviousRow);
+
+    let _positioned = editor.apply(EditCommand::SetVisualCursor {
+        position: TextPosition::new(0, 8),
+        affinity: VisualCursorAffinity::PreviousRow,
+        extend_selection: false,
+    });
+    let deleted = editor.apply(EditCommand::DeleteForward);
+    assert!(deleted.changes.is_empty());
+    assert_eq!(
+        deleted.snapshot.cursor_affinity,
+        VisualCursorAffinity::PreviousRow
+    );
 }

--- a/tests/pty/shutdown.rs
+++ b/tests/pty/shutdown.rs
@@ -3,7 +3,7 @@
 use std::{fs, os::unix::fs::PermissionsExt as _, path::Path, time::Duration};
 
 use super::{
-    support::{consume_first_run, expect_command, json_command},
+    support::{consume_first_run, expect_command, json_command, json_input_command},
     watchdog,
 };
 
@@ -230,8 +230,9 @@ fn delayed_capture_shutdown(
     fs::write(&staged, png_bytes()).expect("staged screenshot");
     let target = watched.path().join("delayed.png");
     let watchdog_pids = state.path().join("watchdog-pids");
+    let input_acceptance = state.path().join("runtime/input-accepted");
     let binary = env!("CARGO_BIN_EXE_proqi");
-    consume_first_run(binary, state.path());
+    let session = seed_editor(binary, state.path());
     let exit_action = capture_exit_action(terminate);
     let capture_barrier = if persistent_failure {
         r#"
@@ -281,6 +282,9 @@ fn delayed_capture_shutdown(
         .args(["-c", &workflow])
         .env("PROQI_TEST_BINARY", binary)
         .env("PROQI_TEST_STATE", state.path())
+        .env("PROQI_TEST_SESSION", &session)
+        .env("PROQI_TEST_INPUT_ACCEPTANCE", "1")
+        .env("PROQI_TEST_INPUT_ACCEPTANCE_PATH", &input_acceptance)
         .env(
             "PROQI_TEST_DATABASE",
             state.path().join("data/proqi.sqlite3"),
@@ -294,6 +298,21 @@ fn delayed_capture_shutdown(
         "delayed capture shutdown PTY workflow",
     );
     assert_capture_shutdown_result(status, state.path(), binary, &target, persistent_failure);
+}
+
+fn seed_editor(binary: &str, state: &Path) -> String {
+    let created = json_command(binary, state, &[]);
+    let session = created["data"]["session_id"]
+        .as_str()
+        .expect("session ID")
+        .to_owned();
+    let _added = json_input_command(
+        binary,
+        state,
+        &["thoughts", "add", &session],
+        "durable editor",
+    );
+    session
 }
 
 fn capture_exit_action(terminate: bool) -> &'static str {
@@ -325,17 +344,39 @@ fn capture_shutdown_workflow(
             puts $owned $pid
             close $owned
         }}
-        spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE)
+        proc wait_for_input_acceptance {{failure expected_mode}} {{
+            global env
+            for {{set attempt 0}} {{$attempt < 250}} {{incr attempt}} {{
+                if {{[file exists $env(PROQI_TEST_INPUT_ACCEPTANCE_PATH)]}} {{
+                    set input [open $env(PROQI_TEST_INPUT_ACCEPTANCE_PATH) r]
+                    set receipt [read $input]
+                    close $input
+                    if {{[string first "mode=$expected_mode" $receipt] >= 0}} {{ return }}
+                }}
+                after 20
+            }}
+            exit $failure
+        }}
+        proc clear_input_acceptance {{}} {{
+            global env
+            file delete $env(PROQI_TEST_INPUT_ACCEPTANCE_PATH)
+        }}
+        spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE) -r $env(PROQI_TEST_SESSION)
         stty rows 24 columns 80
         set proqi $spawn_id
         set child [exp_pid]
         register_watchdog_pid $child
         expect -exact "\x1b\[?1049h"
         expect -exact "\x1b\[1 q"
-        after 1000
-        send -- "\x1b"
-        after 50
-        send -- "i"
+        send -- "\x1b\[27u"
+        wait_for_input_acceptance 81 board
+        clear_input_acceptance
+        send -- "\x1b\[A"
+        wait_for_input_acceptance 82 board
+        clear_input_acceptance
+        send -- "\x1b\[105u"
+        wait_for_input_acceptance 83 board
+        clear_input_acceptance
         set capture_lock "$env(PROQI_TEST_STATE)/runtime/screenshot-capture.json"
         for {{set attempt 0}} {{$attempt < 100 && ![file exists $capture_lock]}} {{incr attempt}} {{
             after 50
@@ -351,9 +392,8 @@ fn capture_shutdown_workflow(
             exit 93
         }}
         send -- "\r"
-        after 50
-        send -- "\x1b\[200~durable editor\x1b\[201~"
-        after 700
+        wait_for_input_acceptance 86 edit
+        clear_input_acceptance
         spawn /usr/bin/sqlite3 $env(PROQI_TEST_DATABASE)
         set sqlite $spawn_id
         register_watchdog_pid [exp_pid]
@@ -364,6 +404,7 @@ fn capture_shutdown_workflow(
         set spawn_id $proqi
         {capture_barrier}
         send -- "!"
+        wait_for_input_acceptance 87 edit
         set shutdown_started [clock milliseconds]
         {exit_action}
         {finish_action}

--- a/tests/pty/update_control/highlight_fixture.rs
+++ b/tests/pty/update_control/highlight_fixture.rs
@@ -47,9 +47,22 @@ pub(super) fn run_dismissal(binary: &Path, state: &Path, session: &str) -> ExitS
         spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE) -r $env(PROQI_TEST_SESSION)
         expect -exact "\x1b\[?1049h"
         stty rows 18 columns 84
-        after 300
+        expect -exact "what's new"
         send -- "\x1b"
-        after 500
+        for {set attempt 0} {$attempt < 100} {incr attempt} {
+            set acknowledged 0
+            foreach path [glob -nocomplain "$env(PROQI_TEST_STATE)/cache/updates/*/state.json"] {
+                set input [open $path r]
+                set contents [read $input]
+                close $input
+                if {[string first {"acknowledged":true} $contents] >= 0} {
+                    set acknowledged 1
+                }
+            }
+            if {$acknowledged} { break }
+            after 20
+        }
+        if {!$acknowledged} { exit 96 }
         send -- $env(PROQI_TEST_PRIMARY_Q)
         expect {
             eof {}

--- a/tests/pty/visual_row_selection.rs
+++ b/tests/pty/visual_row_selection.rs
@@ -1,6 +1,79 @@
 //! Exact macOS visual-row selection bytes with a durable replacement oracle.
 
-use super::support::{consume_first_run, expect_command, json_command};
+use super::support::{consume_first_run, expect_command, json_command, json_input_command};
+
+fn seed_wrapped_thought(binary: &str, state: &std::path::Path) -> String {
+    let created = json_command(binary, state, &[]);
+    let session = created["data"]["session_id"]
+        .as_str()
+        .expect("session ID")
+        .to_owned();
+    let content = "a".repeat(100);
+    let _added = json_input_command(binary, state, &["thoughts", "add", &session], &content);
+    session
+}
+
+fn rendered_cursor_after_visual_end(sequence: &str) -> (u16, u16) {
+    let state = tempfile::tempdir().expect("temporary state");
+    let binary = env!("CARGO_BIN_EXE_proqi");
+    let session = seed_wrapped_thought(binary, state.path());
+    let transcript = state.path().join("cursor.transcript");
+    let script = r#"
+        log_user 0
+        set timeout 10
+        set stty_init "rows 10 columns 24"
+        set capture [open $env(PROQI_TEST_TRANSCRIPT) "w"]
+        fconfigure $capture -translation binary -encoding binary
+        spawn $env(PROQI_TEST_BINARY) --state-dir $env(PROQI_TEST_STATE) -r $env(PROQI_TEST_SESSION)
+        expect -exact "\x1b\[?1049h"
+        puts -nonewline $capture "\x1b\[?1049h"
+        after 200
+        send -- "\r"
+        after 100
+        send -- "\x1b\[H"
+        for {set index 0} {$index < 5} {incr index} {
+            send -- "\x1b\[C"
+        }
+        if {$env(PROQI_TEST_SEQUENCE) ne ""} {
+            send -- $env(PROQI_TEST_SEQUENCE)
+        }
+        after 200
+        set timeout 1
+        expect {
+            -re {.+} {
+                puts -nonewline $capture $expect_out(buffer)
+                exp_continue
+            }
+            timeout {}
+        }
+        close $capture
+        set timeout 10
+        send "\x1b"
+        after 100
+        send "q"
+        expect eof
+        catch wait result
+        exit [lindex $result 3]
+    "#;
+    let status = expect_command()
+        .args(["-c", script])
+        .env("PROQI_TEST_BINARY", binary)
+        .env("PROQI_TEST_STATE", state.path())
+        .env("PROQI_TEST_SESSION", session)
+        .env("PROQI_TEST_TRANSCRIPT", &transcript)
+        .env("PROQI_TEST_SEQUENCE", sequence)
+        .status()
+        .expect("run visual-row cursor PTY workflow");
+    assert!(
+        status.success(),
+        "visual-row cursor PTY exited with {status}"
+    );
+
+    let bytes = std::fs::read(transcript).expect("read cursor transcript");
+    let mut parser = vt100::Parser::new(10, 24, 0);
+    parser.process(&bytes);
+    parser.screen().cursor_position()
+}
 
 #[test]
 fn macos_primary_shift_right_replaces_more_than_one_grapheme_in_a_wrapped_row() {
@@ -102,4 +175,24 @@ fn macos_primary_left_moves_without_selection_to_the_current_wrapped_row_start()
         .as_str()
         .expect("persisted content");
     assert_eq!(persisted, format!("X{original}"));
+}
+
+#[test]
+fn macos_primary_right_stays_on_the_current_wrapped_row_end() {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+    let interior = rendered_cursor_after_visual_end("");
+    let at_end = rendered_cursor_after_visual_end("\x1b[1;9C");
+    let repeated = rendered_cursor_after_visual_end("\x1b[1;9C\x1b[1;9C");
+
+    assert_eq!(
+        at_end.0, interior.0,
+        "visual-row end changed rows: interior={interior:?}, end={at_end:?}"
+    );
+    assert!(
+        at_end.1 > interior.1,
+        "visual-row end did not move right: interior={interior:?}, end={at_end:?}"
+    );
+    assert_eq!(repeated, at_end, "repeated visual-row end did not converge");
 }

--- a/tests/ui_board.rs
+++ b/tests/ui_board.rs
@@ -463,6 +463,8 @@ mod transformations;
 mod versioned_keymap;
 #[path = "ui_board/viewport_bounds.rs"]
 mod viewport_bounds;
+#[path = "ui_board/visual_row_affinity.rs"]
+mod visual_row_affinity;
 #[path = "ui_board/visual_row_selection.rs"]
 mod visual_row_selection;
 

--- a/tests/ui_board/visual_row_affinity.rs
+++ b/tests/ui_board/visual_row_affinity.rs
@@ -1,5 +1,7 @@
 //! Cursor-affinity contracts at shared and synthetic wrapped-row boundaries.
 
+#![cfg(target_os = "macos")]
+
 use super::{Fixture, draw};
 use proqi::{
     domain::TextPosition,

--- a/tests/ui_board/visual_row_affinity.rs
+++ b/tests/ui_board/visual_row_affinity.rs
@@ -1,0 +1,59 @@
+//! Cursor-affinity contracts at shared and synthetic wrapped-row boundaries.
+
+use super::{Fixture, draw};
+use proqi::{
+    domain::TextPosition,
+    ports::editor::{CursorMovement, VisualCursorAffinity, VisualLine},
+    ui::{UiKey, VisualRowEdge},
+};
+use ratatui_core::{backend::Backend as _, layout::Rect};
+
+fn move_to_grapheme(fixture: &mut Fixture, grapheme: usize) {
+    fixture.input(crate::key_input(UiKey::Move {
+        movement: CursorMovement::DocumentStart,
+        extend_selection: false,
+    }));
+    for _ in 0..grapheme {
+        fixture.input(crate::key_input(UiKey::Move {
+            movement: CursorMovement::GraphemeForward,
+            extend_selection: false,
+        }));
+    }
+}
+
+fn row_end(row: &VisualLine) -> TextPosition {
+    TextPosition::new(row.logical_line, row.end_grapheme)
+}
+
+fn move_to_end(fixture: &mut Fixture) {
+    fixture.input(crate::key_input(UiKey::MoveVisualRow {
+        edge: VisualRowEdge::End,
+    }));
+}
+
+#[test]
+fn exact_width_synthetic_final_row_keeps_next_row_affinity() {
+    let mut fixture = Fixture::new();
+    fixture.paste(&"x".repeat(28));
+    let _frame = draw(&mut fixture, 16, 8);
+    let rows = fixture.app.editor_snapshot().expect("editor").visual_lines;
+    let final_index = rows.len() - 1;
+    let final_row = &rows[final_index];
+    assert_eq!(final_row.start_grapheme, final_row.end_grapheme);
+    move_to_grapheme(&mut fixture, final_row.end_grapheme);
+
+    move_to_end(&mut fixture);
+    move_to_end(&mut fixture);
+
+    let snapshot = fixture.app.editor_snapshot().expect("synthetic row end");
+    assert_eq!(snapshot.cursor, row_end(final_row));
+    assert_eq!(snapshot.cursor_affinity, VisualCursorAffinity::NextRow);
+    let area = fixture.app.prepare_frame(Rect::new(0, 0, 16, 8)).thoughts[0].text_area;
+    let mut terminal = draw(&mut fixture, 16, 8);
+    let cursor = terminal
+        .backend_mut()
+        .get_cursor_position()
+        .expect("cursor");
+    assert_eq!(cursor.x, area.x);
+    assert_eq!(cursor.y, area.y + u16::try_from(final_index).expect("row"));
+}

--- a/tests/ui_board/visual_row_selection.rs
+++ b/tests/ui_board/visual_row_selection.rs
@@ -4,16 +4,20 @@ use super::{Fixture, draw, navigation};
 use proqi::{
     application::Effect,
     domain::{ContentAnnotation, ContentAnnotationKind, TextPosition},
-    ports::editor::{CursorMovement, TextSelection, VisualCursorAffinity, VisualLine},
+    ports::editor::{CursorMovement, TextSelection, VisualLine},
     ui::{HitTarget, PointerButton, PointerKind, UiKey, UiSettings, VisualRowEdge},
 };
 use ratatui_core::layout::Rect;
 use unicode_segmentation::UnicodeSegmentation as _;
 
+#[cfg(target_os = "macos")]
+use proqi::ports::editor::VisualCursorAffinity;
+
 fn extend(fixture: &mut Fixture, edge: VisualRowEdge) {
     fixture.input(crate::key_input(UiKey::ExtendVisualRow { edge }));
 }
 
+#[cfg(target_os = "macos")]
 fn move_to_edge(fixture: &mut Fixture, edge: VisualRowEdge) {
     fixture.input(crate::key_input(UiKey::MoveVisualRow { edge }));
 }
@@ -89,6 +93,7 @@ fn repeated_chords_extend_both_selection_directions_across_wrapped_unicode_rows(
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn unshifted_row_edge_movement_uses_the_current_wrapped_row_without_selection() {
     let mut fixture = Fixture::new();
     fixture.paste("0123456789 abcdefghijklmnopqrstuvwxyz");
@@ -140,6 +145,7 @@ fn unshifted_row_edge_movement_uses_the_current_wrapped_row_without_selection() 
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn unshifted_visual_row_end_renders_at_the_current_row_boundary() {
     use ratatui_core::backend::Backend as _;
 
@@ -175,6 +181,7 @@ fn unshifted_visual_row_end_renders_at_the_current_row_boundary() {
 }
 
 #[test]
+#[cfg(target_os = "macos")]
 fn exact_width_visual_row_end_uses_the_last_cell_without_advancing() {
     use ratatui_core::backend::Backend as _;
 

--- a/tests/ui_board/visual_row_selection.rs
+++ b/tests/ui_board/visual_row_selection.rs
@@ -4,7 +4,7 @@ use super::{Fixture, draw, navigation};
 use proqi::{
     application::Effect,
     domain::{ContentAnnotation, ContentAnnotationKind, TextPosition},
-    ports::editor::{CursorMovement, TextSelection, VisualLine},
+    ports::editor::{CursorMovement, TextSelection, VisualCursorAffinity, VisualLine},
     ui::{HitTarget, PointerButton, PointerKind, UiKey, UiSettings, VisualRowEdge},
 };
 use ratatui_core::layout::Rect;
@@ -14,7 +14,6 @@ fn extend(fixture: &mut Fixture, edge: VisualRowEdge) {
     fixture.input(crate::key_input(UiKey::ExtendVisualRow { edge }));
 }
 
-#[cfg(target_os = "macos")]
 fn move_to_edge(fixture: &mut Fixture, edge: VisualRowEdge) {
     fixture.input(crate::key_input(UiKey::MoveVisualRow { edge }));
 }
@@ -90,41 +89,162 @@ fn repeated_chords_extend_both_selection_directions_across_wrapped_unicode_rows(
 }
 
 #[test]
-#[cfg(target_os = "macos")]
 fn unshifted_row_edge_movement_uses_the_current_wrapped_row_without_selection() {
     let mut fixture = Fixture::new();
     fixture.paste("0123456789 abcdefghijklmnopqrstuvwxyz");
     let _frame = draw(&mut fixture, 16, 8);
     let rows = fixture.app.editor_snapshot().expect("editor").visual_lines;
     assert!(rows.len() >= 3, "expected wrapping: {rows:?}");
-    move_to_grapheme(&mut fixture, rows[1].start_grapheme + 2);
+    for index in [0, 1, rows.len() - 1] {
+        let row = &rows[index];
+        move_to_grapheme(&mut fixture, row.start_grapheme + 1);
 
-    move_to_edge(&mut fixture, VisualRowEdge::Start);
-    let at_start = fixture.app.editor_snapshot().expect("row start");
-    assert_eq!(at_start.cursor, row_position(&rows[1], false));
-    assert_eq!(at_start.selection, None);
-    move_to_edge(&mut fixture, VisualRowEdge::Start);
+        move_to_edge(&mut fixture, VisualRowEdge::Start);
+        let at_start = fixture.app.editor_snapshot().expect("row start");
+        assert_eq!(at_start.cursor, row_position(row, false));
+        assert_eq!(at_start.selection, None);
+        move_to_edge(&mut fixture, VisualRowEdge::Start);
+        assert_eq!(
+            fixture
+                .app
+                .editor_snapshot()
+                .expect("stable row start")
+                .cursor,
+            row_position(row, false)
+        );
+
+        move_to_edge(&mut fixture, VisualRowEdge::End);
+        let at_end = fixture.app.editor_snapshot().expect("row end");
+        assert_eq!(at_end.cursor, row_position(row, true));
+        let expected_affinity = if row.start_byte < row.end_byte
+            && rows
+                .get(index + 1)
+                .is_some_and(|next| next.start_byte == row.end_byte)
+        {
+            VisualCursorAffinity::PreviousRow
+        } else {
+            VisualCursorAffinity::NextRow
+        };
+        assert_eq!(at_end.cursor_affinity, expected_affinity);
+        assert_eq!(at_end.selection, None);
+        move_to_edge(&mut fixture, VisualRowEdge::End);
+        assert_eq!(
+            fixture
+                .app
+                .editor_snapshot()
+                .expect("stable row end")
+                .cursor,
+            row_position(row, true)
+        );
+    }
+}
+
+#[test]
+fn unshifted_visual_row_end_renders_at_the_current_row_boundary() {
+    use ratatui_core::backend::Backend as _;
+
+    let mut fixture = Fixture::new();
+    fixture.paste("alpha beta gamma delta epsilon zeta eta theta");
+    let _frame = draw(&mut fixture, 16, 8);
+    let rows = fixture.app.editor_snapshot().expect("editor").visual_lines;
+    let (row_index, row) = rows
+        .iter()
+        .enumerate()
+        .find(|(index, row)| *index > 0 && *index + 1 < rows.len() && row.cell_width < 14)
+        .expect("interior row ending before the wrap width");
+    move_to_grapheme(&mut fixture, row.start_grapheme + 1);
+
+    move_to_edge(&mut fixture, VisualRowEdge::End);
+
+    let canonical = fixture.app.editor_snapshot().expect("row end");
+    assert_eq!(canonical.cursor, row_position(row, true));
+    assert_eq!(canonical.cursor_affinity, VisualCursorAffinity::PreviousRow);
+    let area = fixture.app.prepare_frame(Rect::new(0, 0, 16, 8)).thoughts[0].text_area;
+    let mut terminal = draw(&mut fixture, 16, 8);
+    let rendered = terminal
+        .backend_mut()
+        .get_cursor_position()
+        .expect("rendered cursor");
     assert_eq!(
-        fixture
-            .app
-            .editor_snapshot()
-            .expect("stable row start")
-            .cursor,
-        row_position(&rows[1], false)
+        (rendered.x, rendered.y),
+        (
+            area.x + u16::try_from(row.cell_width).expect("row width"),
+            area.y + u16::try_from(row_index).expect("row index"),
+        )
     );
+}
+
+#[test]
+fn exact_width_visual_row_end_uses_the_last_cell_without_advancing() {
+    use ratatui_core::backend::Backend as _;
+
+    let mut fixture = Fixture::new();
+    fixture.paste(&"x".repeat(56));
+    let _frame = draw(&mut fixture, 16, 8);
+    let rows = fixture.app.editor_snapshot().expect("editor").visual_lines;
+    let row = &rows[1];
+    assert_eq!(row.cell_width, 14);
+    move_to_grapheme(&mut fixture, row.start_grapheme + 1);
 
     move_to_edge(&mut fixture, VisualRowEdge::End);
-    let at_end = fixture.app.editor_snapshot().expect("row end");
-    assert_eq!(at_end.cursor, row_position(&rows[1], true));
-    assert_eq!(at_end.selection, None);
     move_to_edge(&mut fixture, VisualRowEdge::End);
+
+    let canonical = fixture.app.editor_snapshot().expect("exact-width end");
+    assert_eq!(canonical.cursor, row_position(row, true));
+    assert_eq!(canonical.cursor_affinity, VisualCursorAffinity::PreviousRow);
+    let area = fixture.app.prepare_frame(Rect::new(0, 0, 16, 8)).thoughts[0].text_area;
+    let mut terminal = draw(&mut fixture, 16, 8);
+    let rendered = terminal
+        .backend_mut()
+        .get_cursor_position()
+        .expect("rendered exact-width cursor");
+    assert_eq!((rendered.x, rendered.y), (area.right() - 1, area.y + 1));
+
+    fixture.input(crate::key_input(UiKey::Move {
+        movement: CursorMovement::VisualDown,
+        extend_selection: false,
+    }));
+    let moved = fixture.app.editor_snapshot().expect("next exact-width row");
+    assert_eq!(moved.cursor, row_position(&rows[2], true));
+    assert_eq!(moved.cursor_affinity, VisualCursorAffinity::PreviousRow);
+}
+
+#[test]
+fn shifted_visual_row_edges_reverse_around_one_stable_anchor() {
+    let mut fixture = Fixture::new();
+    fixture.paste("alpha beta gamma delta epsilon zeta eta theta");
+    let _frame = draw(&mut fixture, 16, 8);
+    let rows = fixture.app.editor_snapshot().expect("editor").visual_lines;
+    let anchor = rows[1].start_grapheme + 2;
+    move_to_grapheme(&mut fixture, anchor);
+
+    extend(&mut fixture, VisualRowEdge::End);
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("forward").selection,
+        Some(TextSelection {
+            start: TextPosition::new(0, anchor),
+            end: row_position(&rows[1], true),
+        })
+    );
+    extend(&mut fixture, VisualRowEdge::Start);
+    assert_eq!(
+        fixture.app.editor_snapshot().expect("reversed").selection,
+        Some(TextSelection {
+            start: row_position(&rows[1], false),
+            end: TextPosition::new(0, anchor),
+        })
+    );
+    extend(&mut fixture, VisualRowEdge::Start);
     assert_eq!(
         fixture
             .app
             .editor_snapshot()
-            .expect("stable row end")
-            .cursor,
-        row_position(&rows[2], true)
+            .expect("past anchor")
+            .selection,
+        Some(TextSelection {
+            start: row_position(&rows[0], false),
+            end: TextPosition::new(0, anchor),
+        })
     );
 }
 


### PR DESCRIPTION
## Summary

- Preserve explicit previous-row or next-row affinity at canonical soft-wrap boundary positions.
- Route visual-row movement, rendering, scrolling, vertical navigation, selection, folds, and substitutions through the shared text-layout projection.
- Integrate current main at `9ff04a98dcc9724b4991b47762e540d7d6282a56`, including PR #97's unified undo and redo ownership.
- Keep PR #97's durable editor history contract for content, annotations, cursor, and directional selection anchor. Visual-row affinity remains transient presentation state and does not alter persistence.
- Stabilize existing PTY shutdown and update-highlight checks with reducer acceptance and durable-state oracles instead of fixed-delay assumptions.
- Keep physical Primary shortcut coverage on macOS, where Primary is Command, and test the semantic visual-row owner directly on every platform.

## Regression proof

On original base `a219dd5b56e2c137334c003e1d882272a4443f6c`, the new rendered-cursor regression failed with the caret at row 2, column 2 instead of row 1, column 14. The canonical byte was shared by the end of one soft-wrapped row and the start of the next, but the renderer always assigned it to the next row. The same regression passes after the affinity fix.

PR #97 did not already solve or conflict with this defect. It restores canonical cursor and directional selection anchor through unified history, while this change disambiguates how a shared canonical byte is projected onto a soft-wrapped row. The deliberate merge retains both fields in editor snapshots, defaults transient affinity when restoring durable history, and keeps PR #97's shared word-boundary owner.

## Acceptance coverage

- Visual-row start and end are symmetric across first, middle, final, exact-width, newline, empty, endpoint, and one-row cases.
- Repeated end movement converges on the same rendered row.
- Shifted movement extends, shrinks, and reverses from a stable anchor.
- ASCII, tabs, controls, CJK, combining marks, emoji, folded attachments, and large-paste substitutions retain canonical geometry.
- Resize and reflow recompute from current layout without mutating logical content or undo history.
- Logical-line Control movement, named Home and End, word and thought movement, Board navigation, Compose, overlays, and configurable shortcut identities remain unchanged.

## Verification

- Focused visual-row UI: 12 passed.
- Canonical projection affinity and exact-width convergence: 3 passed.
- Wrapped editor contract: 71 passed.
- Unified-history UI focus: 25 passed.
- Exact serial macOS PTY gate: 91 passed.
- Coverage: 1,834 passed, 5 skipped, threshold satisfied.
- `cargo xtask audit`: passed. Existing duplicate dependency warnings remain informational; advisories, bans, licenses, sources, and shear passed.
- `cargo xtask package`: passed, including installed-product contract. Nothing published.
- `cargo xtask check-full`: passed with 1,834 tests, 5 skipped, doctest green, and `complete_gate=true`.
- Snapshots: 102 reviewed by the gate, no topic snapshot changes and no pending `.snap.new` files.
- Eight native Codex reviews completed. All supported findings from earlier passes were fixed. The final post-#97 integration review found no supported findings.
- Initial PR CI correctly caught that one integration test routed a semantic visual-row action through platform Primary on Ubuntu. The corrected tests invoke the canonical semantic owner directly, while physical Command shortcut tests remain macOS-only.

## Live matrix

The integrated topic binary was exercised in a disposable Herdr tab with isolated synthetic state. Exact macOS logical Primary+Left (`CSI 1;9 D`), Primary+Right (`CSI 1;9 C`), repeated Primary+Right, and Primary+Shift+Right (`CSI 1;10 C`) covered movement and directional selection. The visual-row PTY scenarios passed 3 of 3. PR #97's exact Primary and Control history bytes, undo and redo restoration, clean restart, and terminal restoration passed 1 of 1. The child returned to a clean shell, and the disposable tab and pane were removed.

## Risks and limitations

The affinity value is transient editor presentation state. Durable unified history continues to restore cursor and directional selection anchor without introducing a schema or protocol change in this PR. There is no CLI, JSON, configuration, default shortcut, mouse, or content migration change. PTY acceptance receipts are test-only, opt-in, content-free, and contained within each isolated test state root.
